### PR TITLE
Allow running tests locally via Test Explorer

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/app.config
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/app.config
@@ -2,6 +2,7 @@
 <configuration>
   <appSettings>
     <add key="xunit.methodDisplay" value="method" />
+    <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
Inspired by @sharwell's Microsoft/vs-threading#104, this makes tests "just work" in Test Explorer with skip verification and environment variables.