### PR TITLE
Temporarily turn off NB.GV on Mac

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,8 +21,13 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningVersion)" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- NerdBank.GitVersioning currently doesn't work on Mac/Unix.
+  See https://github.com/AArnott/Nerdbank.GitVersioning/issues/123 -->
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Until https://github.com/AArnott/Nerdbank.GitVersioning/issues/123 is fixed.