### PR TITLE
Work toward compiling on .netstandard (1.6)

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
+++ b/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
@@ -237,8 +237,8 @@ namespace Microsoft.VisualStudio.Composition
                     {
                         // Whitelist Type[] and RuntimeType[] arrays as equivalent.
                         if (!(x.GetType().IsArray && y.GetType().IsArray &&
-                            typeof(Type).IsAssignableFrom(x.GetType().GetElementType()) &&
-                            typeof(Type).IsAssignableFrom(y.GetType().GetElementType())))
+                            typeof(Type).GetTypeInfo().IsAssignableFrom(x.GetType().GetElementType()) &&
+                            typeof(Type).GetTypeInfo().IsAssignableFrom(y.GetType().GetElementType())))
                         {
                             return false;
                         }

--- a/src/Microsoft.VisualStudio.Composition/CollectionServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/CollectionServices.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Composition
 
     internal static partial class CollectionServices
     {
-        private static readonly ConstructorInfo CollectionOfObjectCtor = typeof(CollectionOfObject<>).GetConstructors()[0];
+        private static readonly ConstructorInfo CollectionOfObjectCtor = typeof(CollectionOfObject<>).GetTypeInfo().GetConstructors()[0];
         private static readonly Dictionary<Type, Func<object, ICollection<object>>> CachedCollectionWrapperFactories = new Dictionary<Type, Func<object, ICollection<object>>>();
 
         internal static ICollection<object> GetCollectionWrapper(Type itemType, object collectionObject)
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(itemType, nameof(itemType));
             Requires.NotNull(collectionObject, nameof(collectionObject));
 
-            var underlyingItemType = itemType.UnderlyingSystemType;
+            var underlyingItemType = itemType.GetTypeInfo().UnderlyingSystemType;
 
             if (underlyingItemType == typeof(object))
             {
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Composition
             // Most common .Net collections implement IList as well so for those
             // cases we can optimize the wrapping instead of using reflection to create
             // a generic type.
-            if (typeof(IList).IsAssignableFrom(collectionObject.GetType()))
+            if (typeof(IList).GetTypeInfo().IsAssignableFrom(collectionObject.GetType().GetTypeInfo()))
             {
                 return new CollectionOfObjectList((IList)collectionObject);
             }

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Composition
             }
 
             var importsWithGenericTypeParameters = this.Definition.Imports
-                .Where(import => import.ImportingSiteElementType.ContainsGenericParameters).ToList();
+                .Where(import => import.ImportingSiteElementType.GetTypeInfo().ContainsGenericParameters).ToList();
             foreach (var import in importsWithGenericTypeParameters)
             {
                 yield return new ComposedPartDiagnostic(

--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET45
+
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
@@ -381,3 +383,5 @@ namespace Microsoft.VisualStudio.Composition
         }
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Composition/Configuration/ExportMetadataViewInterfaceEmitProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/ExportMetadataViewInterfaceEmitProxy.cs
@@ -37,8 +37,8 @@ namespace Microsoft.VisualStudio.Composition
             public bool IsMetadataViewSupported(Type metadataType)
             {
                 // We apply to interfaces with nothing but property getters.
-                return metadataType.IsInterface
-                    && metadataType.GetMembers().All(IsPropertyRelated);
+                return metadataType.GetTypeInfo().IsInterface
+                    && metadataType.GetTypeInfo().GetMembers().All(IsPropertyRelated);
             }
 
             public object CreateProxy(IReadOnlyDictionary<string, object> metadata, IReadOnlyDictionary<string, object> defaultValues, Type metadataViewType)

--- a/src/Microsoft.VisualStudio.Composition/Configuration/NetFxAdapters.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/NetFxAdapters.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET45
+
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
@@ -418,3 +420,5 @@ namespace Microsoft.VisualStudio.Composition
         }
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -581,7 +581,7 @@ namespace Microsoft.VisualStudio.Composition
                     throw new NotSupportedException();
                 }
 
-                var list = Array.CreateInstance(elementType, count);
+                var list = Array.CreateInstance(elementType, (int)count);
                 for (int i = 0; i < list.Length; i++)
                 {
                     object value = itemReader();
@@ -766,7 +766,7 @@ namespace Microsoft.VisualStudio.Composition
                         this.Write(ObjectType.CreationPolicy);
                         this.writer.Write((byte)(CreationPolicy)value);
                     }
-                    else if (typeof(Type).IsAssignableFrom(valueType))
+                    else if (typeof(Type).GetTypeInfo().IsAssignableFrom(valueType))
                     {
                         this.Write(ObjectType.Type);
                         this.Write(TypeRef.Get((Type)value, this.Resolver));

--- a/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
+++ b/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.Composition
     internal class LazyMetadataWrapper : ExportProvider.IMetadataDictionary
     {
         private static readonly HashSet<Assembly> AlwaysLoadedAssemblies = new HashSet<Assembly>(new[] {
-            typeof(CreationPolicy).Assembly,
-            typeof(string).Assembly,
+            typeof(CreationPolicy).GetTypeInfo().Assembly,
+            typeof(string).GetTypeInfo().Assembly,
         });
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(typeOfValue, nameof(typeOfValue));
 
-            return !AlwaysLoadedAssemblies.Contains(typeOfValue.Assembly);
+            return !AlwaysLoadedAssemblies.Contains(typeOfValue.GetTypeInfo().Assembly);
         }
 
         internal class Enum32Substitution : ISubstitutedValue, IEquatable<Enum32Substitution>
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.Composition
                 if (value != null)
                 {
                     Type valueType = value.GetType();
-                    if (valueType.IsEnum && Enum.GetUnderlyingType(valueType) == typeof(int) && IsTypeWorthDeferring(valueType))
+                    if (valueType.GetTypeInfo().IsEnum && Enum.GetUnderlyingType(valueType) == typeof(int) && IsTypeWorthDeferring(valueType))
                     {
                         substitutedValue = new Enum32Substitution(TypeRef.Get(valueType, resolver), (int)value);
                         return true;

--- a/src/Microsoft.VisualStudio.Composition/LazyServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/LazyServices.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.Composition
     /// </summary>
     internal static class LazyServices
     {
-        private static readonly MethodInfo CreateStronglyTypedLazyOfTMValue = typeof(LazyServices).GetMethod("CreateStronglyTypedLazyOfTM", BindingFlags.NonPublic | BindingFlags.Static);
-        private static readonly MethodInfo CreateStronglyTypedLazyOfTValue = typeof(LazyServices).GetMethod("CreateStronglyTypedLazyOfT", BindingFlags.NonPublic | BindingFlags.Static);
+        private static readonly MethodInfo CreateStronglyTypedLazyOfTMValue = typeof(LazyServices).GetTypeInfo().GetMethod("CreateStronglyTypedLazyOfTM", BindingFlags.NonPublic | BindingFlags.Static);
+        private static readonly MethodInfo CreateStronglyTypedLazyOfTValue = typeof(LazyServices).GetTypeInfo().GetMethod("CreateStronglyTypedLazyOfT", BindingFlags.NonPublic | BindingFlags.Static);
 
         internal static readonly Type DefaultMetadataViewType = typeof(IDictionary<string, object>);
         internal static readonly Type DefaultExportedValueType = typeof(object);
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns><c>true</c> if <paramref name="type"/> is some Lazy type.</returns>
         internal static bool IsAnyLazyType(this Type type)
         {
-            if (type.IsGenericType)
+            if (type.GetTypeInfo().IsGenericType)
             {
                 Type genericTypeDefinition = type.GetGenericTypeDefinition();
                 if (genericTypeDefinition == typeof(Lazy<>) || genericTypeDefinition == typeof(Lazy<,>))

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -1,21 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45</TargetFrameworks>
     <CodeAnalysisRuleSet>Microsoft.VisualStudio.Composition.ruleset</CodeAnalysisRuleSet>
     <DebugType>full</DebugType>
 
     <Description>Lightning fast MEF engine, supporting System.ComponentModel.Composition and System.Composition.</Description>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.ComponentModel.Composition" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.1.36" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.0.82" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.1.36" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="all" />
     <PackageReference Include="System.Composition" Version="1.0.31" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.VisualStudio.Composition.LocalizationShell\Strings.Designer.cs" />

--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -168,9 +168,9 @@ namespace Microsoft.VisualStudio.Composition
             foreach (var attribute in member.GetAttributes<Attribute>())
             {
                 Type attrType = attribute.GetType();
-                if (attrType.IsAttributeDefined<TMetadataAttribute>(inherit: true))
+                if (attrType.GetTypeInfo().IsAttributeDefined<TMetadataAttribute>(inherit: true))
                 {
-                    assemblyNames.Add(attrType.Assembly.GetName());
+                    assemblyNames.Add(attrType.GetTypeInfo().Assembly.GetName());
                 }
             }
         }
@@ -395,7 +395,7 @@ namespace Microsoft.VisualStudio.Composition
                     }
                     catch (Exception ex)
                     {
-                        return new PartDiscoveryException(string.Format(CultureInfo.CurrentCulture, Strings.FailureWhileScanningType, type.FullName), ex) { AssemblyPath = type.Assembly.Location, ScannedType = type };
+                        return new PartDiscoveryException(string.Format(CultureInfo.CurrentCulture, Strings.FailureWhileScanningType, type.FullName), ex) { AssemblyPath = type.GetTypeInfo().Assembly.Location, ScannedType = type };
                     }
                 },
                 new ExecutionDataflowBlockOptions

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
@@ -63,9 +63,9 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                     this.Property = new PropertyRef((PropertyInfo)member, resolver);
                     break;
                 default:
-                    if (member is TypeInfo type)
+                    if (member is TypeInfo typeInfo)
                     {
-                        this.Type = TypeRef.Get(type.AsType(), resolver);
+                        this.Type = TypeRef.Get(typeInfo.AsType(), resolver);
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
@@ -63,9 +63,9 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                     this.Property = new PropertyRef((PropertyInfo)member, resolver);
                     break;
                 default:
-                    if (member is Type)
+                    if (member is TypeInfo type)
                     {
-                        this.Type = TypeRef.Get((Type)member, resolver);
+                        this.Type = TypeRef.Get(type.AsType(), resolver);
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
 
             if (memberRef.IsType)
             {
-                return memberRef.Type.Resolve();
+                return memberRef.Type.Resolve().GetTypeInfo();
             }
 
             throw new NotSupportedException();
@@ -185,13 +185,13 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                 var type = typeRef.Resolve();
                 foreach (var baseType in type.EnumTypeAndBaseTypes())
                 {
-                    assemblies.Add(baseType.Assembly.GetName());
+                    assemblies.Add(baseType.GetTypeInfo().Assembly.GetName());
                 }
 
                 // Interfaces may also define [InheritedExport] attributes, metadata view filters, etc.
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in type.GetTypeInfo().GetInterfaces())
                 {
-                    assemblies.Add(iface.Assembly.GetName());
+                    assemblies.Add(iface.GetTypeInfo().Assembly.GetName());
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -207,10 +207,10 @@ namespace Microsoft.VisualStudio.Composition
 
         internal static Type GetMemberType(MemberInfo fieldOrPropertyOrType)
         {
-            var type = fieldOrPropertyOrType as TypeInfo;
-            if (type != null)
+            var typeInfo = fieldOrPropertyOrType as TypeInfo;
+            if (typeInfo != null)
             {
-                return type.AsType();
+                return typeInfo.AsType();
             }
 
             var property = fieldOrPropertyOrType as PropertyInfo;

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -114,14 +114,14 @@ namespace Microsoft.VisualStudio.Composition
 
                 bool valueTypeKnownExactly =
                     export.ExportingMemberRef.IsEmpty || // When [Export] appears on the type itself, we instantiate that exact type.
-                    exportingType.IsSealed;
+                    exportingType.GetTypeInfo().IsSealed;
                 if (valueTypeKnownExactly)
                 {
                     // There is no way that an exported value can implement the required types to make it assignable.
                     return Assignability.DefinitelyNot;
                 }
 
-                if (receivingType.IsInterface || exportingType.IsAssignableFrom(receivingType))
+                if (receivingType.GetTypeInfo().IsInterface || exportingType.GetTypeInfo().IsAssignableFrom(receivingType))
                 {
                     // The actual exported value at runtime *may* be a derived type that *is* assignable to the import site.
                     return Assignability.Maybe;
@@ -207,10 +207,10 @@ namespace Microsoft.VisualStudio.Composition
 
         internal static Type GetMemberType(MemberInfo fieldOrPropertyOrType)
         {
-            var type = fieldOrPropertyOrType as Type;
+            var type = fieldOrPropertyOrType as TypeInfo;
             if (type != null)
             {
-                return type;
+                return type.AsType();
             }
 
             var property = fieldOrPropertyOrType as PropertyInfo;
@@ -491,9 +491,9 @@ namespace Microsoft.VisualStudio.Composition
 
             // The generic type arguments may be buried in the base type of the "constructedType" that we were given.
             var constructedGenericType = constructedType;
-            while (constructedGenericType != null && (!constructedGenericType.IsGenericType || !genericTypeDefinitionInfo.IsAssignableFrom(constructedGenericType.GetGenericTypeDefinition().GetTypeInfo())))
+            while (constructedGenericType != null && (!constructedGenericType.GetTypeInfo().IsGenericType || !genericTypeDefinitionInfo.IsAssignableFrom(constructedGenericType.GetGenericTypeDefinition().GetTypeInfo())))
             {
-                constructedGenericType = constructedGenericType.BaseType;
+                constructedGenericType = constructedGenericType.GetTypeInfo().BaseType;
             }
 
             Requires.Argument(constructedGenericType != null, "constructedType", Strings.NotClosedFormOfOther);
@@ -655,12 +655,12 @@ namespace Microsoft.VisualStudio.Composition
 
             foreach (var baseType in type.EnumTypeAndBaseTypes())
             {
-                assemblies.Add(baseType.Assembly.GetName());
+                assemblies.Add(baseType.GetTypeInfo().Assembly.GetName());
             }
 
-            foreach (var iface in type.GetInterfaces())
+            foreach (var iface in type.GetTypeInfo().GetInterfaces())
             {
-                assemblies.Add(iface.Assembly.GetName());
+                assemblies.Add(iface.GetTypeInfo().Assembly.GetName());
             }
         }
 

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 if (exportedValue != null)
                 {
-                    if (!import.ImportingSiteTypeWithoutCollection.IsAssignableFrom(exportedValue.GetType()))
+                    if (!import.ImportingSiteTypeWithoutCollection.GetTypeInfo().IsAssignableFrom(exportedValue.GetType()))
                     {
                         throw new CompositionFailedException(
                             string.Format(
@@ -374,7 +374,7 @@ namespace Microsoft.VisualStudio.Composition
                 bool containsGenericParameters = member.DeclaringType.GetTypeInfo().ContainsGenericParameters;
                 if (containsGenericParameters)
                 {
-                    member = ReflectionHelpers.CloseGenericType(member.DeclaringType, part.GetType())
+                    member = ReflectionHelpers.CloseGenericType(member.DeclaringType, part.GetType()).GetTypeInfo()
                         .GetMember(member.Name, MemberTypes.Property | MemberTypes.Field, DeclaredOnlyLookup)[0];
                 }
 

--- a/src/Microsoft.VisualStudio.Composition/Utilities.cs
+++ b/src/Microsoft.VisualStudio.Composition/Utilities.cs
@@ -7,6 +7,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
@@ -32,7 +33,7 @@ namespace Microsoft.VisualStudio.Composition
                 ImmutableList<ImportDefinitionBinding>.Empty,
                 string.Empty,
                 default(MethodRef),
-                ConstructorRef.Get(providerType.GetConstructor(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance, null, new Type[0], null), resolver),
+                ConstructorRef.Get(providerType.GetTypeInfo().GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Single(c => c.GetParameters().Length == 0), resolver),
                 ImmutableList<ImportDefinitionBinding>.Empty,
                 CreationPolicy.Shared,
                 false);


### PR DESCRIPTION
This fixes most (all the easy) compile errors when compiling on netstandard1.6. It doesn't actually enable such a compilation so that it can still be merged with master.

The changes consist of:

1. Use `TypeInfo` instead of `Type` where required.
2. Reference .netstandard compatible versions of NuGet packages.
3. Remove references to .NET MEF, which isn't available on .netstandard.
4. Replace use of `Thread` with the managed thread ID for purposes of detecting thread equivalence.