### PR TITLE
Better failure messages when assertions fail in AppDomain tests

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using Microsoft.VisualStudio.Composition.AppDomainTests;
     using Microsoft.VisualStudio.Composition.AppDomainTests2;
     using Xunit;
+    using static Microsoft.VisualStudio.Composition.Tests.AssertEx;
 
     [Trait("Efficiency", "LazyLoad")]
     public abstract class AssembliesLazyLoadedTests : IDisposable
@@ -270,130 +271,87 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 this.container = containerFactory.CreateExportProvider();
             }
 
-            /// <summary>
-            /// Since the exceptions thrown by xUnit asserts are not serializable we lose information
-            /// in case tests fail in another appdomain. These four helpers throw a serializable exception
-            /// that results in a more information exception in the error log.
-            /// </summary>
-            internal void AssertFalse(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
-            {
-                if (condition)
-                {
-                    var message = $"Assert failed: expected false (actual: true) at {filePath}, {memberName} line {lineNumber}";
-                    throw new AssertFailedException(message);
-                }
-            }
-
-            internal void AssertTrue(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
-            {
-                if (!condition)
-                {
-                    var message = $"Assert failed: expected true (actual: false) at {filePath}, {memberName} line {lineNumber}";
-                    throw new AssertFailedException(message);
-                }
-            }
-
-            internal void AssertNotNull(object reference, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
-            {
-                if (reference == null)
-                {
-                    var message = $"Assert failed: unexpected null at {filePath}, {memberName} line {lineNumber}";
-                    throw new AssertFailedException(message);
-                }
-            }
-
-            internal void AssertEqual<T>(T expected, T actual, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
-                where T : IEquatable<T>
-            {
-                if (!EqualityComparer<T>.Default.Equals(expected, actual))
-                {
-                    var message = $"Assert failed: expected: {expected} actual: {actual} at {filePath}, {memberName} line {lineNumber}";
-                    throw new AssertFailedException(message);
-                }
-            }
-
             internal void TestGetInputAssembliesDoesNotLoadLazyExport(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.catalog.GetInputAssemblies();
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestExternalExport(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.CauseLazyLoad1(this.container);
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestYetAnotherExport(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.CauseLazyLoad2(this.container);
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestExternalExportWithLazy(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(true);
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<ExternalExportWithLazy>();
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.NotNull(exportWithLazy.YetAnotherExport.Value);
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithTypeMetadataViaDictionary(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaDictionary>();
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.NotNull(exportWithLazy.ImportWithDictionary.Metadata.ContainsKey("foo"));
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Type type = (Type)exportWithLazy.ImportWithDictionary.Metadata["SomeType"];
                 Type[] types = (Type[])exportWithLazy.ImportWithDictionary.Metadata["SomeTypes"];
-                this.AssertEqual("YetAnotherExport", type.Name);
+                AssertEqual("YetAnotherExport", type.Name);
                 types.Single(t => t.Name == "String");
                 types.Single(t => t.Name == "YetAnotherExport");
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithTypeMetadataViaTMetadata(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaTMetadata>();
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Type type = exportWithLazy.ImportWithTMetadata.Metadata.SomeType;
                 Type[] types = exportWithLazy.ImportWithTMetadata.Metadata.SomeTypes;
-                this.AssertEqual("YetAnotherExport", type.Name);
+                AssertEqual("YetAnotherExport", type.Name);
                 types.Single(t => t.Name == "String");
                 types.Single(t => t.Name == "YetAnotherExport");
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithGenericTypeArg(string lazyLoadedAssemblyPath)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartImportingOpenGenericExport>();
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatLazyImportsExportWithMetadataOfCustomType(string lazyLoadedAssemblyPath, bool isRuntime)
             {
-                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithMetadataOfCustomType>();
 
                 // This next segment we'll permit an assembly load only for code gen cases, which aren't as well tuned at present.
-                this.AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
-                this.AssertEqual("Value", exportWithLazy.ImportingProperty.Metadata["Simple"] as string);
-                this.AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEqual("Value", exportWithLazy.ImportingProperty.Metadata["Simple"] as string);
+                AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
 
                 // At this point, loading the assembly is absolutely required.
                 object customEnum = exportWithLazy.ImportingProperty.Metadata["CustomValue"];
-                this.AssertEqual("CustomEnum", customEnum.GetType().Name);
-                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEqual("CustomEnum", customEnum.GetType().Name);
+                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             private static IEnumerable<Assembly> GetLoadedAssemblies()
@@ -415,7 +373,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // Actually the lazy load happens before GetExport is actually called since this method
                 // references a type in that assembly.
                 var export = container.GetExportedValue<ExternalExport>();
-                this.AssertNotNull(export);
+                AssertNotNull(export);
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)] // if this method is inlined, it defeats the point of it being a separate method in the test and causes test failure.
@@ -424,7 +382,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // Actually the lazy load happens before GetExport is actually called since this method
                 // references a type in that assembly.
                 var export = container.GetExportedValue<YetAnotherExport>();
-                this.AssertNotNull(export);
+                AssertNotNull(export);
             }
         }
     }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -270,87 +270,130 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 this.container = containerFactory.CreateExportProvider();
             }
 
+            /// <summary>
+            /// Since the exceptions thrown by xUnit asserts are not serializable we lose information
+            /// in case tests fail in another appdomain. These four helpers throw a serializable exception
+            /// that results in a more information exception in the error log.
+            /// </summary>
+            internal void AssertFalse(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            {
+                if (condition)
+                {
+                    var message = $"Assert failed: expected false (actual: true) at {filePath}, {memberName} line {lineNumber}";
+                    throw new AssertFailedException(message);
+                }
+            }
+
+            internal void AssertTrue(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            {
+                if (!condition)
+                {
+                    var message = $"Assert failed: expected true (actual: false) at {filePath}, {memberName} line {lineNumber}";
+                    throw new AssertFailedException(message);
+                }
+            }
+
+            internal void AssertNotNull(object reference, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            {
+                if (reference == null)
+                {
+                    var message = $"Assert failed: unexpected null at {filePath}, {memberName} line {lineNumber}";
+                    throw new AssertFailedException(message);
+                }
+            }
+
+            internal void AssertEqual<T>(T expected, T actual, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+                where T : IEquatable<T>
+            {
+                if (!EqualityComparer<T>.Default.Equals(expected, actual))
+                {
+                    var message = $"Assert failed: expected: {expected} actual: {actual} at {filePath}, {memberName} line {lineNumber}";
+                    throw new AssertFailedException(message);
+                }
+            }
+
             internal void TestGetInputAssembliesDoesNotLoadLazyExport(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.catalog.GetInputAssemblies();
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestExternalExport(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.CauseLazyLoad1(this.container);
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestYetAnotherExport(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.CauseLazyLoad2(this.container);
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestExternalExportWithLazy(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(true);
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<ExternalExportWithLazy>();
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.NotNull(exportWithLazy.YetAnotherExport.Value);
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithTypeMetadataViaDictionary(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaDictionary>();
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.NotNull(exportWithLazy.ImportWithDictionary.Metadata.ContainsKey("foo"));
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Type type = (Type)exportWithLazy.ImportWithDictionary.Metadata["SomeType"];
                 Type[] types = (Type[])exportWithLazy.ImportWithDictionary.Metadata["SomeTypes"];
-                Assert.Equal("YetAnotherExport", type.Name);
+                this.AssertEqual("YetAnotherExport", type.Name);
                 types.Single(t => t.Name == "String");
                 types.Single(t => t.Name == "YetAnotherExport");
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithTypeMetadataViaTMetadata(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaTMetadata>();
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Type type = exportWithLazy.ImportWithTMetadata.Metadata.SomeType;
                 Type[] types = exportWithLazy.ImportWithTMetadata.Metadata.SomeTypes;
-                Assert.Equal("YetAnotherExport", type.Name);
+                this.AssertEqual("YetAnotherExport", type.Name);
                 types.Single(t => t.Name == "String");
                 types.Single(t => t.Name == "YetAnotherExport");
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithGenericTypeArg(string lazyLoadedAssemblyPath)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartImportingOpenGenericExport>();
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatLazyImportsExportWithMetadataOfCustomType(string lazyLoadedAssemblyPath, bool isRuntime)
             {
-                Assert.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithMetadataOfCustomType>();
 
                 // This next segment we'll permit an assembly load only for code gen cases, which aren't as well tuned at present.
-                Assert.False(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
-                Assert.Equal("Value", exportWithLazy.ImportingProperty.Metadata["Simple"]);
-                Assert.False(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertEqual("Value", exportWithLazy.ImportingProperty.Metadata["Simple"] as string);
+                this.AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
 
                 // At this point, loading the assembly is absolutely required.
                 object customEnum = exportWithLazy.ImportingProperty.Metadata["CustomValue"];
-                Assert.Equal("CustomEnum", customEnum.GetType().Name);
-                Assert.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                this.AssertEqual("CustomEnum", customEnum.GetType().Name);
+                this.AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             private static IEnumerable<Assembly> GetLoadedAssemblies()
@@ -372,7 +415,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // Actually the lazy load happens before GetExport is actually called since this method
                 // references a type in that assembly.
                 var export = container.GetExportedValue<ExternalExport>();
-                Assert.NotNull(export);
+                this.AssertNotNull(export);
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)] // if this method is inlined, it defeats the point of it being a separate method in the test and causes test failure.
@@ -381,7 +424,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // Actually the lazy load happens before GetExport is actually called since this method
                 // references a type in that assembly.
                 var export = container.GetExportedValue<YetAnotherExport>();
-                Assert.NotNull(export);
+                this.AssertNotNull(export);
             }
         }
     }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using Microsoft.VisualStudio.Composition.AppDomainTests;
     using Microsoft.VisualStudio.Composition.AppDomainTests2;
     using Xunit;
-    using static Microsoft.VisualStudio.Composition.Tests.AssertEx;
 
     [Trait("Efficiency", "LazyLoad")]
     public abstract class AssembliesLazyLoadedTests : IDisposable
@@ -273,85 +272,85 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             internal void TestGetInputAssembliesDoesNotLoadLazyExport(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.catalog.GetInputAssemblies();
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestExternalExport(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.CauseLazyLoad1(this.container);
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestYetAnotherExport(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 this.CauseLazyLoad2(this.container);
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestExternalExportWithLazy(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<ExternalExportWithLazy>();
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.NotNull(exportWithLazy.YetAnotherExport.Value);
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithTypeMetadataViaDictionary(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaDictionary>();
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.NotNull(exportWithLazy.ImportWithDictionary.Metadata.ContainsKey("foo"));
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Type type = (Type)exportWithLazy.ImportWithDictionary.Metadata["SomeType"];
                 Type[] types = (Type[])exportWithLazy.ImportWithDictionary.Metadata["SomeTypes"];
-                AssertEqual("YetAnotherExport", type.Name);
+                AssertEx.Equal("YetAnotherExport", type.Name);
                 types.Single(t => t.Name == "String");
                 types.Single(t => t.Name == "YetAnotherExport");
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithTypeMetadataViaTMetadata(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaTMetadata>();
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Type type = exportWithLazy.ImportWithTMetadata.Metadata.SomeType;
                 Type[] types = exportWithLazy.ImportWithTMetadata.Metadata.SomeTypes;
-                AssertEqual("YetAnotherExport", type.Name);
+                AssertEx.Equal("YetAnotherExport", type.Name);
                 types.Single(t => t.Name == "String");
                 types.Single(t => t.Name == "YetAnotherExport");
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatImportsExportWithGenericTypeArg(string lazyLoadedAssemblyPath)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartImportingOpenGenericExport>();
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             internal void TestPartThatLazyImportsExportWithMetadataOfCustomType(string lazyLoadedAssemblyPath, bool isRuntime)
             {
-                AssertFalse(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container.GetExportedValue<PartThatLazyImportsExportWithMetadataOfCustomType>();
 
                 // This next segment we'll permit an assembly load only for code gen cases, which aren't as well tuned at present.
-                AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
-                AssertEqual("Value", exportWithLazy.ImportingProperty.Metadata["Simple"] as string);
-                AssertFalse(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.False(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.Equal("Value", exportWithLazy.ImportingProperty.Metadata["Simple"] as string);
+                AssertEx.False(isRuntime && GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
 
                 // At this point, loading the assembly is absolutely required.
                 object customEnum = exportWithLazy.ImportingProperty.Metadata["CustomValue"];
-                AssertEqual("CustomEnum", customEnum.GetType().Name);
-                AssertTrue(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                AssertEx.Equal("CustomEnum", customEnum.GetType().Name);
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
             }
 
             private static IEnumerable<Assembly> GetLoadedAssemblies()
@@ -373,7 +372,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // Actually the lazy load happens before GetExport is actually called since this method
                 // references a type in that assembly.
                 var export = container.GetExportedValue<ExternalExport>();
-                AssertNotNull(export);
+                AssertEx.NotNull(export);
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)] // if this method is inlined, it defeats the point of it being a separate method in the test and causes test failure.
@@ -382,7 +381,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // Actually the lazy load happens before GetExport is actually called since this method
                 // references a type in that assembly.
                 var export = container.GetExportedValue<YetAnotherExport>();
-                AssertNotNull(export);
+                AssertEx.NotNull(export);
             }
         }
     }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertEx.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertEx.cs
@@ -4,14 +4,17 @@
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
 
+    /// <summary>
+    /// Xunit-like assertions that throw a serializable exception.
+    /// </summary>
+    /// <remarks>
+    /// Since the exceptions thrown by xUnit asserts are not serializable we lose information
+    /// in case tests fail in another appdomain. These four helpers throw a serializable exception
+    /// that results in a more information exception in the error log.
+    /// </remarks>
     internal static class AssertEx
     {
-        /// <summary>
-        /// Since the exceptions thrown by xUnit asserts are not serializable we lose information
-        /// in case tests fail in another appdomain. These four helpers throw a serializable exception
-        /// that results in a more information exception in the error log.
-        /// </summary>
-        internal static void AssertFalse(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        internal static void False(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
             if (condition)
             {
@@ -20,7 +23,7 @@
             }
         }
 
-        internal static void AssertTrue(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        internal static void True(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
             if (!condition)
             {
@@ -29,7 +32,7 @@
             }
         }
 
-        internal static void AssertNotNull(object reference, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        internal static void NotNull(object reference, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
             if (reference == null)
             {
@@ -38,7 +41,7 @@
             }
         }
 
-        internal static void AssertEqual<T>(T expected, T actual, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        internal static void Equal<T>(T expected, T actual, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
             where T : IEquatable<T>
         {
             if (!EqualityComparer<T>.Default.Equals(expected, actual))

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertEx.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertEx.cs
@@ -1,0 +1,51 @@
+﻿namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+
+    internal static class AssertEx
+    {
+        /// <summary>
+        /// Since the exceptions thrown by xUnit asserts are not serializable we lose information
+        /// in case tests fail in another appdomain. These four helpers throw a serializable exception
+        /// that results in a more information exception in the error log.
+        /// </summary>
+        internal static void AssertFalse(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (condition)
+            {
+                var message = $"Assert failed: expected false (actual: true) at {filePath}, {memberName} line {lineNumber}";
+                throw new AssertFailedException(message);
+            }
+        }
+
+        internal static void AssertTrue(bool condition, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (!condition)
+            {
+                var message = $"Assert failed: expected true (actual: false) at {filePath}, {memberName} line {lineNumber}";
+                throw new AssertFailedException(message);
+            }
+        }
+
+        internal static void AssertNotNull(object reference, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (reference == null)
+            {
+                var message = $"Assert failed: unexpected null at {filePath}, {memberName} line {lineNumber}";
+                throw new AssertFailedException(message);
+            }
+        }
+
+        internal static void AssertEqual<T>(T expected, T actual, [CallerFilePath] string filePath = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            {
+                var message = $"Assert failed: expected: {expected} actual: {actual} at {filePath}, {memberName} line {lineNumber}";
+                throw new AssertFailedException(message);
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertFailedException.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertFailedException.cs
@@ -6,16 +6,16 @@
     [Serializable]
     internal class AssertFailedException : Exception
     {
-        public AssertFailedException()
+        internal AssertFailedException()
         {
         }
 
-        public AssertFailedException(string message)
+        internal AssertFailedException(string message)
             : base(message)
         {
         }
 
-        public AssertFailedException(string message, Exception innerException)
+        internal AssertFailedException(string message, Exception innerException)
             : base(message, innerException)
         {
         }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertFailedException.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertFailedException.cs
@@ -1,0 +1,28 @@
+﻿namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    internal class AssertFailedException : Exception
+    {
+        public AssertFailedException()
+        {
+        }
+
+        public AssertFailedException(string message)
+            : base(message)
+        {
+        }
+
+        public AssertFailedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected AssertFailedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
If xUnit asserts fail in another appdomain, instead of the legible error we get
Type 'Xunit.Sdk.FalseException' in assembly 'xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c' is not marked as serializable.

Instead, we have our own serializable exception that can travel across appdomains and preserve a better error message in case any of these tests fail.

Fixes #7