### PR TITLE
Add support for internal metadata view interfaces

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewGenerator.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewGenerator.cs
@@ -9,16 +9,14 @@
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
     using System.Security;
     using System.Threading;
-    using Microsoft.Internal;
+    using Microsoft.VisualStudio.Composition.Reflection;
 
     /// <summary>
     /// Constructs concrete types for metadata view interfaces.
@@ -90,6 +88,7 @@ namespace Microsoft.VisualStudio.Composition
         private static readonly ConstructorInfo ObjectCtor = typeof(object).GetConstructor(Type.EmptyTypes);
 
         private static ModuleBuilder transparentProxyModuleBuilder;
+        private static SkipClrVisibilityChecks skipClrVisibilityChecks;
 
         public delegate object MetadataViewFactory(IReadOnlyDictionary<string, object> metadata, IReadOnlyDictionary<string, object> defaultMetadata);
 
@@ -106,6 +105,7 @@ namespace Microsoft.VisualStudio.Composition
                 // make a new assemblybuilder and modulebuilder
                 var assemblyBuilder = CreateProxyAssemblyBuilder(typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes));
                 transparentProxyModuleBuilder = assemblyBuilder.DefineDynamicModule("MetadataViewProxiesModule");
+                skipClrVisibilityChecks = new SkipClrVisibilityChecks(assemblyBuilder, transparentProxyModuleBuilder);
             }
 
             return transparentProxyModuleBuilder;
@@ -142,6 +142,8 @@ namespace Microsoft.VisualStudio.Composition
             Type[] interfaces = { viewType };
 
             var proxyModuleBuilder = GetProxyModuleBuilder();
+            skipClrVisibilityChecks.SkipVisibilityChecksFor(viewType.GetTypeInfo());
+
             proxyTypeBuilder = proxyModuleBuilder.DefineType(
                 string.Format(CultureInfo.InvariantCulture, "_proxy_{0}_{1}", viewType.FullName, Guid.NewGuid()),
                 TypeAttributes.Public,

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/AssemblyInfo.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Runtime.CompilerServices;
+
+// This is an important part of testing. We need to know that our ability to handle
+// internal types can span assemblies when, for example, an internal type in one assembly
+// references an internal type in another assembly.
+[assembly: InternalsVisibleTo("Microsoft.VisualStudio.Composition.Tests")]

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/IInternalMetadataView.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/IInternalMetadataView.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
+{
+    /// <summary>
+    /// An internal interface that is used as the base interface
+    /// of a metadata view defined in another assembly.
+    /// </summary>
+    internal interface IInternalMetadataView
+    {
+        string MetadataOnInternalInterface { get; }
+    }
+}

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataTests.cs
@@ -107,6 +107,17 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.IsType<PartWithExportMetadata>(importingPart.ImportingProperty.Single().Value);
         }
 
+        [MefFact(CompositionEngines.V3EmulatingV1, typeof(ImportManyPartWithInternalMetadataInterface), typeof(PartWithExportMetadata))]
+        public void ImportManyWithInternalMetadataInterface(IContainer container)
+        {
+            var importingPart = container.GetExportedValue<ImportManyPartWithInternalMetadataInterface>();
+            Assert.NotNull(importingPart.ImportingProperty);
+            Assert.Equal(1, importingPart.ImportingProperty.Count());
+            Assert.Equal("b", importingPart.ImportingProperty.Single().Metadata.a);
+            Assert.False(importingPart.ImportingProperty.Single().IsValueCreated);
+            Assert.IsType<PartWithExportMetadata>(importingPart.ImportingProperty.Single().Value);
+        }
+
         [MefFact(CompositionEngines.Unspecified, typeof(ImportingPartWithMetadataInterface), typeof(PartWithExportMetadata))]
         [Trait("Efficiency", "InstanceReuse")]
         public void MetadataViewInterfaceInstanceSharedAcrossImports(IContainer container)
@@ -606,6 +617,14 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [MefV1.Export, MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
         [Export]
+        public class ImportManyPartWithInternalMetadataInterface
+        {
+            [ImportMany, MefV1.ImportMany]
+            internal IEnumerable<Lazy<PartWithExportMetadata, IMetadataInternal>> ImportingProperty { get; set; }
+        }
+
+        [MefV1.Export, MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
+        [Export]
         public class ImportManyPartWithMetadataClass
         {
             [ImportMany, MefV1.ImportMany]
@@ -635,6 +654,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             [DefaultValue(4)]
             int SomeInt { get; }
+        }
+
+        internal interface IMetadataInternal : IMetadata
+        {
         }
 
         public class MetadataClass

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataTests.cs
@@ -107,6 +107,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.IsType<PartWithExportMetadata>(importingPart.ImportingProperty.Single().Value);
         }
 
+        [Trait("Access", "NonPublic")]
         [MefFact(CompositionEngines.V3EmulatingV1, typeof(ImportManyPartWithInternalMetadataInterface), typeof(PartWithExportMetadata))]
         public void ImportManyWithInternalMetadataInterface(IContainer container)
         {
@@ -114,6 +115,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(importingPart.ImportingProperty);
             Assert.Equal(1, importingPart.ImportingProperty.Count());
             Assert.Equal("b", importingPart.ImportingProperty.Single().Metadata.a);
+            Assert.Equal("internal!", importingPart.ImportingProperty.Single().Metadata.MetadataOnInternalInterface);
             Assert.False(importingPart.ImportingProperty.Single().IsValueCreated);
             Assert.IsType<PartWithExportMetadata>(importingPart.ImportingProperty.Single().Value);
         }
@@ -563,8 +565,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [MefV1.Export, MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
         [MefV1.ExportMetadata("a", "b")]
+        [MefV1.ExportMetadata(nameof(AssemblyDiscoveryTests.IInternalMetadataView.MetadataOnInternalInterface), "internal!")]
         [Export]
         [ExportMetadata("a", "b")]
+        [ExportMetadata(nameof(AssemblyDiscoveryTests.IInternalMetadataView.MetadataOnInternalInterface), "internal!")]
         public class PartWithExportMetadata { }
 
         [MefV1.Export, MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
@@ -656,7 +660,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             int SomeInt { get; }
         }
 
-        internal interface IMetadataInternal : IMetadata
+        internal interface IMetadataInternal : IMetadata, AssemblyDiscoveryTests.IInternalMetadataView
         {
         }
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportProviderTests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(export.Value);
         }
 
+        [Trait("Access", "NonPublic")]
         [MefFact(CompositionEngines.V3EmulatingV1 | CompositionEngines.V3EmulatingV2, typeof(SomeOtherPart))]
         public void GetExportWithInternalMetadataView(IContainer container)
         {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportProviderTests.cs
@@ -54,6 +54,14 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(export.Value);
         }
 
+        [MefFact(CompositionEngines.V3EmulatingV1 | CompositionEngines.V3EmulatingV2, typeof(SomeOtherPart))]
+        public void GetExportWithInternalMetadataView(IContainer container)
+        {
+            var export = container.GetExport<SomeOtherPart, ISomeOtherPartInternalMetadataView>();
+            Assert.Equal(1, export.Metadata.A);
+            Assert.NotNull(export.Value);
+        }
+
         [MefFact(CompositionEngines.V1Compat | CompositionEngines.V3EmulatingV2, typeof(SomeOtherPart))]
         public void GetExportWithFilteringMetadataView(IContainer container)
         {
@@ -114,6 +122,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         public class SomeOtherPart { }
 
         public interface ISomeOtherPartMetadataView
+        {
+            int A { get; }
+        }
+
+        internal interface ISomeOtherPartInternalMetadataView
         {
             int A { get; }
         }


### PR DESCRIPTION
This gives VS MEF the ability to generate metadata view dynamic types that derive from internal interfaces. .NET MEF and NuGet MEF don't have this capability, but it is achievable using the CLR's assembly attribute that tells it to disregard visibility checks.

Closes #9