### PR TITLE
Skip more AppDomain and assembly load related tests on Mono

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -39,9 +39,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         /// <summary>
         /// Verifies that the assemblies that MEF parts belong to are only loaded when their parts are actually instantiated.
         /// </summary>
-        [Fact]
+        [SkippableFact]
+        [Trait("AppDomains", "true")]
         public async Task ComposableAssembliesLazyLoadedWhenQueried()
         {
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(ExternalExport), typeof(YetAnotherExport)));
             var catalogCache = await this.SaveCatalogAsync(catalog);
@@ -90,9 +92,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         /// <summary>
         /// Verifies that the assemblies that MEF parts belong to are only loaded when their parts are actually instantiated.
         /// </summary>
-        [Fact]
+        [SkippableFact]
+        [Trait("AppDomains", "true")]
         public async Task ComposableAssembliesLazyLoadedByLazyImport()
         {
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(ExternalExportWithLazy), typeof(YetAnotherExport)));
             var catalogCache = await this.SaveCatalogAsync(catalog);
@@ -121,7 +125,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         [Trait("AppDomains", "true")]
         public async Task ComposableAssembliesLazyLoadedByLazyMetadataDictionary()
         {
-            TestUtilities.SkipOnMono("AppDomains(?)");
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(PartThatLazyImportsExportWithTypeMetadataViaDictionary), typeof(AnExportWithMetadataTypeValue)));
             var catalogCache = await this.SaveCatalogAsync(catalog);
@@ -146,9 +150,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         /// Verifies that the assemblies that MEF parts belong to are only loaded when
         /// their metadata is actually retrieved.
         /// </summary>
-        [Fact]
+        [SkippableFact]
+        [Trait("AppDomains", "true")]
         public async Task ComposableAssembliesLazyLoadedByLazyTMetadata()
         {
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(PartThatLazyImportsExportWithTypeMetadataViaTMetadata), typeof(AnExportWithMetadataTypeValue)))
                 .WithDesktopSupport();
@@ -174,9 +180,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         /// Verifies that lazy assembly load isn't defeated when that assembly
         /// defines a type used as a generic type argument elsewhere.
         /// </summary>
-        [Fact]
+        [SkippableFact]
+        [Trait("AppDomains", "true")]
         public async Task ComposableAssembliesLazyLoadedWithGenericTypeArg()
         {
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(PartImportingOpenGenericExport), typeof(OpenGenericExport<>)))
                 .WithDesktopSupport();
@@ -202,9 +210,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         /// Verifies that the assemblies that MEF parts belong to are only loaded when the custom metadata types they define
         /// are actually required by some import.
         /// </summary>
-        [Fact]
+        [SkippableFact]
+        [Trait("AppDomains", "true")]
         public async Task ComposableAssembliesLazyLoadedWhenCustomMetadataIsRequired()
         {
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(ExportWithCustomMetadata), typeof(PartThatLazyImportsExportWithMetadataOfCustomType)));
             var catalogCache = await this.SaveCatalogAsync(catalog);
@@ -223,6 +233,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 AppDomain.Unload(appDomain);
             }
+        }
+
+        private static void SkipOnMono()
+        {
+            TestUtilities.SkipOnMono("Assemblies are loaded more eagerly in other AppDomains on Mono");
         }
 
         private async Task<Stream> SaveConfigurationAsync(CompositionConfiguration configuration)

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
@@ -106,6 +106,8 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [Trait("Disposal", "")]
         [MefFact(CompositionEngines.V2Compat)]
+        [Trait("WeakReference", "true")]
+        [Trait(Traits.SkipOnMono, "WeakReference")]
         public void DisposeExportDisposesContainer(IContainer container)
         {
             var root = container.GetExportedValue<RootPart>();

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
@@ -106,8 +106,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [Trait("Disposal", "")]
         [MefFact(CompositionEngines.V2Compat)]
-        [Trait("WeakReference", "true")]
-        [Trait(Traits.SkipOnMono, "WeakReference")]
         public void DisposeExportDisposesContainer(IContainer container)
         {
             var root = container.GetExportedValue<RootPart>();
@@ -122,6 +120,8 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [MefFact(CompositionEngines.V2Compat)]
+        [Trait("WeakReference", "true")]
+        [Trait(Traits.SkipOnMono, "WeakReference")]
         public void DisposeExportReleasesContainer(IContainer container)
         {
             var root = container.GetExportedValue<RootPart>();


### PR DESCRIPTION
I'm not quite sure yet what is going on but by the time the test driver starts running in the new appdomain on Mono, all related assemblies are already loaded.

We'll investigate this later.