### PR TITLE
Improve test coverage of catalog input assemblies

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
@@ -11,25 +11,43 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests;
     using Shell.Interop;
     using Xunit;
+    using Xunit.Abstractions;
     using MEFv1 = System.ComponentModel.Composition;
 
     public class CompositionCatalogTests
     {
-        [Fact]
-        public async Task CreateFromTypesOmitsNonPartsV1()
+        private readonly ITestOutputHelper logger;
+
+        public CompositionCatalogTests(ITestOutputHelper logger)
         {
-            var discovery = TestUtilities.V1Discovery;
-            var catalog = ComposableCatalog.Create(discovery.Resolver).AddParts(
-                await discovery.CreatePartsAsync(typeof(NonExportingType), typeof(ExportingType)));
-            Assert.Equal(1, catalog.Parts.Count);
-            Assert.Equal(typeof(ExportingType), catalog.Parts.Single().Type);
+            this.logger = logger;
         }
 
-        [Fact]
-        public async Task CreateFromTypesOmitsNonPartsV2()
+        public static PartDiscovery[] DiscoveryEngines
         {
-            var discovery = TestUtilities.V2Discovery;
-            var catalog = TestUtilities.EmptyCatalog.AddParts(
+            get
+            {
+                return new PartDiscovery[]
+                {
+                    TestUtilities.V1Discovery,
+                    ////TestUtilities.V2Discovery,
+                };
+            }
+        }
+
+        public static object[][] DiscoveryEnginesTheoryData
+        {
+            get
+            {
+                return DiscoveryEngines.Select(e => new object[] { e }).ToArray();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task CreateFromTypesOmitsNonParts(PartDiscovery discovery)
+        {
+            var catalog = ComposableCatalog.Create(discovery.Resolver).AddParts(
                 await discovery.CreatePartsAsync(typeof(NonExportingType), typeof(ExportingType)));
             Assert.Equal(1, catalog.Parts.Count);
             Assert.Equal(typeof(ExportingType), catalog.Parts.Single().Type);
@@ -47,264 +65,278 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal(0, TestUtilities.EmptyCatalog.GetInputAssemblies().Count);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningParts()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningParts(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(NonExportingType), typeof(ExportingType)));
+                await discovery.CreatePartsAsync(typeof(NonExportingType), typeof(ExportingType)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(NonExportingType).Assembly.GetName(),
-                typeof(object).Assembly.GetName(),
+                typeof(NonExportingType).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName(),
             };
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningBaseTypesOfParts()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningBaseTypesOfParts(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingTypeDerivesFromOtherAssembly)));
+                await discovery.CreatePartsAsync(typeof(ExportingTypeDerivesFromOtherAssembly)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(ExportingTypeDerivesFromOtherAssembly).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests.NonPart).Assembly.GetName(),
-                typeof(object).Assembly.GetName(),
+                typeof(ExportingTypeDerivesFromOtherAssembly).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests.NonPart).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName(),
             };
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningInterfacesOfParts()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningInterfacesOfParts(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingTypeImplementsFromOtherAssembly)));
+                await discovery.CreatePartsAsync(typeof(ExportingTypeImplementsFromOtherAssembly)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(ExportingTypeImplementsFromOtherAssembly).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(object).Assembly.GetName(),
+                typeof(ExportingTypeImplementsFromOtherAssembly).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName(),
             };
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningEnumUsedInPartMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningEnumUsedInPartMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(PartWithEnumValueMetadata)));
+                await discovery.CreatePartsAsync(typeof(PartWithEnumValueMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(PartWithEnumValueMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(PartWithEnumValueMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningTypeSingleMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningTypeSingleMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithTypeSingleMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithTypeSingleMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(ExportingWithTypeSingleMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithTypeSingleMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningTypeMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningTypeMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithTypeMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithTypeMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(ExportingWithTypeMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithTypeMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningMultipleTypeMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningMultipleTypeMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithMultipleTypeMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithMultipleTypeMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AllColorableItemInfo).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(ExportingWithMultipleTypeMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AllColorableItemInfo).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithMultipleTypeMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningEnumMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningEnumMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithEnumMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithEnumMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.SomeEnum).Assembly.GetName(),
-                typeof(ExportingWithEnumMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.SomeEnum).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithEnumMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningMultipleDifferentEnumMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningMultipleDifferentEnumMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithMultipleDifferentEnumMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithMultipleDifferentEnumMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.SomeEnum).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests2.SomeOtherEnum).Assembly.GetName(),
-                typeof(ExportingWithMultipleDifferentEnumMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.SomeEnum).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests2.SomeOtherEnum).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithMultipleDifferentEnumMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningLotsOfMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningLotsOfMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithLotsOfMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithLotsOfMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.SomeEnum).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests2.SomeOtherEnum).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(ExportingWithLotsOfMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.SomeEnum).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests2.SomeOtherEnum).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithLotsOfMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningExportingMembersWithTypeMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_IdentifiesAssembliesDefiningExportingMembersWithTypeMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingWithExportingMembers)));
+                await discovery.CreatePartsAsync(typeof(ExportingWithExportingMembers)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(ExportingWithExportingMembers).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingWithExportingMembers).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_FunctionsCorrectlyWithNullMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_FunctionsCorrectlyWithNullMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingTypeWithNullExportMetadata)));
+                await discovery.CreatePartsAsync(typeof(ExportingTypeWithNullExportMetadata)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(ExportingTypeWithNullExportMetadata).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingTypeWithNullExportMetadata).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_RecursesThroughTypeTreeInMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_RecursesThroughTypeTreeInMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingTypeWithExportMetadataWithExternalDependencies)));
+                await discovery.CreatePartsAsync(typeof(ExportingTypeWithExportMetadataWithExternalDependencies)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterface).Assembly.GetName(),
-                typeof(System.Exception).Assembly.GetName(),
-                typeof(ExportingTypeWithExportMetadataWithExternalDependencies).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(System.Exception).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingTypeWithExportMetadataWithExternalDependencies).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_RecursesThroughInterfaceTreeInMetadata()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_RecursesThroughInterfaceTreeInMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingTypeWithExportMetadataWithExternalDependenciesAndInterfaceTree)));
+                await discovery.CreatePartsAsync(typeof(ExportingTypeWithExportMetadataWithExternalDependenciesAndInterfaceTree)));
 
             var expected = new HashSet<AssemblyName>(AssemblyNameComparer.Default)
             {
-                typeof(AssemblyDiscoveryTests.ISomeInterfaceWithBaseInterface).Assembly.GetName(),
-                typeof(AssemblyDiscoveryTests2.IBlankInterface).Assembly.GetName(),
-                typeof(ExportingTypeWithExportMetadataWithExternalDependenciesAndInterfaceTree).Assembly.GetName(),
-                typeof(object).Assembly.GetName()
+                typeof(AssemblyDiscoveryTests.ISomeInterfaceWithBaseInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(AssemblyDiscoveryTests2.IBlankInterface).GetTypeInfo().Assembly.GetName(),
+                typeof(ExportingTypeWithExportMetadataWithExternalDependenciesAndInterfaceTree).GetTypeInfo().Assembly.GetName(),
+                typeof(object).GetTypeInfo().Assembly.GetName()
             };
 
             var actual = catalog.GetInputAssemblies();
-            Assert.True(expected.SetEquals(actual));
+            this.AssertExpectedInputAssemblies(expected, actual);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_ContainsDefiningAttributeAssemblyForMetadataV1()
+        [Theory]
+        [MemberData(nameof(DiscoveryEnginesTheoryData))]
+        public async Task GetAssemblyInputs_ContainsDefiningAttributeAssemblyForMetadata(PartDiscovery discovery)
         {
             var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V1Discovery.CreatePartsAsync(typeof(ExportingTypeWithMetadataWhoseDefiningAttributeIsInAnotherAssembly)));
+                await discovery.CreatePartsAsync(typeof(ExportingTypeWithMetadataWhoseDefiningAttributeIsInAnotherAssembly)));
 
             var inputAssemblies = catalog.GetInputAssemblies();
-            Assert.Contains(typeof(SomeMetadataAttributeFromAnotherAssemblyAttribute).Assembly.GetName(), inputAssemblies, AssemblyNameComparer.Default);
+            Assert.Contains(typeof(SomeMetadataAttributeFromAnotherAssemblyAttribute).GetTypeInfo().Assembly.GetName(), inputAssemblies, AssemblyNameComparer.Default);
         }
 
-        [Fact]
-        public async Task GetAssemblyInputs_ContainsDefiningAttributeAssemblyForMetadataV2()
+        private void AssertExpectedInputAssemblies(ISet<AssemblyName> expectedSubset, IEnumerable<AssemblyName> actual)
         {
-            var catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V2Discovery.CreatePartsAsync(typeof(ExportingTypeWithMetadataWhoseDefiningAttributeIsInAnotherAssembly)));
-
-            var inputAssemblies = catalog.GetInputAssemblies();
-            Assert.Contains(typeof(SomeMetadataAttributeFromAnotherAssemblyAttribute).Assembly.GetName(), inputAssemblies, AssemblyNameComparer.Default);
+            this.logger.WriteLine("Expected:");
+            this.logger.WriteLine(string.Join(Environment.NewLine, expectedSubset.OrderBy(async => async.FullName)));
+            this.logger.WriteLine("Actual:");
+            this.logger.WriteLine(string.Join(Environment.NewLine, actual.OrderBy(async => async.FullName)));
+            Assert.Equal(expectedSubset, actual);
         }
 
         public class NonExportingType { }
@@ -420,11 +452,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
                     return true;
                 }
 
+#if DESKTOP
                 // fast path
                 if (x.CodeBase == y.CodeBase)
                 {
                     return true;
                 }
+#endif
 
                 // Testing on FullName is horrifically slow.
                 // So test directly on its components instead.

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             this.logger.WriteLine(string.Join(Environment.NewLine, expectedSubset.OrderBy(async => async.FullName)));
             this.logger.WriteLine("Actual:");
             this.logger.WriteLine(string.Join(Environment.NewLine, actual.OrderBy(async => async.FullName)));
-            Assert.Equal(expectedSubset, actual);
+            Assert.True(expectedSubset.IsSubsetOf(actual)); // Allow for extra assemblies, since V2 discovery adds MS.VS.Composition itself for Shared/NonShared part metadata
         }
 
         public class NonExportingType { }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
@@ -385,6 +385,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [Export, MEFv1.Export]
         [MEFv1.ExportMetadata("Type", typeof(AssemblyDiscoveryTests.ISomeInterface))]
+        [ExportMetadata("Type", typeof(AssemblyDiscoveryTests.ISomeInterface))]
         public class ExportingWithTypeMetadata { }
 
         [Export, MEFv1.Export]
@@ -394,21 +395,28 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [Export, MEFv1.Export]
         [MEFv1.ExportMetadata("AdornmentLayerType", typeof(AssemblyDiscoveryTests.ISomeInterface), IsMultiple = false)]
+        [ExportMetadata("AdornmentLayerType", typeof(AssemblyDiscoveryTests.ISomeInterface))]
         public class ExportingWithTypeSingleMetadata { }
 
         [Export, MEFv1.Export]
         [MEFv1.ExportMetadata("Position", AssemblyDiscoveryTests.SomeEnum.SomeEnumValue)]
+        [ExportMetadata("Position", AssemblyDiscoveryTests.SomeEnum.SomeEnumValue)]
         public class ExportingWithEnumMetadata { }
 
         [Export, MEFv1.Export]
         [MEFv1.ExportMetadata("SomeEnum", AssemblyDiscoveryTests.SomeEnum.SomeEnumValue)]
         [MEFv1.ExportMetadata("SomeOtherEnum", AssemblyDiscoveryTests2.SomeOtherEnum.EnumValue)]
+        [ExportMetadata("SomeEnum", AssemblyDiscoveryTests.SomeEnum.SomeEnumValue)]
+        [ExportMetadata("SomeOtherEnum", AssemblyDiscoveryTests2.SomeOtherEnum.EnumValue)]
         public class ExportingWithMultipleDifferentEnumMetadata { }
 
         [Export, MEFv1.Export]
         [MEFv1.ExportMetadata("SomeEnum", AssemblyDiscoveryTests.SomeEnum.SomeEnumValue)]
         [MEFv1.ExportMetadata("SomeOtherEnum", AssemblyDiscoveryTests2.SomeOtherEnum.EnumValue)]
         [MEFv1.ExportMetadata("SomeInterface", typeof(AssemblyDiscoveryTests.ISomeInterface))]
+        [ExportMetadata("SomeEnum", AssemblyDiscoveryTests.SomeEnum.SomeEnumValue)]
+        [ExportMetadata("SomeOtherEnum", AssemblyDiscoveryTests2.SomeOtherEnum.EnumValue)]
+        [ExportMetadata("SomeInterface", typeof(AssemblyDiscoveryTests.ISomeInterface))]
         [MultipleTypeMetadata(typeof(AssemblyDiscoveryTests.SomeEnum))]
         [MultipleTypeMetadata(typeof(AssemblyDiscoveryTests2.SomeOtherEnum))]
         [PartMetadata("ExternalAssemblyValue", typeof(AssemblyDiscoveryTests.SomeEnum))]
@@ -417,8 +425,9 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         public class ExportingWithExportingMembers
         {
-            [MEFv1.Export]
+            [Export, MEFv1.Export]
             [MEFv1.ExportMetadata("SomeInterface", typeof(AssemblyDiscoveryTests.ISomeInterface))]
+            [ExportMetadata("SomeInterface", typeof(AssemblyDiscoveryTests.ISomeInterface))]
             public object Export { get; set; }
         }
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionCatalogTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 return new PartDiscovery[]
                 {
                     TestUtilities.V1Discovery,
-                    ////TestUtilities.V2Discovery,
+                    TestUtilities.V2Discovery,
                 };
             }
         }


### PR DESCRIPTION
The `CompositionCatalogTests` class ran primarily on just the V1 discovery class. Adding the V2 discovery class revealed several test failures, which were actually due to more test defects.

This change adds the V2 discovery test coverage and fills in the missing MEF v2 attributes so that the tests pass. In a couple cases, there were doubled up tests for V1 and V2 before this change. I've removed the duplicate test in favor of the Theory approach to reduce code duplication and maintain one consistent pattern in the class.

This prepares us for maintaining adequate coverage when #15 changes are ready.