### PR TITLE
Fix DebuggerDisplay for RuntimePart

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ComposablePartDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposablePartDefinition.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
 
-    [DebuggerDisplay("{Type.Name}")]
+    [DebuggerDisplay("{" + nameof(Type) + ".Name}")]
     public class ComposablePartDefinition : IEquatable<ComposablePartDefinition>
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Threading.Tasks;
     using Reflection;
 
-    [DebuggerDisplay("{Definition.Type.Name}")]
+    [DebuggerDisplay("{" + nameof(Definition) + "." + nameof(ComposablePartDefinition.Type) + ".Name}")]
     public class ComposedPart
     {
         public ComposedPart(ComposablePartDefinition definition, IReadOnlyDictionary<ImportDefinitionBinding, IReadOnlyList<ExportDefinitionBinding>> satisfyingExports, IImmutableSet<string> requiredSharingBoundaries)

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -500,7 +500,7 @@ namespace Microsoft.VisualStudio.Composition
             return dgml;
         }
 
-        [DebuggerDisplay("{PartDefinition.Type.Name}")]
+        [DebuggerDisplay("{" + nameof(PartDefinition) + "." + nameof(ComposablePartDefinition.Type) + ".Name}")]
         private class PartBuilder
         {
             internal PartBuilder(ComposablePartDefinition partDefinition, IReadOnlyDictionary<ImportDefinitionBinding, IReadOnlyList<ExportDefinitionBinding>> importedParts)

--- a/src/Microsoft.VisualStudio.Composition/ExportDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportDefinition.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Text;
     using System.Threading.Tasks;
 
-    [DebuggerDisplay("{ContractName,nq}")]
+    [DebuggerDisplay("{" + nameof(ContractName) + ",nq}")]
     public class ExportDefinition : IEquatable<ExportDefinition>
     {
         public ExportDefinition(string contractName, IReadOnlyDictionary<string, object> metadata)

--- a/src/Microsoft.VisualStudio.Composition/ImportDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportDefinition.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Text;
     using System.Threading.Tasks;
 
-    [DebuggerDisplay("{ContractName,nq} ({Cardinality})")]
+    [DebuggerDisplay("{" + nameof(ContractName) + ",nq} ({Cardinality})")]
     public class ImportDefinition : IEquatable<ImportDefinition>
     {
         private readonly ImmutableList<IImportSatisfiabilityConstraint> exportConstraints;

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
     using System.Text;
     using System.Threading.Tasks;
 
-    [DebuggerDisplay("{ResolvedType.FullName,nq}")]
+    [DebuggerDisplay("{" + nameof(ResolvedType) + ".FullName,nq}")]
     public class TypeRef : IEquatable<TypeRef>, IEquatable<Type>
     {
         private static readonly IEqualityComparer<AssemblyName> AssemblyNameComparer = ByValueEquality.AssemblyNameNoFastCheck;

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.Composition
                 resolver);
         }
 
-        [DebuggerDisplay("{Type.ResolvedType.FullName,nq}")]
+        [DebuggerDisplay("{" + nameof(RuntimePart.TypeRef) + "." + nameof(Reflection.TypeRef.ResolvedType) + ".FullName,nq}")]
         public class RuntimePart : IEquatable<RuntimePart>
         {
             private ConstructorInfo importingConstructor;
@@ -338,7 +338,7 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        [DebuggerDisplay("{ImportingSiteElementType}")]
+        [DebuggerDisplay("{" + nameof(ImportingSiteElementType) + "}")]
         public class RuntimeImport : IEquatable<RuntimeImport>
         {
             private bool? isLazy;

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -445,7 +445,7 @@ namespace Microsoft.VisualStudio.Composition
                 public PartLifecycleTracker ExportingPart { get; private set; }
             }
 
-            [DebuggerDisplay("{partDefinition.TypeRef.ResolvedType.FullName,nq} ({State})")]
+            [DebuggerDisplay("{" + nameof(partDefinition) + "." + nameof(RuntimeComposition.RuntimePart.TypeRef) + "." + nameof(TypeRef.ResolvedType) + ".FullName,nq} ({State})")]
             private class RuntimePartLifecycleTracker : PartLifecycleTracker
             {
                 private readonly RuntimeComposition.RuntimePart partDefinition;


### PR DESCRIPTION
Also update all DebuggerDisplay's to use c# nameof to keep them from going out of date later.

**Before**:
![image](https://user-images.githubusercontent.com/3548/27146898-c1df1cb4-50ef-11e7-923d-10118ef012b3.png)

**After**:
![image](https://user-images.githubusercontent.com/3548/27148628-d27568ac-50f5-11e7-94e7-ca5a481a177c.png)
