### PR TITLE
Speed up cost of reflection a bit

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ComposablePartDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposablePartDefinition.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public MethodInfo OnImportsSatisfied
         {
-            get { return this.OnImportsSatisfiedRef.Resolve(); }
+            get { return this.OnImportsSatisfiedRef.MethodBase as MethodInfo; }
         }
 
         public MethodRef OnImportsSatisfiedRef { get; private set; }
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public ConstructorInfo ImportingConstructorInfo
         {
-            get { return this.ImportingConstructorRef.Resolve(); }
+            get { return this.ImportingConstructorRef.ConstructorInfo; }
         }
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace Microsoft.VisualStudio.Composition
             {
                 foreach (var exportingMember in this.ExportingMembers)
                 {
-                    indentingWriter.WriteLine(exportingMember.Key.Resolve().Name);
+                    indentingWriter.WriteLine(exportingMember.Key.MemberInfo.Name);
                     using (indentingWriter.Indent())
                     {
                         foreach (var export in exportingMember.Value)

--- a/src/Microsoft.VisualStudio.Composition/ExportDefinitionBinding.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportDefinitionBinding.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Composition
         /// </summary>
         public MemberInfo ExportingMember
         {
-            get { return this.ExportingMemberRef.Resolve(); }
+            get { return this.ExportingMemberRef.MemberInfo; }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/ImportDefinitionBinding.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportDefinitionBinding.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.Composition
         /// </summary>
         public MemberInfo ImportingMember
         {
-            get { return this.ImportingMemberRef.Resolve(); }
+            get { return this.ImportingMemberRef.MemberInfo; }
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     if (!this.ImportingMemberRef.IsEmpty)
                     {
-                        this.importingSiteTypeRef = TypeRef.Get(ReflectionHelpers.GetMemberType(this.ImportingMemberRef.Resolve()), this.ImportingMemberRef.Resolver);
+                        this.importingSiteTypeRef = TypeRef.Get(ReflectionHelpers.GetMemberType(this.ImportingMemberRef.MemberInfo), this.ImportingMemberRef.Resolver);
                     }
                     else if (!this.ImportingParameterRef.IsEmpty)
                     {

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
@@ -1,14 +1,24 @@
+Microsoft.VisualStudio.Composition.Reflection.ConstructorRef.ConstructorInfo.get -> System.Reflection.ConstructorInfo
 Microsoft.VisualStudio.Composition.Reflection.ConstructorRef.ConstructorRef(Microsoft.VisualStudio.Composition.Reflection.TypeRef declaringType, int metadataToken, System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef> parameterTypes) -> void
 Microsoft.VisualStudio.Composition.Reflection.ConstructorRef.ParameterTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef>
+Microsoft.VisualStudio.Composition.Reflection.FieldRef.FieldInfo.get -> System.Reflection.FieldInfo
 Microsoft.VisualStudio.Composition.Reflection.FieldRef.FieldRef(Microsoft.VisualStudio.Composition.Reflection.TypeRef declaringType, int metadataToken, string name) -> void
 Microsoft.VisualStudio.Composition.Reflection.FieldRef.Name.get -> string
+Microsoft.VisualStudio.Composition.Reflection.MemberRef.MemberInfo.get -> System.Reflection.MemberInfo
+Microsoft.VisualStudio.Composition.Reflection.MethodRef.MethodBase.get -> System.Reflection.MethodBase
+Microsoft.VisualStudio.Composition.Reflection.MethodRef.MethodRef(Microsoft.VisualStudio.Composition.Reflection.ConstructorRef constructor) -> void
 Microsoft.VisualStudio.Composition.Reflection.MethodRef.MethodRef(Microsoft.VisualStudio.Composition.Reflection.TypeRef declaringType, int metadataToken, string name, System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef> parameterTypes, System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef> genericMethodArguments) -> void
+Microsoft.VisualStudio.Composition.Reflection.MethodRef.MethodRef(System.Reflection.MethodBase method, Microsoft.VisualStudio.Composition.Resolver resolver) -> void
+Microsoft.VisualStudio.Composition.Reflection.MethodRef.MethodRef(System.Reflection.MethodBase method, Microsoft.VisualStudio.Composition.Resolver resolver, System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef> parameterTypes) -> void
 Microsoft.VisualStudio.Composition.Reflection.MethodRef.Name.get -> string
 Microsoft.VisualStudio.Composition.Reflection.MethodRef.ParameterTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef>
 Microsoft.VisualStudio.Composition.Reflection.ParameterRef.Constructor.get -> Microsoft.VisualStudio.Composition.Reflection.ConstructorRef
 Microsoft.VisualStudio.Composition.Reflection.ParameterRef.Method.get -> Microsoft.VisualStudio.Composition.Reflection.MethodRef
 Microsoft.VisualStudio.Composition.Reflection.PropertyRef.Name.get -> string
+Microsoft.VisualStudio.Composition.Reflection.PropertyRef.PropertyInfo.get -> System.Reflection.PropertyInfo
 Microsoft.VisualStudio.Composition.Reflection.PropertyRef.PropertyRef(Microsoft.VisualStudio.Composition.Reflection.TypeRef declaringType, int metadataToken, int? getMethodMetadataToken, int? setMethodMetadataToken, string name) -> void
 Microsoft.VisualStudio.Composition.Reflection.TypeRef.FullName.get -> string
+static Microsoft.VisualStudio.Composition.Reflection.MethodRef.Get(System.Reflection.MethodBase method, Microsoft.VisualStudio.Composition.Resolver resolver) -> Microsoft.VisualStudio.Composition.Reflection.MethodRef
+static Microsoft.VisualStudio.Composition.Reflection.ResolverExtensions.Resolve2(this Microsoft.VisualStudio.Composition.Reflection.MethodRef methodRef) -> System.Reflection.MethodBase
 static Microsoft.VisualStudio.Composition.Reflection.TypeRef.Get(Microsoft.VisualStudio.Composition.Resolver resolver, System.Reflection.AssemblyName assemblyName, int metadataToken, string fullName, bool isArray, int genericTypeParameterCount, System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef> genericTypeArguments) -> Microsoft.VisualStudio.Composition.Reflection.TypeRef
 static Microsoft.VisualStudio.Composition.Reflection.TypeRef.Get(Microsoft.VisualStudio.Composition.Resolver resolver, System.Reflection.AssemblyName assemblyName, int metadataToken, string fullName, bool isArray, int genericTypeParameterCount, System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.Composition.Reflection.TypeRef> genericTypeArguments, Microsoft.VisualStudio.Composition.Reflection.MemberRef declaringMember, int declaringMethodParameterIndex = 0) -> Microsoft.VisualStudio.Composition.Reflection.TypeRef

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ConstructorDesc.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ConstructorDesc.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
     using System.Text;
     using System.Threading.Tasks;
 
+    [Obsolete("Use " + nameof(ConstructorRef) + " instead.", error: true)]
     public class ConstructorDesc : MemberDesc
     {
         public ConstructorDesc(ConstructorRef constructor, string name, bool isStatic)

--- a/src/Microsoft.VisualStudio.Composition/Reflection/FieldDesc.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/FieldDesc.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
     using System.Text;
     using System.Threading.Tasks;
 
+    [Obsolete("Use " + nameof(FieldRef) + " instead.", error: true)]
     public class FieldDesc : MemberDesc
     {
         public FieldDesc(FieldRef fieldRef, TypeDesc fieldType, string name, bool isStatic)

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MemberDesc.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MemberDesc.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {
+    using System;
+
+    [Obsolete("Use " + nameof(MemberRef) + " instead.", error: true)]
     public abstract class MemberDesc
     {
         protected MemberDesc(string name, bool isStatic)

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
@@ -117,6 +117,8 @@ namespace Microsoft.VisualStudio.Composition.Reflection
             }
         }
 
+        public MemberInfo MemberInfo => this.Resolve();
+
         public bool IsEmpty
         {
             get { return this.Constructor.IsEmpty && this.Field.IsEmpty && this.Property.IsEmpty && this.Method.IsEmpty && this.Type == null; }

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MethodDesc.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MethodDesc.cs
@@ -3,12 +3,9 @@
 namespace Microsoft.VisualStudio.Composition.Reflection
 {
     using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
+    [Obsolete("Use " + nameof(MethodRef) + " instead.", error: true)]
     public class MethodDesc : MemberDesc
     {
         public MethodDesc(MethodRef method, string name, bool isStatic, TypeRef returnType, ImmutableArray<TypeRef> parameters)

--- a/src/Microsoft.VisualStudio.Composition/Reflection/PropertyDesc.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/PropertyDesc.cs
@@ -3,11 +3,8 @@
 namespace Microsoft.VisualStudio.Composition.Reflection
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
+    [Obsolete("Use " + nameof(PropertyRef) + " instead.", error: true)]
     public class PropertyDesc : MemberDesc
     {
         public PropertyDesc(PropertyDesc property, TypeDesc propertyType, string name, bool isStatic)

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -52,10 +52,11 @@ namespace Microsoft.VisualStudio.Composition.Reflection
             var manifest = methodRef.Resolver.GetManifest(methodRef.DeclaringType.AssemblyName);
             var method = manifest.ResolveMethod(methodRef.MetadataToken);
 #else
-            var method = FindMethodByParameters(
-                Resolve(methodRef.DeclaringType).GetTypeInfo().GetMethods(AllInstanceMembers),
-                methodRef.Name,
-                methodRef.ParameterTypes);
+            TypeInfo declaringType = methodRef.DeclaringType.ResolvedType.GetTypeInfo();
+            var candidates = methodRef.Name == ConstructorInfo.ConstructorName
+                ? (MethodBase[])declaringType.GetConstructors(AllInstanceMembers)
+                : declaringType.GetMethods(AllInstanceMembers);
+            var method = FindMethodByParameters(candidates, methodRef.Name, methodRef.ParameterTypes);
 #endif
             if (methodRef.GenericMethodArguments.Length > 0)
             {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -74,15 +74,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
 #if RuntimeHandles
             return type.GetRuntimeProperties().First(p => p.MetadataToken == propertyRef.MetadataToken);
 #else
-            foreach (var property in type.GetProperties(AllInstanceMembers))
-            {
-                if (property.Name == propertyRef.Name)
-                {
-                    return property;
-                }
-            }
-
-            return null;
+            return type.GetProperty(propertyRef.Name, AllInstanceMembers);
 #endif
         }
 

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -174,6 +174,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
             throw new NotSupportedException();
         }
 
+        [Obsolete("Use " + nameof(MemberRef) + " instead.", error: true)]
         public static MemberInfo Resolve(this MemberDesc memberDesc)
         {
             var fieldDesc = memberDesc as FieldDesc;

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -27,8 +27,8 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                 return null;
             }
 
-            var manifest = constructorRef.Resolver.GetManifest(constructorRef.DeclaringType.AssemblyName);
 #if RuntimeHandles
+            var manifest = constructorRef.Resolver.GetManifest(constructorRef.DeclaringType.AssemblyName);
             return (ConstructorInfo)manifest.ResolveMethod(constructorRef.MetadataToken);
 #else
             return FindMethodByParameters(
@@ -45,8 +45,8 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                 return null;
             }
 
-            var manifest = methodRef.Resolver.GetManifest(methodRef.DeclaringType.AssemblyName);
 #if RuntimeHandles
+            var manifest = methodRef.Resolver.GetManifest(methodRef.DeclaringType.AssemblyName);
             var method = (MethodInfo)manifest.ResolveMethod(methodRef.MetadataToken);
 #else
             var method = FindMethodByParameters(

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeDesc.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeDesc.cs
@@ -3,11 +3,8 @@
 namespace Microsoft.VisualStudio.Composition.Reflection
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
+    [Obsolete("Use " + nameof(TypeRef) + " instead.", error: true)]
     public class TypeDesc
     {
         public TypeDesc(TypeRef type, string fullName)

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                     }
                     else
                     {
-                        MemberInfo declaringMember = this.GenericParameterDeclaringMemberRef.Resolve();
+                        MemberInfo declaringMember = this.GenericParameterDeclaringMemberRef.MemberInfo;
                         Type[] genericTypeArgs = GetGenericTypeArguments(declaringMember);
                         type = genericTypeArgs[this.GenericParameterDeclaringMemberIndex];
                     }

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(exportDefinition, nameof(exportDefinition));
 
-            var exportingMember = exportingMemberRef.Resolve();
+            var exportingMember = exportingMemberRef.MemberInfo;
             return new RuntimeExport(
                 exportDefinition.ContractName,
                 TypeRef.Get(partType, resolver),
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     if (this.importingConstructor == null)
                     {
-                        this.importingConstructor = this.ImportingConstructorRef.Resolve();
+                        this.importingConstructor = this.ImportingConstructorRef.ConstructorInfo;
                     }
 
                     return this.importingConstructor;
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     if (this.onImportsSatisfied == null)
                     {
-                        this.onImportsSatisfied = this.OnImportsSatisfiedRef.Resolve();
+                        this.onImportsSatisfied = this.OnImportsSatisfiedRef.MethodBase as MethodInfo;
                     }
 
                     return this.onImportsSatisfied;
@@ -420,7 +420,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     if (this.importingMember == null)
                     {
-                        this.importingMember = this.ImportingMemberRef.Resolve();
+                        this.importingMember = this.ImportingMemberRef.MemberInfo;
                     }
 
                     return this.importingMember;
@@ -598,7 +598,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     if (this.member == null)
                     {
-                        this.member = this.MemberRef.Resolve();
+                        this.member = this.MemberRef.MemberInfo;
                     }
 
                     return this.member;

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/Reflection/MethodRefTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/Reflection/MethodRefTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.Composition.Tests.Reflection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Composition.Reflection;
+    using Xunit;
+
+    public class MethodRefTests
+    {
+        [Fact]
+        public void CtorInfo_FromInstance()
+        {
+            ConstructorInfo ctor = this.GetType().GetTypeInfo().GetConstructor(Type.EmptyTypes);
+            var methodRef = new MethodRef(ctor, Resolver.DefaultInstance);
+            Assert.Same(ctor, methodRef.MethodBase);
+        }
+
+        [Fact]
+        public void CtorInfo_FromMetadataToken()
+        {
+            ConstructorInfo ctor = this.GetType().GetTypeInfo().GetConstructor(Type.EmptyTypes);
+            var methodRef = new MethodRef(TypeRef.Get(this.GetType(), Resolver.DefaultInstance), ctor.MetadataToken, ConstructorInfo.ConstructorName, ImmutableArray<TypeRef>.Empty, ImmutableArray<TypeRef>.Empty);
+            Assert.Same(ctor, methodRef.MethodBase);
+        }
+
+        [Fact]
+        public void MethodInfo_FromInstance()
+        {
+            MethodInfo methodInfo = this.GetType().GetTypeInfo().GetMethod(nameof(this.MethodInfo_FromInstance));
+            var methodRef = new MethodRef(methodInfo, Resolver.DefaultInstance);
+            Assert.Same(methodInfo, methodRef.MethodBase);
+        }
+
+        [Fact]
+        public void MethodInfo_FromMetadataToken()
+        {
+            MethodInfo methodInfo = this.GetType().GetTypeInfo().GetMethod(nameof(this.MethodInfo_FromInstance));
+            var methodRef = new MethodRef(TypeRef.Get(this.GetType(), Resolver.DefaultInstance), methodInfo.MetadataToken, methodInfo.Name, ImmutableArray<TypeRef>.Empty, ImmutableArray<TypeRef>.Empty);
+            Assert.Same(methodInfo, methodRef.MethodBase);
+        }
+    }
+}


### PR DESCRIPTION
We cache the result of reflection at a few easy places.

More can certainly be done here and will be included in subsequent PRs.

I also take the opportunity to fix Equals and GetHashCode methods in light of the dual mode (metadata token vs. actual Reflection info object).