### PR TITLE
Fix build warnings regarding resource assemblies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <NoWarn>CS1591</NoWarn>
 
     <NerdbankGitVersioningVersion>1.6.35</NerdbankGitVersioningVersion>
-    <MicroBuildVersion>2.0.40</MicroBuildVersion>
+    <MicroBuildVersion>2.0.43</MicroBuildVersion>
     <MicroBuild_LocalizeOutputAssembly>false</MicroBuild_LocalizeOutputAssembly>
 
     <PackageTags>Mef Composition Extensibility</PackageTags>
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningVersion)" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
This is a necessary change to accommodate build agents with 15.3 and dotnet SDK 2.0 installed.

I have confirmed that this is effective and necessary both on AppVeyor and our MicroBuild build agents on VSTS.