### PR TITLE
Add support for metadata view classes with default constructors

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.Composition
             ExportProvider.ExportProviderPartDefinition,
             PassthroughMetadataViewProvider.PartDefinition,
             MetadataViewClassProvider.PartDefinition,
+            MetadataViewClassDefaultCtorProvider.PartDefinition,
             ExportMetadataViewInterfaceEmitProxy.PartDefinition)
 #if NET45
             .Add(MetadataViewImplProxy.PartDefinition)

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -729,7 +729,7 @@ namespace Microsoft.VisualStudio.Composition
 
             if (result == null)
             {
-                if (metadataView.GetTypeInfo().IsInterface && !metadataView.Equals(typeof(IDictionary<string, object>)))
+                if (metadataView.GetTypeInfo().IsClass || (metadataView.GetTypeInfo().IsInterface && !metadataView.Equals(typeof(IDictionary<string, object>))))
                 {
                     var metadataBuilder = ImmutableDictionary.CreateBuilder<string, object>();
                     foreach (var property in metadataView.EnumProperties().WherePublicInstance())

--- a/src/Microsoft.VisualStudio.Composition/IMetadataViewProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/IMetadataViewProvider.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.Composition
         /// Creates a metadata view that acts as a strongly-typed accessor
         /// to a metadata dictionary.
         /// </summary>
-        /// <param name="metadata">The metadata dictionary.</param>
-        /// <param name="defaultValues">The metadata dictionary of defaults, to be used when <paramref name="metadata"/> is missing a key.</param>
+        /// <param name="metadata">The metadata dictionary. Never null.</param>
+        /// <param name="defaultValues">The metadata dictionary of defaults, to be used when <paramref name="metadata"/> is missing a key. Is never null.</param>
         /// <param name="metadataViewType">The type of metadata view to create.</param>
         /// <returns>The proxy instance.</returns>
         object CreateProxy(IReadOnlyDictionary<string, object> metadata, IReadOnlyDictionary<string, object> defaultValues, Type metadataViewType);

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.Composition
         public object CreateProxy(IReadOnlyDictionary<string, object> metadata, IReadOnlyDictionary<string, object> defaultValues, Type metadataViewType)
         {
             Requires.NotNull(metadata, nameof(metadata));
+            Requires.NotNull(defaultValues, nameof(defaultValues));
             Requires.NotNull(metadataViewType, nameof(metadataViewType));
 
             TypeInfo typeInfo = metadataViewType.GetTypeInfo();

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.Composition
 
             foreach (var propertyInfo in typeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public))
             {
-                if (metadata.TryGetValue(propertyInfo.Name, out object value) && propertyInfo.SetMethod != null)
+                if ((metadata.TryGetValue(propertyInfo.Name, out object value) || defaultValues.TryGetValue(propertyInfo.Name, out value)) && propertyInfo.SetMethod != null)
                 {
                     propertyInfo.SetValue(view, value);
                 }

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(metadataType, nameof(metadataType));
 
-            return metadataType.DeclaredConstructors.FirstOrDefault(ctor => ctor.GetParameters().Length == 0 && !ctor.IsPrivate);
+            return metadataType.DeclaredConstructors.FirstOrDefault(ctor => ctor.GetParameters().Length == 0 && ctor.IsPublic);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Composition
             TypeInfo typeInfo = metadataViewType.GetTypeInfo();
             var view = FindConstructor(typeInfo).Invoke(Type.EmptyTypes);
 
-            foreach (var propertyInfo in typeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            foreach (var propertyInfo in metadataViewType.EnumProperties().WherePublicInstance())
             {
                 if ((metadata.TryGetValue(propertyInfo.Name, out object value) || defaultValues.TryGetValue(propertyInfo.Name, out value)) && propertyInfo.SetMethod != null)
                 {

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.Composition
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Composition.Reflection;
+
+    /// <summary>
+    /// Supports metadata views that are concrete classes with a public default constructor
+    /// and properties with set accessors.
+    /// </summary>
+    internal class MetadataViewClassDefaultCtorProvider : IMetadataViewProvider
+    {
+        internal static readonly ComposablePartDefinition PartDefinition =
+            Utilities.GetMetadataViewProviderPartDefinition(typeof(MetadataViewClassDefaultCtorProvider), 1100000, Resolver.DefaultInstance);
+
+        internal static readonly IMetadataViewProvider Default = new MetadataViewClassDefaultCtorProvider();
+
+        private MetadataViewClassDefaultCtorProvider()
+        {
+        }
+
+        public bool IsMetadataViewSupported(Type metadataType)
+        {
+            Requires.NotNull(metadataType, nameof(metadataType));
+            var typeInfo = metadataType.GetTypeInfo();
+
+            return typeInfo.IsClass && !typeInfo.IsAbstract && FindConstructor(typeInfo) != null;
+        }
+
+        public object CreateProxy(IReadOnlyDictionary<string, object> metadata, IReadOnlyDictionary<string, object> defaultValues, Type metadataViewType)
+        {
+            Requires.NotNull(metadata, nameof(metadata));
+            Requires.NotNull(metadataViewType, nameof(metadataViewType));
+
+            TypeInfo typeInfo = metadataViewType.GetTypeInfo();
+            var view = FindConstructor(typeInfo).Invoke(Type.EmptyTypes);
+
+            foreach (var propertyInfo in typeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (metadata.TryGetValue(propertyInfo.Name, out object value) && propertyInfo.SetMethod != null)
+                {
+                    propertyInfo.SetValue(view, value);
+                }
+            }
+
+            return view;
+        }
+
+        private static ConstructorInfo FindConstructor(TypeInfo metadataType)
+        {
+            Requires.NotNull(metadataType, nameof(metadataType));
+
+            return metadataType.DeclaredConstructors.FirstOrDefault(ctor => ctor.GetParameters().Length == 0 && !ctor.IsPrivate);
+        }
+    }
+}

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -157,6 +157,34 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Empty(catalog.DiscoveredParts.DiscoveryErrors);
         }
 
+        [MefFact(CompositionEngines.V2 | CompositionEngines.V3EmulatingV1AndV2AtOnce, typeof(PartWithStronglyTypedMetadata), typeof(PartContainingPartWithStronglyTypedMetadata))]
+        public void StronglyTypedMetadataOnType(IContainer container)
+        {
+            var part = container.GetExportedValue<PartContainingPartWithStronglyTypedMetadata>();
+            Assert.NotNull(part);
+            Assert.NotNull(part.InnerPart);
+            Assert.Equal("MetadataPropertyValue", part.InnerPart.Metadata.Property);
+        }
+
+        [Export]
+        public class PartContainingPartWithStronglyTypedMetadata
+        {
+            [Import]
+            public Lazy<PartWithStronglyTypedMetadata, StronglyTypedMetadata> InnerPart { get; set; }
+        }
+
+        [Export]
+        [StronglyTypedMetadata(Property = "MetadataPropertyValue")]
+        public class PartWithStronglyTypedMetadata
+        {
+        }
+
+        [MetadataAttribute]
+        public class StronglyTypedMetadata : Attribute
+        {
+            public string Property { get; set; }
+        }
+
         [MefV1.Export, Export]
         [DerivedMetadata("prop1", "prop2")]
         public class ExportWithDerivedExportMetadata

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -157,45 +157,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Empty(catalog.DiscoveredParts.DiscoveryErrors);
         }
 
-        /* Tests to add:
-         *   internal constructor on metadata view?
-         *   internal properties on metadata view?
-         *   metadata for which there is no matching properties?
-         *   defaultValues?
-         *   case sensitivity?
-         *   exceptions thrown from setter?
-         *   no default ctor, but has a constructor that takes some parameters.
-         *   test properties without setters.
-         */
-
-        [MefFact(CompositionEngines.V2Compat, typeof(PartWithStronglyTypedMetadata), typeof(PartContainingPartWithStronglyTypedMetadata))]
-        public void StronglyTypedMetadataOnType(IContainer container)
-        {
-            var part = container.GetExportedValue<PartContainingPartWithStronglyTypedMetadata>();
-            Assert.NotNull(part);
-            Assert.NotNull(part.InnerPart);
-            Assert.Equal("MetadataPropertyValue", part.InnerPart.Metadata.Property);
-        }
-
-        [Export]
-        public class PartContainingPartWithStronglyTypedMetadata
-        {
-            [Import]
-            public Lazy<PartWithStronglyTypedMetadata, StronglyTypedMetadata> InnerPart { get; set; }
-        }
-
-        [Export]
-        [StronglyTypedMetadata(Property = "MetadataPropertyValue")]
-        public class PartWithStronglyTypedMetadata
-        {
-        }
-
-        [MetadataAttribute]
-        public class StronglyTypedMetadata : Attribute
-        {
-            public string Property { get; set; }
-        }
-
         [MefV1.Export, Export]
         [DerivedMetadata("prop1", "prop2")]
         public class ExportWithDerivedExportMetadata

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Empty(catalog.DiscoveredParts.DiscoveryErrors);
         }
 
-        [MefFact(CompositionEngines.V2 | CompositionEngines.V3EmulatingV1AndV2AtOnce, typeof(PartWithStronglyTypedMetadata), typeof(PartContainingPartWithStronglyTypedMetadata))]
+        [MefFact(CompositionEngines.V2Compat, typeof(PartWithStronglyTypedMetadata), typeof(PartContainingPartWithStronglyTypedMetadata))]
         public void StronglyTypedMetadataOnType(IContainer container)
         {
             var part = container.GetExportedValue<PartContainingPartWithStronglyTypedMetadata>();

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -157,6 +157,17 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Empty(catalog.DiscoveredParts.DiscoveryErrors);
         }
 
+        /* Tests to add:
+         *   internal constructor on metadata view?
+         *   internal properties on metadata view?
+         *   metadata for which there is no matching properties?
+         *   defaultValues?
+         *   case sensitivity?
+         *   exceptions thrown from setter?
+         *   no default ctor, but has a constructor that takes some parameters.
+         *   test properties without setters.
+         */
+
         [MefFact(CompositionEngines.V2Compat, typeof(PartWithStronglyTypedMetadata), typeof(PartContainingPartWithStronglyTypedMetadata))]
         public void StronglyTypedMetadataOnType(IContainer container)
         {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
+    using System.ComponentModel;
     using System.Composition;
     using Xunit;
 
@@ -12,12 +13,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         private const string InternalPropertyExpectedValue = "Internal Property Value";
 
+        private const string DefaultPropertyExpectedValue = "Some default value";
+
         /* Tests to add:
-         *   defaultValues?
+         *   private properties (or private setters) on base class
          *   case sensitivity?
          *   exceptions thrown from setter?
          *   no default ctor, but has a constructor that takes some parameters.
-         *   test properties without setters.
          */
 
         [MefFact(CompositionEngines.V2Compat, typeof(MetadataDecoratedPart), typeof(DefaultMetadataViewImporter))]
@@ -25,6 +27,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             var part = container.GetExportedValue<DefaultMetadataViewImporter>();
             Assert.Equal(PublicPropertyExpectedValue, part.InnerPart.Metadata.PublicProperty);
+        }
+
+        [MefFact(CompositionEngines.V2Compat, typeof(MetadataDecoratedPart), typeof(DefaultMetadataViewImporter))]
+        public void DefaultProperty(IContainer container)
+        {
+            var part = container.GetExportedValue<DefaultMetadataViewImporter>();
+            Assert.Equal(DefaultPropertyExpectedValue, part.InnerPart.Metadata.PropertyWithDefault);
         }
 
         [MefFact(CompositionEngines.V2Compat, typeof(MetadataDecoratedPart), typeof(DefaultMetadataViewImporter))]
@@ -51,6 +60,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
         public class DefaultMetadataView
         {
             public string PublicProperty { get; set; }
+
+            public string UnsettableProperty => null;
+
+            [DefaultValue(DefaultPropertyExpectedValue)]
+            public string PropertyWithDefault { get; set; }
 
             internal string InternalProperty { get; set; }
         }
@@ -88,6 +102,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         [Export]
         [ExportMetadata(nameof(DefaultMetadataView.PublicProperty), PublicPropertyExpectedValue)]
         [ExportMetadata(nameof(DefaultMetadataView.InternalProperty), InternalPropertyExpectedValue)]
+        [ExportMetadata(nameof(DefaultMetadataView.UnsettableProperty), "Any value")]
         [ExportMetadata("Some extra property", "Some value")]
         [ExportMetadata("AnotherExtraProperty", "Some value")]
         public class MetadataDecoratedPart

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
@@ -15,10 +15,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         private const string DefaultPropertyExpectedValue = "Some default value";
 
-        /* Tests to add:
-         *   exceptions thrown from setter?
-         */
-
         [MefFact(CompositionEngines.V2Compat, typeof(MetadataDecoratedPart), typeof(DefaultMetadataViewImporter))]
         public void PublicCtorPublicProperty(IContainer container)
         {
@@ -73,6 +69,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             var part = container.GetExportedValue<InternalMetadataViewImporter>();
             Assert.Equal(PublicPropertyExpectedValue, part.InnerPart.Metadata.PublicProperty);
+        }
+
+        [MefFact(CompositionEngines.V2, typeof(MetadataDecoratedPart), typeof(PropertySetterThrowsMetadataViewImporter))]
+        public void MetadataViewPropertySetterThrows_V2(IContainer container)
+        {
+            Assert.Throws<InvalidOperationException>(() => container.GetExportedValue<PropertySetterThrowsMetadataViewImporter>());
+        }
+
+        [MefFact(CompositionEngines.V3EmulatingV2, typeof(MetadataDecoratedPart), typeof(PropertySetterThrowsMetadataViewImporter))]
+        public void MetadataViewPropertySetterThrows_V3(IContainer container)
+        {
+            Assert.Throws<CompositionFailedException>(() => container.GetExportedValue<PropertySetterThrowsMetadataViewImporter>());
         }
 
         public class DefaultMetadataView
@@ -141,6 +149,22 @@ namespace Microsoft.VisualStudio.Composition.Tests
 #pragma warning disable SA1313 // Parameter names must begin with lower-case letter
                 public DerivedView(string PublicProperty) { }
 #pragma warning restore SA1313 // Parameter names must begin with lower-case letter
+            }
+        }
+
+        [Export]
+        public class PropertySetterThrowsMetadataViewImporter
+        {
+            [Import]
+            public Lazy<MetadataDecoratedPart, PropertySetterThrowingMetadataView> InnerPart { get; set; }
+
+            public class PropertySetterThrowingMetadataView
+            {
+                public string UnsettableProperty
+                {
+                    get => throw new NotImplementedException();
+                    set => throw new InvalidOperationException();
+                }
             }
         }
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Composition;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+    using MefV1 = System.ComponentModel.Composition;
+
+    public class MetadataViewClassDefaultCtorProviderTests
+    {
+        /* Tests to add:
+         *   internal constructor on metadata view?
+         *   internal properties on metadata view?
+         *   metadata for which there is no matching properties?
+         *   defaultValues?
+         *   case sensitivity?
+         *   exceptions thrown from setter?
+         *   no default ctor, but has a constructor that takes some parameters.
+         *   test properties without setters.
+         */
+
+        [MefFact(CompositionEngines.V2Compat, typeof(PartWithStronglyTypedMetadata), typeof(PartContainingPartWithStronglyTypedMetadata))]
+        public void StronglyTypedMetadataOnType(IContainer container)
+        {
+            var part = container.GetExportedValue<PartContainingPartWithStronglyTypedMetadata>();
+            Assert.NotNull(part);
+            Assert.NotNull(part.InnerPart);
+            Assert.Equal("MetadataPropertyValue", part.InnerPart.Metadata.Property);
+        }
+
+        [Export]
+        public class PartContainingPartWithStronglyTypedMetadata
+        {
+            [Import]
+            public Lazy<PartWithStronglyTypedMetadata, StronglyTypedMetadata> InnerPart { get; set; }
+        }
+
+        [Export]
+        [StronglyTypedMetadata(Property = "MetadataPropertyValue")]
+        public class PartWithStronglyTypedMetadata
+        {
+        }
+
+        [MetadataAttribute]
+        public class StronglyTypedMetadata : Attribute
+        {
+            public string Property { get; set; }
+        }
+    }
+}

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
@@ -50,11 +50,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Null(part.InnerPart.Metadata.InternalProperty);
         }
 
-        [MefFact(CompositionEngines.V3EmulatingV2, typeof(MetadataDecoratedPart), typeof(InternalCtorMetadataViewImporter))]
+        [MefFact(CompositionEngines.V2Compat, typeof(MetadataDecoratedPart), typeof(InternalCtorMetadataViewImporter), InvalidConfiguration = true)]
         public void InternalCtorPublicProperty(IContainer container)
         {
             var part = container.GetExportedValue<InternalCtorMetadataViewImporter>();
-            Assert.Equal(PublicPropertyExpectedValue, part.InnerPart.Metadata.PublicProperty);
         }
 
         [MefFact(CompositionEngines.V2Compat, typeof(MetadataDecoratedPart), typeof(NoDefaultCtorMetadataViewImporter), InvalidConfiguration = true)]


### PR DESCRIPTION
MEFv2 (i.e. "NuGet MEF") supports metadata views defined by classes with a public default constructor and public property setters. VS MEF was missing this feature (probably because MEFv1 doesn't share it). 

This change adds this feature with a bunch of tests for variations on the idea. Some tests verify correct configurations and other tests verify incorrect configurations fail the way we would expect.

One slight deviation from the MEFv2 feature is that VS MEF supports internal types used as metadata views. This allows libraries to use VS MEF internally without exposing implementation details.