### PR TITLE
Support inheritance on MEFv2's [MetadataAttribute]

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
@@ -243,8 +243,8 @@ namespace Microsoft.VisualStudio.Composition
                     // Perf optimization, relies on short circuit evaluation, often a property attribute is an ExportAttribute
                     if (attrType != typeof(ExportAttribute).GetTypeInfo() && attrType.IsAttributeDefined<MetadataAttributeAttribute>(inherit: true))
                     {
-                        var properties = attrType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-                        foreach (var property in properties)
+                        var properties = attrType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                        foreach (var property in properties.Where(p => p.DeclaringType != typeof(Attribute)))
                         {
                             UpdateMetadataDictionary(result, namesOfMetadataWithMultipleValues, property.Name, property.GetValue(attribute), ReflectionHelpers.GetMemberType(property));
                         }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
@@ -241,10 +241,10 @@ namespace Microsoft.VisualStudio.Composition
                 else
                 {
                     // Perf optimization, relies on short circuit evaluation, often a property attribute is an ExportAttribute
-                    if (attrType != typeof(ExportAttribute).GetTypeInfo() && attrType.IsAttributeDefined<MetadataAttributeAttribute>())
+                    if (attrType != typeof(ExportAttribute).GetTypeInfo() && attrType.IsAttributeDefined<MetadataAttributeAttribute>(inherit: true))
                     {
-                        var properties = attrType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                        foreach (var property in properties.Where(p => p.DeclaringType != typeof(Attribute)))
+                        var properties = attrType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                        foreach (var property in properties)
                         {
                             UpdateMetadataDictionary(result, namesOfMetadataWithMultipleValues, property.Name, property.GetValue(attribute), ReflectionHelpers.GetMemberType(property));
                         }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -406,6 +406,43 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
+        [MetadataAttribute]
+        [AttributeUsage(AttributeTargets.Class)]
+        internal abstract class AbstractCustomExportAttribute : ExportAttribute
+        {
+            protected AbstractCustomExportAttribute(Type contractType)
+                : base(contractType)
+            {
+            }
+
+            public abstract string CustomProperty { get; set; }
+        }
+
+        internal sealed class CustomExportWithBaseClassAttribute : AbstractCustomExportAttribute
+        {
+            public CustomExportWithBaseClassAttribute()
+                : base(default(Type))
+            {
+            }
+
+            /// <summary>
+            /// This silly override is needed for MEF2 to work correctly :-(
+            /// </summary>
+            public override string CustomProperty { get; set; }
+        }
+
+        [MetadataAttribute]
+        [AttributeUsage(AttributeTargets.Class)]
+        internal sealed class CustomExportAttribute : ExportAttribute
+        {
+            public CustomExportAttribute()
+                : base(default(Type))
+            {
+            }
+
+            public string CustomProperty { get; set; }
+        }
+
         #region CustomMetadataAttributeLotsOfTypesAndVisibilities test
 
         [MefFact(CompositionEngines.V1Compat, typeof(PartThatImportsLotsOfTypesAndVisibilitiesAttribute), typeof(PartWithLotsOfTypesAndVisibilitiesAttribute))]

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -22,20 +22,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal("4", part.ImportOfType.Metadata["Age"]);
         }
 
-        [MefFact(CompositionEngines.V2Compat, typeof(ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes), typeof(PartWithCustomMetadata))]
-        public void CustomMetadataBasePropertyWithOverride(IContainer container)
-        {
-            var part = container.GetExportedValue<ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes>();
-            Assert.Equal("B", part.Import.Metadata.BasePropertyWithOverride);
-        }
-
-        [MefFact(CompositionEngines.V2Compat, typeof(ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes), typeof(PartWithCustomMetadata))]
-        public void CustomMetadataDerivedTypeOnlyProperty(IContainer container)
-        {
-            var part = container.GetExportedValue<ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes>();
-            Assert.Equal("C", part.Import.Metadata.DerivedTypeOnlyProperty);
-        }
-
         [MefFact(CompositionEngines.V1Compat, typeof(ExportedTypeWithDerivedMetadata), typeof(PartThatImportsExportWithDerivedMetadata))]
         public void CustomMetadataOnDerivedMetadataAttributeOnExportedTypeV1(IContainer container)
         {
@@ -373,7 +359,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public string Property { get; }
         }
 
-        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = true)]
         public class DerivedMetadataAttribute : BaseMetadataAttribute
         {
             public DerivedMetadataAttribute(string property, string anotherProperty)
@@ -416,34 +401,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 this.Property = property;
             }
-        }
-
-        [Export, MefV1.Export]
-        public class ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes
-        {
-            [Import, MefV1.Import]
-            public Lazy<PartWithCustomMetadata, CustomMetadataAttributeWithBaseClassAttribute> Import { get; set; }
-        }
-
-        [Export, MefV1.Export]
-        [CustomMetadataAttributeWithBaseClass(BasePropertyWithOverride = "B", DerivedTypeOnlyProperty = "C")]
-        public class PartWithCustomMetadata
-        {
-        }
-
-        [MetadataAttribute, MefV1.MetadataAttribute]
-        [AttributeUsage(AttributeTargets.Class)]
-        public abstract class AbstractCustomMetadataAttributeAttribute : Attribute
-        {
-            public abstract string BasePropertyWithOverride { get; set; }
-        }
-
-        public sealed class CustomMetadataAttributeWithBaseClassAttribute : AbstractCustomMetadataAttributeAttribute
-        {
-            // This silly override is needed for MEF2 to work correctly :-(
-            public override string BasePropertyWithOverride { get; set; }
-
-            public string DerivedTypeOnlyProperty { get; set; }
         }
 
         #region CustomMetadataAttributeLotsOfTypesAndVisibilities test

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -139,8 +139,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(part.ImportingProperty.Value);
         }
 
-        // The MEF v2 behavior is that properties from a base class do not get included in the metadata. Currently, our MEF v2 discovery does include them. After fixing this, we can enable the test for MEF v2 compat.
-        [MefFact(CompositionEngines.V2, typeof(ExportWithDerivedExportMetadata), typeof(ImportingPartForDerivedExportMetadata))]
+        [MefFact(CompositionEngines.V2Compat, typeof(ExportWithDerivedExportMetadata), typeof(ImportingPartForDerivedExportMetadata))]
         public void BasePropertiesAreIgnoredInMefV2(IContainer container)
         {
             var part = container.GetExportedValue<ImportingPartForDerivedExportMetadata>();
@@ -375,7 +374,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = true)]
-        [MefV1.MetadataAttribute, MetadataAttribute]
         public class DerivedMetadataAttribute : BaseMetadataAttribute
         {
             public DerivedMetadataAttribute(string property, string anotherProperty)

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -34,6 +34,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(firstValue);
         }
 
+        [MefFact(CompositionEngines.V2Compat, typeof(ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes), typeof(ImportingPartWithCustomExportWithBaseClassAttribute))]
+        public void CustomExportWithBaseClassAttributeOnExportedType(IContainer container)
+        {
+            var part = container.GetExportedValue<ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes>();
+            Assert.NotNull(part);
+            var firstLazy = part.First;
+            Assert.NotNull(firstLazy);
+            Assert.Equal("CustomWithBaseClass", firstLazy.Metadata.CustomProperty);
+            var firstValue = firstLazy.Value;
+            Assert.NotNull(firstValue);
+        }
+
         [MefFact(CompositionEngines.V1Compat, typeof(ExportedTypeWithDerivedMetadata), typeof(PartThatImportsExportWithDerivedMetadata))]
         public void CustomMetadataOnDerivedMetadataAttributeOnExportedTypeV1(IContainer container)
         {
@@ -433,11 +445,31 @@ namespace Microsoft.VisualStudio.Composition.Tests
             internal Lazy<ImportingPartWithCustomExportAttribute, CustomExportAttribute> First => this.parts?.FirstOrDefault();
         }
 
+        [Export]
+        internal class ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes
+        {
+            private IEnumerable<Lazy<ImportingPartWithCustomExportWithBaseClassAttribute, CustomExportWithBaseClassAttribute>> parts;
+
+            [ImportingConstructor]
+            public ImportingPartWithEnumerableOfImportingPartsWithCustomExportWithBaseClassAttributes(
+                [ImportMany] IEnumerable<Lazy<ImportingPartWithCustomExportWithBaseClassAttribute, CustomExportWithBaseClassAttribute>> parts)
+            {
+                this.parts = parts;
+            }
+
+            internal Lazy<ImportingPartWithCustomExportWithBaseClassAttribute, CustomExportWithBaseClassAttribute> First => this.parts?.FirstOrDefault();
+        }
 
         [CustomExport(CustomProperty = "Custom")]
         public class ImportingPartWithCustomExportAttribute
         {
         }
+
+        [CustomExportWithBaseClass(CustomProperty = "CustomWithBaseClass")]
+        public class ImportingPartWithCustomExportWithBaseClassAttribute
+        {
+        }
+
         [MetadataAttribute]
         [AttributeUsage(AttributeTargets.Class)]
         internal abstract class AbstractCustomExportAttribute : ExportAttribute

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal("Andrew", part.ImportingProperty.Metadata["Name"]);
         }
 
-        [MefFact(CompositionEngines.V2Compat, typeof(ExportedTypeWithDerivedMetadata), typeof(PartThatImportsExportWithDerivedMetadata))]
+        [MefFact(CompositionEngines.V2, typeof(ExportedTypeWithDerivedMetadata), typeof(PartThatImportsExportWithDerivedMetadata), NoCompatGoal = true)]
         public void CustomMetadataOnDerivedMetadataAttributeOnExportedTypeV2(IContainer container)
         {
             var part = container.GetExportedValue<PartThatImportsExportWithDerivedMetadata>();
@@ -135,15 +135,32 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(part.ImportingProperty.Value);
         }
 
-        [MefFact(CompositionEngines.V2Compat, typeof(ExportWithDerivedExportMetadata), typeof(ImportingPartForDerivedExportMetadata))]
+        [MefFact(CompositionEngines.V2, typeof(ExportWithDerivedExportMetadata), typeof(ImportingPartForDerivedExportMetadata), NoCompatGoal = true)]
         public void BasePropertiesAreIgnoredInMefV2(IContainer container)
         {
             var part = container.GetExportedValue<ImportingPartForDerivedExportMetadata>();
 
             Assert.False(part.ImportingProperty.Metadata.ContainsKey("Property"));
+        }
+
+        [MefFact(CompositionEngines.V3EmulatingV2, typeof(ExportWithDerivedExportMetadata), typeof(ImportingPartForDerivedExportMetadata))]
+        public void BasePropertiesAreNotIgnoredWhenEmulatingV2(IContainer container)
+        {
+            var part = container.GetExportedValue<ImportingPartForDerivedExportMetadata>();
+
+            object prop1 = part.ImportingProperty.Metadata["Property"];
+            Assert.Equal("prop1", prop1);
 
             object prop2 = part.ImportingProperty.Metadata["AnotherProperty"];
-            Assert.Equal("prop2", prop2.ToString());
+            Assert.Equal("prop2", prop2);
+        }
+
+        [MefFact(CompositionEngines.V1Compat | CompositionEngines.V2Compat, typeof(ExportWithDerivedExportMetadata), typeof(ImportingPartForDerivedExportMetadata), NoCompatGoal = true)]
+        public void DerivedPropertiesAreObservedOnAllMEF(IContainer container)
+        {
+            var part = container.GetExportedValue<ImportingPartForDerivedExportMetadata>();
+
+            Assert.True(part.ImportingProperty.Metadata.ContainsKey("AnotherProperty"));
         }
 
 #if DESKTOP

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -489,9 +489,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
             }
 
-            /// <summary>
-            /// This silly override is needed for MEF2 to work correctly :-(
-            /// </summary>
+            // This silly override is needed for MEF2 to work correctly :-(
             public override string CustomProperty { get; set; }
         }
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -22,6 +22,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal("4", part.ImportOfType.Metadata["Age"]);
         }
 
+        [MefFact(CompositionEngines.V2Compat, typeof(ImportingPartWithEnumerableOfImportingPartsWithCustomExportAttributes), typeof(ImportingPartWithCustomExportAttribute))]
+        public void CustomExportAttributeOnExportedType(IContainer container)
+        {
+            var part = container.GetExportedValue<ImportingPartWithEnumerableOfImportingPartsWithCustomExportAttributes>();
+            Assert.NotNull(part);
+            var firstLazy = part.First;
+            Assert.NotNull(firstLazy);
+            Assert.Equal("Custom", firstLazy.Metadata.CustomProperty);
+            var firstValue = firstLazy.Value;
+            Assert.NotNull(firstValue);
+        }
+
         [MefFact(CompositionEngines.V1Compat, typeof(ExportedTypeWithDerivedMetadata), typeof(PartThatImportsExportWithDerivedMetadata))]
         public void CustomMetadataOnDerivedMetadataAttributeOnExportedTypeV1(IContainer container)
         {
@@ -406,6 +418,26 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
+        [Export]
+        internal class ImportingPartWithEnumerableOfImportingPartsWithCustomExportAttributes
+        {
+            private IEnumerable<Lazy<ImportingPartWithCustomExportAttribute, CustomExportAttribute>> parts;
+
+            [ImportingConstructor]
+            public ImportingPartWithEnumerableOfImportingPartsWithCustomExportAttributes(
+                [ImportMany] IEnumerable<Lazy<ImportingPartWithCustomExportAttribute, CustomExportAttribute>> parts)
+            {
+                this.parts = parts;
+            }
+
+            internal Lazy<ImportingPartWithCustomExportAttribute, CustomExportAttribute> First => this.parts?.FirstOrDefault();
+        }
+
+
+        [CustomExport(CustomProperty = "Custom")]
+        public class ImportingPartWithCustomExportAttribute
+        {
+        }
         [MetadataAttribute]
         [AttributeUsage(AttributeTargets.Class)]
         internal abstract class AbstractCustomExportAttribute : ExportAttribute

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataValueTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataValueTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         // Consider: do we want MEFv3 to follow V1's lead or V2's lead?
         // We could follow V2's lead by recognizing when we need to instantiate the attribute
         // at runtime in order to construct the metadata value.
-        [MefFact(CompositionEngines.V1, InvalidConfiguration = true)]
+        [MefFact(CompositionEngines.V1, typeof(ImportingPart), typeof(ExportWithCustomMetadata), InvalidConfiguration = true)]
         public void CustomMetadataValueV1(IContainer container)
         {
             var importer = container.GetExportedValue<ImportingPart>();
@@ -33,10 +33,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
         /// <remarks>
         /// When it comes time to support this in V3, <see cref="ReflectionHelpers.Instantiate(CustomAttributeData)"/>
         /// is expected to come in useful. We can cache that CustomAttributeData the same way we cache other reflection
-        /// data, and use it to reconsistute the value at runtime.
+        /// data, and use it to reconstitute the value at runtime.
         /// </remarks>
 #pragma warning restore CS1574
-        [MefFact(CompositionEngines.V2)]
+        [MefFact(CompositionEngines.V2, NoCompatGoal = true)]
         public void CustomMetadataValueV2(IContainer container)
         {
             var importer = container.GetExportedValue<ImportingPart>();


### PR DESCRIPTION
In our setup we use this type of construct via Nuget MEF to have shared stuff on the base export attribute.

You can argue that we could do this differently, but nonetheless it works in Nuget MEF :-)

If you have questions or comments, please contact me.