### PR TITLE
Remove LastWriteTimeUtc from StrongAssemblyIdentity

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -494,7 +494,6 @@ namespace Microsoft.VisualStudio.Composition
                 if (this.TryPrepareSerializeReusableObject(assemblyMetadata))
                 {
                     this.Write(assemblyMetadata.Name);
-                    this.Write(assemblyMetadata.LastWriteTimeUtc);
                     this.Write(assemblyMetadata.Mvid);
                 }
             }
@@ -507,9 +506,8 @@ namespace Microsoft.VisualStudio.Composition
                 if (this.TryPrepareDeserializeReusableObject(out uint id, out StrongAssemblyIdentity value))
                 {
                     AssemblyName name = this.ReadAssemblyName();
-                    DateTime lastWriteTimeUtc = this.ReadDateTime();
                     Guid mvid = this.ReadGuid();
-                    value = new StrongAssemblyIdentity(name, lastWriteTimeUtc, mvid);
+                    value = new StrongAssemblyIdentity(name, mvid);
 
                     this.OnDeserializedReusableObject(id, value);
                 }

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
@@ -31,10 +31,9 @@ Microsoft.VisualStudio.Composition.RuntimeComposition.RuntimePart.ImportingConst
 Microsoft.VisualStudio.Composition.RuntimeComposition.RuntimePart.RuntimePart(Microsoft.VisualStudio.Composition.Reflection.TypeRef type, Microsoft.VisualStudio.Composition.Reflection.MethodRef importingConstructor, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.Composition.RuntimeComposition.RuntimeImport> importingConstructorArguments, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.Composition.RuntimeComposition.RuntimeImport> importingMembers, System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.Composition.RuntimeComposition.RuntimeExport> exports, Microsoft.VisualStudio.Composition.Reflection.MethodRef onImportsSatisfied, string sharingBoundary) -> void
 Microsoft.VisualStudio.Composition.StrongAssemblyIdentity
 Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.Equals(Microsoft.VisualStudio.Composition.StrongAssemblyIdentity other) -> bool
-Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.LastWriteTimeUtc.get -> System.DateTime
 Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.Mvid.get -> System.Guid
 Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.Name.get -> System.Reflection.AssemblyName
-Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.StrongAssemblyIdentity(System.Reflection.AssemblyName name, System.DateTime lastWriteTimeUtc, System.Guid mvid) -> void
+Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.StrongAssemblyIdentity(System.Reflection.AssemblyName name, System.Guid mvid) -> void
 override Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.Equals(object obj) -> bool
 override Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.GetHashCode() -> int
 static Microsoft.VisualStudio.Composition.PartDiscovery.GetImportingSiteTypeWithoutCollection(Microsoft.VisualStudio.Composition.ImportDefinition importDefinition, System.Type importingSiteType) -> System.Type

--- a/src/Microsoft.VisualStudio.Composition/Reflection/StrongAssemblyIdentity.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/StrongAssemblyIdentity.cs
@@ -18,13 +18,11 @@
         /// Initializes a new instance of the <see cref="StrongAssemblyIdentity"/> class.
         /// </summary>
         /// <param name="name">The assembly name. Cannot be null.</param>
-        /// <param name="lastWriteTimeUtc">The LastWriteTimeUtc of the assembly manifest file.</param>
         /// <param name="mvid">The MVID of the ManifestModule of the assembly.</param>
-        public StrongAssemblyIdentity(AssemblyName name, DateTime lastWriteTimeUtc, Guid mvid)
+        public StrongAssemblyIdentity(AssemblyName name, Guid mvid)
         {
             Requires.NotNull(name, nameof(name));
             this.Name = name;
-            this.LastWriteTimeUtc = lastWriteTimeUtc;
             this.Mvid = mvid;
         }
 
@@ -32,11 +30,6 @@
         /// Gets the assembly's full name.
         /// </summary>
         public AssemblyName Name { get; }
-
-        /// <summary>
-        /// Gets the LastWriteTimeUtc for the assembly manifest file.
-        /// </summary>
-        public DateTime LastWriteTimeUtc { get; }
 
         /// <summary>
         /// Gets the MVID for the assembly's manifest module. This is a unique identifier that represents individual
@@ -64,10 +57,9 @@
 #endif
             }
 
-            DateTime timestamp = File.GetLastWriteTimeUtc(assemblyFile);
             Guid mvid = GetMvid(assemblyFile);
 
-            return new StrongAssemblyIdentity(assemblyName, timestamp, mvid);
+            return new StrongAssemblyIdentity(assemblyName, mvid);
         }
 
         /// <summary>
@@ -85,8 +77,7 @@
                 assemblyName = assembly.GetName();
             }
 
-            DateTime timestamp = assembly.IsDynamic ? DateTime.MaxValue : File.GetLastWriteTimeUtc(assembly.Location);
-            return new StrongAssemblyIdentity(assemblyName, timestamp, assembly.ManifestModule.ModuleVersionId);
+            return new StrongAssemblyIdentity(assemblyName, assembly.ManifestModule.ModuleVersionId);
         }
 
         /// <inheritdoc/>
@@ -97,7 +88,6 @@
         {
             return other != null
                 && ByValueEquality.AssemblyNameNoFastCheck.Equals(this.Name, other.Name)
-                && this.LastWriteTimeUtc == other.LastWriteTimeUtc
                 && this.Mvid == other.Mvid;
         }
 

--- a/src/Microsoft.VisualStudio.Composition/Resolver.cs
+++ b/src/Microsoft.VisualStudio.Composition/Resolver.cs
@@ -80,18 +80,15 @@ namespace Microsoft.VisualStudio.Composition
                 assemblyName = assembly.GetName();
             }
 
-            lock (this.loadedAssemblyStrongIdentities)
+            if (this.TryGetAssemblyId(assemblyName, out StrongAssemblyIdentity result))
             {
-                if (this.loadedAssemblyStrongIdentities.TryGetValue(assemblyName, out var result))
-                {
-                    return result;
-                }
+                return result;
             }
 
             var assemblyId = StrongAssemblyIdentity.CreateFrom(assembly, assemblyName);
             lock (this.loadedAssemblyStrongIdentities)
             {
-                if (!this.loadedAssemblyStrongIdentities.TryGetValue(assemblyName, out var result))
+                if (!this.loadedAssemblyStrongIdentities.TryGetValue(assemblyName, out result))
                 {
                     this.loadedAssemblyStrongIdentities.Add(assemblyName, assemblyId);
                     result = assemblyId;

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/CatalogScrambler.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/CatalogScrambler.cs
@@ -130,7 +130,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 scrambled = new StrongAssemblyIdentity(
                     assemblyId.Name,
-                    assemblyId.LastWriteTimeUtc,
                     Guid.NewGuid());
 
                 this.scrambledAssemblyIds.Add(assemblyId, scrambled);


### PR DESCRIPTION
Per @KirillOsenkov's comments in #53, the MVID should be a sufficiently unique value to confirm the assembly hasn't changed.