### PR TITLE
Fix up AppHost package

### DIFF
--- a/doc/hosting.md
+++ b/doc/hosting.md
@@ -77,11 +77,6 @@ rejected in the cascade.
 
 ## Hosting MEF in a closed (non-extensible) application
 
-**WARNING:** This scenario is a proof of concept and not vetted for shipping applications.
-The cache it builds is good only for the local machine and can become invalid when
-.NET Framework assemblies are serviced by Windows Update. With that warning aside,
-the following describes the proof of concept...
-
 The easiest way to do it, and get a MEF cache for faster startup to boot, just
 install the [Microsoft.VisualStudio.Composition.AppHost][AppHostPkg] NuGet package:
 

--- a/src/Microsoft.VisualStudio.Composition.AppHost/Microsoft.VisualStudio.Composition.AppHost.csproj
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/Microsoft.VisualStudio.Composition.AppHost.csproj
@@ -5,7 +5,6 @@
     <DebugType>full</DebugType>
 
     <Description>Adds a VS MEF system with a pre-computed, cached MEF graph.</Description>
-    <PackageReleaseNotes>This is a proof of concept and is not vetted for use in shipping applications.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="ExportProviderFactory.cs" />

--- a/src/Microsoft.VisualStudio.Composition.sln
+++ b/src/Microsoft.VisualStudio.Composition.sln
@@ -28,6 +28,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{28B65BDB-4470-4946-BAC3-4EE840F40B37}"
 	ProjectSection(SolutionItems) = preProject
 		..\.appveyor.yml = ..\.appveyor.yml
+		..\.vsts-ci.yml = ..\.vsts-ci.yml
 		Directory.Build.props = Directory.Build.props
 		nuget.config = nuget.config
 		version.json = version.json
@@ -37,13 +38,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Comp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Composition.AppHost", "Microsoft.VisualStudio.Composition.AppHost\Microsoft.VisualStudio.Composition.AppHost.csproj", "{93C14982-BB95-4554-BE09-2D0A4C9ADA09}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.Composition.LocalizationShell", "Microsoft.VisualStudio.Composition.LocalizationShell\Microsoft.VisualStudio.Composition.LocalizationShell.csproj", "{6F1F9729-DCE8-4397-BE0E-EF841EDCD9DC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Composition.LocalizationShell", "Microsoft.VisualStudio.Composition.LocalizationShell\Microsoft.VisualStudio.Composition.LocalizationShell.csproj", "{6F1F9729-DCE8-4397-BE0E-EF841EDCD9DC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Composition.TestEmbeddableTypes", "tests\Microsoft.VisualStudio.Composition.TestEmbeddableTypes\Microsoft.VisualStudio.Composition.TestEmbeddableTypes.csproj", "{E4BB6F4B-EAB5-4DF2-9FFA-08981105DF90}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.ComponentModel.Composition.AttributedModel", "tests\System.ComponentModel.Composition.AttributedModel\System.ComponentModel.Composition.AttributedModel.csproj", "{DFD69876-E482-4F1A-A772-7B5DA5D75724}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ComponentModel.Composition.Runtime", "tests\System.ComponentModel.Composition.Runtime\System.ComponentModel.Composition.Runtime.csproj", "{79BFFA10-6D40-4E91-8C90-0D2AC9171A64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.ComponentModel.Composition.Runtime", "tests\System.ComponentModel.Composition.Runtime\System.ComponentModel.Composition.Runtime.csproj", "{79BFFA10-6D40-4E91-8C90-0D2AC9171A64}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Now that we have slow reflection failover, we can highlight AppHost as a legit option for non-extensible apps.