### PR TITLE
Fix NRE thrown from IsPublicInstance

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.Composition
 
         internal static IEnumerable<PropertyInfo> WherePublicInstance(this IEnumerable<PropertyInfo> infos)
         {
-            return infos.Where(p => p.GetMethod.IsPublicInstance() || p.SetMethod.IsPublicInstance());
+            return infos.Where(p => (p.GetMethod?.IsPublicInstance() ?? false) || (p.SetMethod?.IsPublicInstance() ?? false));
         }
 
         internal static bool IsStatic(this MemberInfo exportingMember)
@@ -238,6 +238,7 @@ namespace Microsoft.VisualStudio.Composition
 
         internal static bool IsPublicInstance(this MethodInfo methodInfo)
         {
+            Requires.NotNull(methodInfo, nameof(methodInfo));
             return methodInfo.IsPublic && !methodInfo.IsStatic;
         }
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
@@ -94,6 +94,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
             internal string InternalProperty { get; set; }
 
             public string PropertyWithPrivateSetter { get; private set; }
+
+            public string UngettableProperty { set { } }
+
+            internal string InternalGetterAndNoSetter => throw new NotImplementedException();
         }
 
         [Export]


### PR DESCRIPTION
This fixes a regression introduced by #46 that shows up when applied to VS's MEF catalog.

It can occur when a metaview class has a property that has no getter, or has a non-public getter with no setter.