### PR TITLE
Run tests on .NET Core 2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,9 +62,9 @@ test_script:
 
     cd src\tests\Microsoft.VisualStudio.Composition.Tests
 
-    dotnet test -f netcoreapp1.0 --no-build
+    dotnet test -f netcoreapp1.0 --no-build --no-restore
 
-    dotnet test -f netcoreapp2.0 --no-build
+    dotnet test -f netcoreapp2.0 --no-build --no-restore
 artifacts:
 - path: bin\%configuration%\Packages\Microsoft.VisualStudio.Composition.15.*.nupkg
   name: NuGet Package

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,6 +63,8 @@ test_script:
     cd src\tests\Microsoft.VisualStudio.Composition.Tests
 
     dotnet test -f netcoreapp1.0 --no-build
+
+    dotnet test -f netcoreapp2.0 --no-build
 artifacts:
 - path: bin\%configuration%\Packages\Microsoft.VisualStudio.Composition.15.*.nupkg
   name: NuGet Package

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/Microsoft.VisualStudio.Composition.Tests.csproj
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/Microsoft.VisualStudio.Composition.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>Microsoft.VisualStudio.Composition.Tests.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn);CS1762</NoWarn>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/TestUtilities.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/TestUtilities.cs
@@ -261,7 +261,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             get
             {
-#if NETCOREAPP1_0
+#if NETCOREAPP1_0 || NETCOREAPP2_0
                 return true;
 #else
                 return false;


### PR DESCRIPTION
No changes to the product in this case, but a couple tests had to be fixed up for WeakReference behavior that is unique to .NET Core 2.0 as documented at https://github.com/dotnet/coreclr/issues/13490