### PR TITLE
Add assembly info to type name diagnostics during part validation

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.cs.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.cs.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.cs.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.cs.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.de.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.de.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.de.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.de.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.es.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.es.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.es.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.es.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.fr.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.fr.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.fr.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.fr.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.it.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.it.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.it.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.it.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ja.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ja.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ja.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ja.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ko.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ko.xlf
@@ -314,7 +314,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ko.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ko.xlf
@@ -311,6 +311,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pl.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pl.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pl.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pl.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pt-BR.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.pt-BR.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ru.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ru.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ru.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.ru.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.tr.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.tr.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.tr.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.tr.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hans.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hans.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hant.xlf
@@ -313,7 +313,7 @@
         <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
           <source>{0}.{1} (in {2})</source>
           <target state="new">{0}.{1} (in {2})</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</note>
         </trans-unit>
       </group>
     </body>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/MultilingualResources/Microsoft.VisualStudio.Composition.LocalizationShell.zh-Hant.xlf
@@ -310,6 +310,11 @@
           <source>Part discovery failed at member {0}.</source>
           <target state="new">Part discovery failed at member {0}.</target>
         </trans-unit>
+        <trans-unit id="TypeNameWithAssemblyLocation" translate="yes" xml:space="preserve">
+          <source>{0}.{1} (in {2})</source>
+          <target state="new">{0}.{1} (in {2})</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.Designer.cs
@@ -586,6 +586,15 @@ namespace Microsoft.VisualStudio.Composition {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}.{1} (in {2}).
+        /// </summary>
+        internal static string TypeNameWithAssemblyLocation {
+            get {
+                return ResourceManager.GetString("TypeNameWithAssemblyLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type of metadata view is unsupported..
         /// </summary>
         internal static string TypeOfMetadataViewUnsupported {

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.resx
@@ -347,6 +347,6 @@
   </data>
   <data name="TypeNameWithAssemblyLocation" xml:space="preserve">
     <value>{0}.{1} (in {2})</value>
-    <comment>{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</comment>
+    <comment>{0} is the full type name (namespace + type), {1} is the member name, {2} is the assembly that the type is located in.</comment>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.resx
@@ -345,4 +345,8 @@
   <data name="PartDiscoveryFailedAtMember" xml:space="preserve">
     <value>Part discovery failed at member {0}.</value>
   </data>
+  <data name="TypeNameWithAssemblyLocation" xml:space="preserve">
+    <value>{0}.{1} (in {2})</value>
+    <comment>{0} is a namespace for a type, {1} is the type name, {2} is the assembly that the type is located in.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.Composition
             {
                 return string.Format(
                     CultureInfo.CurrentCulture,
-                    "{0}.{1} (in {2})",
+                    Strings.TypeNameWithAssemblyLocation,
                     export.PartDefinition.Type.FullName,
                     export.ExportingMember.Name,
                     export.PartDefinition.Type.GetTypeInfo().Assembly.GetName().Name);

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -195,9 +195,10 @@ namespace Microsoft.VisualStudio.Composition
             {
                 return string.Format(
                     CultureInfo.CurrentCulture,
-                    "{0}.{1}",
+                    "{0}.{1} (in {2})",
                     export.PartDefinition.Type.FullName,
-                    export.ExportingMember.Name);
+                    export.ExportingMember.Name,
+                    export.PartDefinition.Type.GetTypeInfo().Assembly.GetName().Name);
             }
             else
             {

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.Composition
                     Strings.TypeNameWithAssemblyLocation,
                     export.PartDefinition.Type.FullName,
                     export.ExportingMember.Name,
-                    export.PartDefinition.Type.GetTypeInfo().Assembly.GetName().Name);
+                    export.PartDefinition.Type.GetTypeInfo().Assembly.FullName);
             }
             else
             {


### PR DESCRIPTION
Closes #43 
This PR modifies #43 slightly in that it applies to every type name, not just when there are duplicates. This seemed to be the best option since checking for duplicates would require some overhead and assembly info can be useful even when there is only one instance of the type (e.g. error involving type `Foo`, having assembly info helps person reading the log determine where `Foo` came from)