### PR TITLE
Add travis-ci for osx and linux

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ skip_commits:
   - doc/*
   - README.md
   - .vsts-ci.yml
+  - .travis-ci.yml
 nuget:
   disable_publish_on_pr: true
 image: Visual Studio 2017

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: csharp
+mono: none
+dotnet: 2.1.4
+
+os:
+  - linux
+  - osx
+
+git:
+  depth: false
+
+install:
+- dotnet restore src/Microsoft.VisualStudio.Composition.sln
+
+script:
+- dotnet build -f netcoreapp2.0 src/Microsoft.VisualStudio.Composition/
+- dotnet test -f netcoreapp2.0 --no-restore src/tests/Microsoft.VisualStudio.Composition.Tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: csharp
 mono: none
 dotnet: 2.1.4
+mono: 5.10.0
+
 branches:
   only:
   - master
@@ -15,8 +17,10 @@ git:
   depth: false
 
 install:
-- dotnet restore src/Microsoft.VisualStudio.Composition.sln
+- nuget install xunit.runner.console -Version 2.2.0 -OutputDirectory testrunner
+- msbuild src/Microsoft.VisualStudio.Composition.sln /nologo /m /v:quiet /t:restore
 
 script:
-- dotnet build -f netcoreapp2.0 src/Microsoft.VisualStudio.Composition/
-- dotnet test -f netcoreapp2.0 --no-restore src/tests/Microsoft.VisualStudio.Composition.Tests/
+- msbuild src/Microsoft.VisualStudio.Composition.sln /nologo /m /v:quiet /t:build
+- mono ./testrunner/xunit.runner.console.2.2.0/tools/xunit.console.exe bin/Tests/Debug/net452/Microsoft.VisualStudio.Composition.Tests.dll
+- dotnet test -f netcoreapp2.0 --no-build --no-restore src/tests/Microsoft.VisualStudio.Composition.Tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: csharp
 mono: none
 dotnet: 2.1.4
+branches:
+  only:
+  - master
+  - /^v\d+(?:\.\d+)?$/
+  - /[\b_]validate\b/
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # VS MEF (Visual Studio's flavor of the Managed Extensibility Framework)
 
 [![NuGet package](https://img.shields.io/nuget/v/Microsoft.VisualStudio.Composition.svg)](https://nuget.org/packages/Microsoft.VisualStudio.Composition)
-[![Build status](https://ci.appveyor.com/api/projects/status/q4uavk7qso20cd9t/branch/master?svg=true)](https://ci.appveyor.com/project/AArnott/vs-mef/branch/master)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/q4uavk7qso20cd9t/branch/master?svg=true)](https://ci.appveyor.com/project/AArnott/vs-mef/branch/master)
+[![Travis-CI Build Status](https://travis-ci.org/Microsoft/vs-mef.svg?branch=master)](https://travis-ci.org/Microsoft/vs-mef)
 [![codecov](https://codecov.io/gh/Microsoft/vs-mef/branch/master/graph/badge.svg)](https://codecov.io/gh/Microsoft/vs-mef)
 [![Join the chat at https://gitter.im/vs-mef/Lobby](https://badges.gitter.im/vs-mef/Lobby.svg)](https://gitter.im/vs-mef/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CacheResiliencyTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CacheResiliencyTests.cs
@@ -31,9 +31,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
             this.cacheManager = new CachedComposition();
         }
 
-        [Fact]
+        [SkippableFact]
         public void CacheStaleFromRecompiledAssembly()
         {
+            TestUtilities.SkipOnMono("Appdomain issues on mono");
+
             // These are our two nearly-identical assemblies, but which are expected to have non-equivalent metadata tables,
             // which simulates the scenario of a cache being created with one assembly, then the cache is reused later after
             // that assembly has been re-compiled (possibly with source changes) such that its metadata table has changed,


### PR DESCRIPTION
Adds support for CI runs for osx and linux via travis-ci. This is just a simple initial configuration and only tests against .NET Core 2.0. Actual builds will have to be enabled in the repo by an admin.