### PR TITLE
Always use .ConfigureAwait(false) for awaits

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Composition
             {
                 var compositionRuntime = RuntimeComposition.CreateRuntimeComposition(configuration);
 
-                await this.SaveAsync(compositionRuntime, cacheStream, cancellationToken);
+                await this.SaveAsync(compositionRuntime, cacheStream, cancellationToken).ConfigureAwait(false);
             });
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken);
+            var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
             return runtimeComposition.CreateExportProviderFactory();
         }
 

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.0.82" />
     <PackageReference Include="GitLink" Version="3.2.0-unstable0014" PrivateAssets="all" />
     <PackageReference Include="System.Composition" Version="1.0.31" />

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.ruleset
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.ruleset
@@ -103,4 +103,7 @@
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers" RuleNamespace="Roslyn.Diagnostics.Analyzers">
     <Rule Id="RS0026" Action="Info" />
   </Rules>
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="UseConfigureAwait" Action="Error" />
+  </Rules>
 </RuleSet>

--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -67,11 +67,11 @@ namespace Microsoft.VisualStudio.Composition
             var tuple = this.CreateDiscoveryBlockChain(true, null, cancellationToken);
             foreach (Type type in partTypes)
             {
-                await tuple.Item1.SendAsync(type);
+                await tuple.Item1.SendAsync(type).ConfigureAwait(false);
             }
 
             tuple.Item1.Complete();
-            var parts = await tuple.Item2;
+            var parts = await tuple.Item2.ConfigureAwait(false);
             return parts;
         }
 
@@ -104,11 +104,11 @@ namespace Microsoft.VisualStudio.Composition
             var tuple = this.CreateAssemblyDiscoveryBlockChain(progress, cancellationToken);
             foreach (var assembly in assemblies)
             {
-                await tuple.Item1.SendAsync(assembly);
+                await tuple.Item1.SendAsync(assembly).ConfigureAwait(false);
             }
 
             tuple.Item1.Complete();
-            var result = await tuple.Item2;
+            var result = await tuple.Item2.ConfigureAwait(false);
             return result;
         }
 
@@ -156,11 +156,11 @@ namespace Microsoft.VisualStudio.Composition
             assemblyLoader.LinkTo(tuple.Item1, new DataflowLinkOptions { PropagateCompletion = true });
             foreach (var assemblyPath in assemblyPaths)
             {
-                await assemblyLoader.SendAsync(assemblyPath);
+                await assemblyLoader.SendAsync(assemblyPath).ConfigureAwait(false);
             }
 
             assemblyLoader.Complete();
-            var result = await tuple.Item2;
+            var result = await tuple.Item2.ConfigureAwait(false);
             return result.Merge(new DiscoveredParts(Enumerable.Empty<ComposablePartDefinition>(), exceptions));
         }
 
@@ -472,7 +472,7 @@ namespace Microsoft.VisualStudio.Composition
             {
                 try
                 {
-                    await aggregatingBlock.Completion;
+                    await aggregatingBlock.Completion.ConfigureAwait(false);
                     tcs.SetResult(new DiscoveredParts(parts.ToImmutable(), errors.ToImmutable()));
                 }
                 catch (Exception ex)
@@ -536,7 +536,7 @@ namespace Microsoft.VisualStudio.Composition
             {
                 try
                 {
-                    var parts = await tuple.Item2;
+                    var parts = await tuple.Item2.ConfigureAwait(false);
                     tcs.SetResult(parts.Merge(new DiscoveredParts(Enumerable.Empty<ComposablePartDefinition>(), exceptions)));
                 }
                 catch (Exception ex)


### PR DESCRIPTION
This will allow folks to synchronously block a UI thread during what would otherwise be an async MEF composition without deadlocking. 

I don't expect this impact VS itself in any meaningful way since composition already happens on background threads, asynchronously, and/or at startup.

Closes #80