### PR TITLE
Improve tracing of serialization

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.Composition
 
             internal void Write(ComposableCatalog catalog)
             {
-                using (this.Trace("Catalog"))
+                using (this.Trace(nameof(ComposableCatalog)))
                 {
                     this.Write(catalog.Parts, this.Write);
                 }
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.Composition
 
             internal ComposableCatalog ReadComposableCatalog()
             {
-                using (this.Trace("Catalog"))
+                using (this.Trace(nameof(ComposableCatalog)))
                 {
                     var parts = this.ReadList(this.ReadComposablePartDefinition);
                     return ComposableCatalog.Create(this.Resolver).AddParts(parts);
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private void Write(ComposablePartDefinition partDefinition)
             {
-                using (this.Trace("ComposablePartDefinition"))
+                using (this.Trace(nameof(ComposablePartDefinition)))
                 {
                     this.Write(partDefinition.TypeRef);
                     this.Write(partDefinition.Metadata);
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private ComposablePartDefinition ReadComposablePartDefinition()
             {
-                using (this.Trace("ComposablePartDefinition"))
+                using (this.Trace(nameof(ComposablePartDefinition)))
                 {
                     var partType = this.ReadTypeRef();
                     var partMetadata = this.ReadMetadata();
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private void Write(CreationPolicy creationPolicy)
             {
-                using (this.Trace("CreationPolicy"))
+                using (this.Trace(nameof(CreationPolicy)))
                 {
                     this.writer.Write((byte)creationPolicy);
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private CreationPolicy ReadCreationPolicy()
             {
-                using (this.Trace("CreationPolicy"))
+                using (this.Trace(nameof(CreationPolicy)))
                 {
                     return (CreationPolicy)this.reader.ReadByte();
                 }
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private void Write(ExportDefinition exportDefinition)
             {
-                using (this.Trace("ExportDefinition"))
+                using (this.Trace(nameof(ExportDefinition)))
                 {
                     this.Write(exportDefinition.ContractName);
                     this.Write(exportDefinition.Metadata);
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private ExportDefinition ReadExportDefinition()
             {
-                using (this.Trace("ExportDefinition"))
+                using (this.Trace(nameof(ExportDefinition)))
                 {
                     var contractName = this.ReadString();
                     var metadata = this.ReadMetadata();
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private void Write(ImportDefinition importDefinition)
             {
-                using (this.Trace("ImportDefinition"))
+                using (this.Trace(nameof(ImportDefinition)))
                 {
                     this.Write(importDefinition.ContractName);
                     this.Write(importDefinition.Cardinality);
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private ImportDefinition ReadImportDefinition()
             {
-                using (this.Trace("ImportDefinition"))
+                using (this.Trace(nameof(ImportDefinition)))
                 {
                     var contractName = this.ReadString();
                     var cardinality = this.ReadImportCardinality();
@@ -229,7 +229,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private void Write(ImportDefinitionBinding importDefinitionBinding)
             {
-                using (this.Trace("ImportDefinitionBinding"))
+                using (this.Trace(nameof(ImportDefinitionBinding)))
                 {
                     this.Write(importDefinitionBinding.ImportDefinition);
                     this.Write(importDefinitionBinding.ComposablePartTypeRef);
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private ImportDefinitionBinding ReadImportDefinitionBinding()
             {
-                using (this.Trace("ImportDefinitionBinding"))
+                using (this.Trace(nameof(ImportDefinitionBinding)))
                 {
                     var importDefinition = this.ReadImportDefinition();
                     var part = this.ReadTypeRef();
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private void Write(IImportSatisfiabilityConstraint importConstraint)
             {
-                using (this.Trace("IImportSatisfiabilityConstraint"))
+                using (this.Trace(nameof(IImportSatisfiabilityConstraint)))
                 {
                     ConstraintTypes type;
                     if (importConstraint is ImportMetadataViewConstraint)
@@ -335,7 +335,7 @@ namespace Microsoft.VisualStudio.Composition
 
             private IImportSatisfiabilityConstraint ReadIImportSatisfiabilityConstraint()
             {
-                using (this.Trace("IImportSatisfiabilityConstraint"))
+                using (this.Trace(nameof(IImportSatisfiabilityConstraint)))
                 {
                     var type = (ConstraintTypes)this.reader.ReadByte();
                     switch (type)

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
@@ -26,9 +26,11 @@ namespace Microsoft.VisualStudio.Composition
             {
                 using (var writer = new BinaryWriter(cacheStream, TextEncoding, leaveOpen: true))
                 {
-                    var context = new SerializationContext(writer, catalog.Parts.Count * 4, catalog.Resolver);
-                    context.Write(catalog);
-                    context.FinalizeObjectTableCapacity();
+                    using (var context = new SerializationContext(writer, catalog.Parts.Count * 4, catalog.Resolver))
+                    {
+                        context.Write(catalog);
+                        context.FinalizeObjectTableCapacity();
+                    }
                 }
             });
         }
@@ -42,9 +44,11 @@ namespace Microsoft.VisualStudio.Composition
             {
                 using (var reader = new BinaryReader(cacheStream, TextEncoding, leaveOpen: true))
                 {
-                    var context = new SerializationContext(reader, resolver);
-                    var catalog = context.ReadComposableCatalog();
-                    return catalog;
+                    using (var context = new SerializationContext(reader, resolver))
+                    {
+                        var catalog = context.ReadComposableCatalog();
+                        return catalog;
+                    }
                 }
             });
         }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(MethodRef methodRef)
         {
-            using (this.Trace("MethodRef"))
+            using (this.Trace(nameof(MethodRef)))
             {
                 if (methodRef == null)
                 {
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected MethodRef ReadMethodRef()
         {
-            using (this.Trace("MethodRef"))
+            using (this.Trace(nameof(MethodRef)))
             {
                 byte nullCheck = this.reader.ReadByte();
                 if (nullCheck == 1)
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(MemberRef memberRef)
         {
-            using (this.Trace("MemberRef"))
+            using (this.Trace(nameof(MemberRef)))
             {
                 switch (memberRef)
                 {
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected MemberRef ReadMemberRef()
         {
-            using (this.Trace("MemberRef"))
+            using (this.Trace(nameof(MemberRef)))
             {
                 int kind = this.reader.ReadByte();
                 switch ((MemberRefType)kind)
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(PropertyRef propertyRef)
         {
-            using (this.Trace("PropertyRef"))
+            using (this.Trace(nameof(PropertyRef)))
             {
                 if (this.TryPrepareSerializeReusableObject(propertyRef))
                 {
@@ -280,7 +280,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected PropertyRef ReadPropertyRef()
         {
-            using (this.Trace("PropertyRef"))
+            using (this.Trace(nameof(PropertyRef)))
             {
                 if (this.TryPrepareDeserializeReusableObject(out uint id, out PropertyRef value))
                 {
@@ -316,7 +316,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(FieldRef fieldRef)
         {
-            using (this.Trace("FieldRef"))
+            using (this.Trace(nameof(FieldRef)))
             {
                 if (this.TryPrepareSerializeReusableObject(fieldRef))
                 {
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected FieldRef ReadFieldRef()
         {
-            using (this.Trace("FieldRef"))
+            using (this.Trace(nameof(FieldRef)))
             {
                 if (this.TryPrepareDeserializeReusableObject(out uint id, out FieldRef value))
                 {
@@ -347,7 +347,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(ParameterRef parameterRef)
         {
-            using (this.Trace("ParameterRef"))
+            using (this.Trace(nameof(ParameterRef)))
             {
                 if (this.TryPrepareSerializeReusableObject(parameterRef))
                 {
@@ -359,7 +359,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected ParameterRef ReadParameterRef()
         {
-            using (this.Trace("ParameterRef"))
+            using (this.Trace(nameof(ParameterRef)))
             {
                 if (this.TryPrepareDeserializeReusableObject(out uint id, out ParameterRef value))
                 {
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(TypeRef typeRef)
         {
-            using (this.Trace("TypeRef"))
+            using (this.Trace(nameof(TypeRef)))
             {
                 if (this.TryPrepareSerializeReusableObject(typeRef))
                 {
@@ -409,7 +409,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected TypeRef ReadTypeRef()
         {
-            using (this.Trace("TypeRef"))
+            using (this.Trace(nameof(TypeRef)))
             {
                 uint id;
                 TypeRef value;
@@ -432,7 +432,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(AssemblyName assemblyName)
         {
-            using (this.Trace("AssemblyName"))
+            using (this.Trace(nameof(AssemblyName)))
             {
                 if (this.TryPrepareSerializeReusableObject(assemblyName))
                 {
@@ -448,7 +448,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected AssemblyName ReadAssemblyName()
         {
-            using (this.Trace("AssemblyName"))
+            using (this.Trace(nameof(AssemblyName)))
             {
                 uint id;
                 AssemblyName value;
@@ -531,7 +531,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(string value)
         {
-            using (this.Trace("String"))
+            using (this.Trace(nameof(String)))
             {
                 if (this.TryPrepareSerializeReusableObject(value))
                 {
@@ -542,7 +542,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected string ReadString()
         {
-            using (this.Trace("String"))
+            using (this.Trace(nameof(String)))
             {
                 uint id;
                 string value;
@@ -719,7 +719,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected void Write(ImportCardinality cardinality)
         {
-            using (this.Trace("ImportCardinality"))
+            using (this.Trace(nameof(ImportCardinality)))
             {
                 this.writer.Write((byte)cardinality);
             }
@@ -727,7 +727,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected ImportCardinality ReadImportCardinality()
         {
-            using (this.Trace("ImportCardinality"))
+            using (this.Trace(nameof(ImportCardinality)))
             {
                 return (ImportCardinality)this.reader.ReadByte();
             }
@@ -933,7 +933,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected object ReadObject()
         {
-            using (this.Trace("Object"))
+            using (this.Trace(nameof(Object)))
             {
                 ObjectType objectType = this.ReadObjectType();
                 switch (objectType)

--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -569,7 +569,7 @@ namespace Microsoft.VisualStudio.Composition
         protected void Write<T>(IReadOnlyCollection<T> list, Action<T> itemWriter)
         {
             Requires.NotNull(list, nameof(list));
-            using (this.Trace("List<" + typeof(T).Name + ">"))
+            using (this.Trace(typeof(T).Name, isArray: true))
             {
                 this.WriteCompressedUInt((uint)list.Count);
                 foreach (var item in list)
@@ -582,7 +582,7 @@ namespace Microsoft.VisualStudio.Composition
         protected void Write(Array list, Action<object> itemWriter)
         {
             Requires.NotNull(list, nameof(list));
-            using (this.Trace((list != null ? list.GetType().GetElementType().Name : "null") + "[]"))
+            using (this.Trace(list?.GetType().GetElementType().Name ?? "null", isArray: true))
             {
                 this.WriteCompressedUInt((uint)list.Length);
                 foreach (var item in list)

--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.Composition
             // each time you get it, the writer is flushed. Since we use the stream
             // for its Position, flushing is actually important. But it's very slow,
             // so don't do it in production.
-            stream = reader != null ? reader.BaseStream : writer.BaseStream;
+            stream = this.reader != null ? this.reader.BaseStream : this.writer.BaseStream;
 #endif
 
             return new SerializationTrace(this, elementName, isArray, stream);

--- a/src/Microsoft.VisualStudio.Composition/IndentingTextWriter.cs
+++ b/src/Microsoft.VisualStudio.Composition/IndentingTextWriter.cs
@@ -48,13 +48,23 @@ namespace Microsoft.VisualStudio.Composition
             this.inner.Write(value);
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         internal CancelIndent Indent()
         {
             this.indentationStack.Push(Indentation);
             return new CancelIndent(this);
         }
 
-        private void Unindent()
+        internal void Unindent()
         {
             this.indentationStack.Pop();
         }


### PR DESCRIPTION
- Use `nameof` for serialization trace messages
- Fix StyleCop issue when TRACESERIALIZATION is defined
- Fix serialization trace messages for lists
- Add object reuse info to serialization trace
- Also trace to files instead of Debug window for easier diff'ing during debugging.