### PR TITLE
Fix VSTS build break

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -43,6 +43,11 @@ steps:
     esrpSigning: true
     zipSources: false
 
+- task: NuGetToolInstaller@0
+  inputs:
+    versionSpec: 4.6.2
+  displayName: Pin nuget.exe version
+
 - task: NuGetCommand@2
   inputs:
     restoreSolution: '**\*.sln'
@@ -61,9 +66,18 @@ steps:
 - task: MicroBuildCleanup@1
   condition: succeededOrFailed()
 
+- task: PowerShell@2
+  displayName: Collect logs
+  inputs:
+    targetType: inline
+    script: |
+      robocopy obj "$(Build.ArtifactStagingDirectory)\build_logs\obj" project.assets.json /s
+    ignoreLASTEXITCODE: true
+  condition: succeededOrFailed()
+
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)\build_logs\$(BuildConfiguration)
+    PathtoPublish: $(Build.ArtifactStagingDirectory)\build_logs
     ArtifactName: build_logs
     ArtifactType: Container
   displayName: 'Publish Artifact: build logs'

--- a/src/Microsoft.VisualStudio.Composition.NetFxAttributes/Microsoft.VisualStudio.Composition.NetFxAttributes.csproj
+++ b/src/Microsoft.VisualStudio.Composition.NetFxAttributes/Microsoft.VisualStudio.Composition.NetFxAttributes.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" Condition=" '$(TargetFramework)' == 'net40' " />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0-preview1-26216-02" Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0-rc1" Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The VSTS build break was due to nuget.exe 4.1.0 being used. Using the latest recommended version (4.6.2) resolves the issue.

Also update NetFX MEF nuget package version.