### PR TITLE
Re-enable MEF parts to omit the property setter on [ImportMany] properties

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.Composition
 
             if (importAttribute != null)
             {
-                this.ThrowOnInvalidImportingMemberOrParameter(member);
+                this.ThrowOnInvalidImportingMemberOrParameter(member, isImportMany: false);
 
                 Type contractType = GetTypeIdentityFromImportingType(importingType, importMany: false);
                 if (contractType.IsAnyLazyType() || contractType.IsExportFactoryTypeV2())
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio.Composition
             }
             else if (importManyAttribute != null)
             {
-                this.ThrowOnInvalidImportingMemberOrParameter(member);
+                this.ThrowOnInvalidImportingMemberOrParameter(member, isImportMany: true);
 
                 Type contractType = GetTypeIdentityFromImportingType(importingType, importMany: true);
                 importConstraints = importConstraints

--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
@@ -293,7 +293,7 @@ namespace Microsoft.VisualStudio.Composition
 
             if (importAttribute != null)
             {
-                this.ThrowOnInvalidImportingMemberOrParameter(member);
+                this.ThrowOnInvalidImportingMemberOrParameter(member, isImportMany: false);
 
                 if (importAttribute.Source != ImportSource.Any)
                 {
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.Composition
             }
             else if (importManyAttribute != null)
             {
-                this.ThrowOnInvalidImportingMemberOrParameter(member);
+                this.ThrowOnInvalidImportingMemberOrParameter(member, isImportMany: true);
 
                 if (importManyAttribute.Source != ImportSource.Any)
                 {

--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -268,10 +268,15 @@ namespace Microsoft.VisualStudio.Composition
         /// Throws an exception if certain basic rules for an importing member or parameter are violated.
         /// </summary>
         /// <param name="member">The importing member or importing parameter.</param>
-        protected virtual void ThrowOnInvalidImportingMemberOrParameter(ICustomAttributeProvider member)
+        /// <param name="isImportMany">A value indicating whether the import is an ImportMany.</param>
+        protected virtual void ThrowOnInvalidImportingMemberOrParameter(ICustomAttributeProvider member, bool isImportMany)
         {
             Requires.NotNull(member, nameof(member));
-            if (member is PropertyInfo importingMember && importingMember.SetMethod == null)
+
+            // Properties with [ImportMany] needn't have a setter (strictly speaking) if the importing constructor
+            // sets a non-null collection instance to that property. When the collection is pre-created, MEF will just
+            // add elements to the collection.
+            if (!isImportMany && member is PropertyInfo importingMember && importingMember.SetMethod == null)
             {
                 throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Strings.ImportingPropertyHasNoSetter, importingMember.Name, importingMember.DeclaringType.FullName));
             }

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
@@ -74,5 +74,5 @@ static Microsoft.VisualStudio.Composition.Reflection.TypeRef.Get(Microsoft.Visua
 static Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.CreateFrom(System.Reflection.Assembly assembly, System.Reflection.AssemblyName assemblyName) -> Microsoft.VisualStudio.Composition.StrongAssemblyIdentity
 static Microsoft.VisualStudio.Composition.StrongAssemblyIdentity.CreateFrom(string assemblyFile, System.Reflection.AssemblyName assemblyName) -> Microsoft.VisualStudio.Composition.StrongAssemblyIdentity
 virtual Microsoft.VisualStudio.Composition.PartDiscovery.ThrowOnInvalidExportingMember(System.Reflection.ICustomAttributeProvider member) -> void
-virtual Microsoft.VisualStudio.Composition.PartDiscovery.ThrowOnInvalidImportingMemberOrParameter(System.Reflection.ICustomAttributeProvider member) -> void
+virtual Microsoft.VisualStudio.Composition.PartDiscovery.ThrowOnInvalidImportingMemberOrParameter(System.Reflection.ICustomAttributeProvider member, bool isImportMany) -> void
 virtual Microsoft.VisualStudio.Composition.Reflection.MemberRef.Equals(Microsoft.VisualStudio.Composition.Reflection.MemberRef other) -> bool

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/RejectionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/RejectionTests.cs
@@ -98,10 +98,19 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Empty(container.GetExportedValues<PartWithImportPropertyAndNoSetter>());
         }
 
-        [MefFact(CompositionEngines.V1Compat | CompositionEngines.V3AllowConfigurationWithErrors, typeof(PartWithImportManyPropertyAndNoSetter), typeof(ValidExportingPart), InvalidConfiguration = true)]
+        [MefFact(CompositionEngines.V1Compat, typeof(PartWithImportManyPropertyAndNoSetter), typeof(ValidExportingPart))]
         public void ImportManyPropertyHasNoSetter(IContainer container)
         {
-            Assert.Empty(container.GetExportedValues<PartWithImportManyPropertyAndNoSetter>());
+            var export = container.GetExportedValue<PartWithImportManyPropertyAndNoSetter>();
+            Assert.NotEmpty(export.ImportingProperty);
+        }
+
+        [MefFact(CompositionEngines.V1Compat, typeof(PartWithImportManyPropertyAndNoSetterNoInit), typeof(ValidExportingPart))]
+        public void ImportManyPropertyHasNoSetterAndNoInit(IContainer container)
+        {
+            // In this case, the ImportMany property had no setter, but we wouldn't know till runtime that the property
+            // isn't initialized by the ImportingConstructor. So we have to fail as a last resort.
+            Assert.Throws<CompositionFailedException>(() => container.GetExportedValue<PartWithImportManyPropertyAndNoSetterNoInit>());
         }
 
         [MefFact(CompositionEngines.V2Compat, typeof(PartWithImportPropertyAndNoSetter), typeof(ValidExportingPart))]
@@ -111,10 +120,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Null(part.ImportingProperty); // MEFv2 quietly does not set the import
         }
 
-        [MefFact(CompositionEngines.V2Compat, typeof(PartWithImportManyPropertyAndNoSetter), typeof(ValidExportingPart))]
+        [MefFact(CompositionEngines.V2Compat, typeof(PartWithImportManyPropertyAndNoSetterNoInit), typeof(ValidExportingPart))]
         public void ImportManyPropertyHasNoSetterV2(IContainer container)
         {
-            var part = container.GetExportedValue<PartWithImportManyPropertyAndNoSetter>();
+            var part = container.GetExportedValue<PartWithImportManyPropertyAndNoSetterNoInit>();
             Assert.Null(part.ImportingProperty); // MEFv2 quietly does not set the import
         }
 
@@ -170,6 +179,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [MefV1.Export, Export]
         public class PartWithImportManyPropertyAndNoSetter
+        {
+            [MefV1.ImportMany, ImportMany]
+            public List<ValidExportingPart> ImportingProperty { get; } = new List<ValidExportingPart>();
+        }
+
+        [MefV1.Export, Export]
+        public class PartWithImportManyPropertyAndNoSetterNoInit
         {
             [MefV1.ImportMany, ImportMany]
             public List<ValidExportingPart> ImportingProperty { get; }


### PR DESCRIPTION
The case where this would actually work at runtime is when the MEF part's ImportingConstructor sets the value of the ImportMany property to an (empty) collection, in which case MEF will simply add elements to it and never have to access the setter.

Fixes #94