### PR TITLE
Enhance testing of missing assemblies

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryCombinedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryCombinedTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#if DESKTOP
+
+namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Composition;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests;
+    using Xunit;
+
+    public class AttributedPartDiscoveryCombinedTests : AttributedPartDiscoveryTestBase
+    {
+        protected override PartDiscovery DiscoveryService
+        {
+            get { return PartDiscovery.Combine(TestUtilities.V1Discovery, TestUtilities.V2DiscoveryWithNonPublics); }
+        }
+    }
+}
+
+#endif

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTestBase.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTestBase.cs
@@ -107,19 +107,14 @@ namespace Microsoft.VisualStudio.Composition.Tests
             var discoverablePart = exportProvider.GetExportedValue<DiscoverablePart1>();
         }
 
-        [SkippableFact]
+        [Fact]
         public async Task AssemblyDiscoveryDropsTypesWithProblematicAttributes()
         {
             // If this assert fails, it means that the assembly that is supposed to be undiscoverable
             // by this unit test is actually discoverable. Check that CopyLocal=false for all references
             // to Microsoft.VisualStudio.Composition.MissingAssemblyTests and that the assembly
             // is not building to the same directory as the test assemblies.
-            try
-            {
-                typeof(TypeWithMissingAttribute).GetTypeInfo().GetCustomAttributes(false);
-                Skip.If(true, "The missing assembly is present. Test cannot verify proper operation.");
-            }
-            catch (FileNotFoundException) { }
+            Assert.Throws<FileNotFoundException>(() => typeof(TypeWithMissingAttribute).GetTypeInfo().GetCustomAttributes(false));
 
             var result = await this.DiscoveryService.CreatePartsAsync(typeof(TypeWithMissingAttribute).GetTypeInfo().Assembly);
 
@@ -134,12 +129,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             // by this unit test is actually discoverable. Check that CopyLocal=false for all references
             // to Microsoft.VisualStudio.Composition.MissingAssemblyTests and that the assembly
             // is not building to the same directory as the test assemblies.
-            try
-            {
-                typeof(TypeWithMissingAttribute).GetTypeInfo().GetCustomAttributes(false);
-                Skip.If(true, "The missing assembly is present. Test cannot verify proper operation.");
-            }
-            catch (FileNotFoundException) { }
+            Assert.Throws<FileNotFoundException>(() => typeof(TypeWithMissingAttribute).GetTypeInfo().GetCustomAttributes(false));
 
             var result = await this.DiscoveryService.CreatePartsAsync(
                 new List<Assembly>

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/Microsoft.VisualStudio.Composition.Tests.csproj
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/Microsoft.VisualStudio.Composition.Tests.csproj
@@ -61,4 +61,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <Target Name="SuppressCopyOfMissingAssembly" BeforeTargets="PrepareForRun;_CopyFilesMarkedCopyLocal;">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition=" '%(FileName)' == 'Microsoft.VisualStudio.Composition.MissingAssemblyTests' " />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Closes #90 by disproving it: the added tests show that in fact VS-MEF *does* recover from `ReflectionTypeLoadException` during discovery.