### PR TITLE
Depend on stable .NET MEF nuget package

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.NetFxAttributes/Microsoft.VisualStudio.Composition.NetFxAttributes.csproj
+++ b/src/Microsoft.VisualStudio.Composition.NetFxAttributes/Microsoft.VisualStudio.Composition.NetFxAttributes.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" Condition=" '$(TargetFramework)' == 'net40' " />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0-rc1" Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will be required for VS MEF 15.8 to be stable. 
The .NET MEF nuget package only just recently went stable, so now we can depend on it.