### PR TITLE
Master branch should track v16.0

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "15.8-alpha",
+  "version": "16.0-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches


### PR DESCRIPTION
This bumps the version to 16.0, and readies the repo for a v15.8 branch, which I will push assuming this PR gets approved.