### PR TITLE
Avoid torn state race condition in RuntimeImport.IsLazy

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/NullableBool.cs
+++ b/src/Microsoft.VisualStudio.Composition/NullableBool.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.Composition
+{
+    using System;
+
+    /// <summary>
+    /// A nullable boolean value with atomic reads and writes.
+    /// </summary>
+    internal struct NullableBool
+    {
+        /// <summary>
+        /// A tri-state backing field for the <see cref="Value"/> property. 0 means not computed, -1 means false and 1 means true.
+        /// </summary>
+        /// <remarks>
+        /// We use a tri-state field to support lock-free atomic writes.
+        /// </remarks>
+        private int state;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NullableBool"/> struct.
+        /// </summary>
+        /// <param name="value">The initial value of the boolean.</param>
+        internal NullableBool(bool value)
+        {
+            this.state = value ? 1 : -1;
+        }
+
+        /// <summary>
+        /// Wraps a boolean value in a <see cref="NullableBool"/> struct.
+        /// </summary>
+        /// <param name="value">The boolean value to wrap.</param>
+        public static implicit operator NullableBool(bool value) => new NullableBool(value);
+
+        /// <summary>
+        /// Gets a value indicating whether the boolean value has been computed.
+        /// </summary>
+        internal bool HasValue => this.state != 0;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the boolean value is <c>true</c>.
+        /// </summary>
+        internal bool Value
+        {
+            get
+            {
+                switch (this.state)
+                {
+                    case 1: return true;
+                    case -1: return false;
+                    case 0: throw new InvalidOperationException("No value.");
+                    default: throw Assumes.NotReachable();
+                }
+            }
+
+            set
+            {
+                this.state = value ? 1 : -1;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition/NullableBool.cs
+++ b/src/Microsoft.VisualStudio.Composition/NullableBool.cs
@@ -7,6 +7,10 @@ namespace Microsoft.VisualStudio.Composition
     /// <summary>
     /// A nullable boolean value with atomic reads and writes.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="Nullable{T}"/> type has two fields which prevent it being initialized or copied atomically as a single "word".
+    /// This type has just one field (which it can do since we specialize in storing <see cref="bool"/> values), so it is just one word and therefore atomic.
+    /// </remarks>
     internal struct NullableBool
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.Composition
         [DebuggerDisplay("{" + nameof(ImportingSiteElementType) + "}")]
         public class RuntimeImport : IEquatable<RuntimeImport>
         {
-            private bool? isLazy;
+            private NullableBool isLazy;
             private Type importingSiteElementType;
             private Func<Func<object>, object, object> lazyFactory;
             private ParameterInfo importingParameter;


### PR DESCRIPTION
There seems to be a race condition due to a non-atomic pair of memory writes while we lazily compute the value for `RuntimeImport.IsLazy`. 

A few hypotheses to explain the race condition:

1. Consider the case of the CPU reordering field write instructions, [which is allowed on some architectures, but not AMD64](https://en.wikipedia.org/wiki/Memory_ordering#In_symmetric_multiprocessing_(SMP)_microprocessor_systems). So that hypothesis is dubious.
1. The fields `hasValue` and `value` inside the `Nullable<T>` type are laid out in that order. So after a method constructs a new `Nullable<T>` value, it copies it to the field location, setting `hasValue` *first*. Before it copies the second field of the struct, another thread copies the entire struct to its own local stack, which now observes torn state of `hasValue=true;value=false` since `value` has not yet been set to true by the original thread. This seems to me the most plausible hypothesis.
1. Cache lines across cores: the `value=false` was cached by the reading thread and `hasValue` was not, such that `hasValue=true` is observed as the current value, but the stale `value=false` value is read from the cache. 

Any of these *should* be fixed by this change.

(hopefully) fixes #108 
