### PR TITLE
Invalid runtime composition exception handling.

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.LocalizationShell/Strings.resx
@@ -160,7 +160,8 @@
     <value>Scanning MEF assemblies...</value>
   </data>
   <data name="TypeOfMetadataViewUnsupported" xml:space="preserve">
-    <value>Type of metadata view is unsupported.</value>
+    <value>The type {0} is an unsupported type of metadata view.</value>
+    <comment>{0} is the metadata view type.</comment>
   </data>
   <data name="UnableToDeterminePrimarySharingBoundary" xml:space="preserve">
     <value>Unable to determine the primary sharing boundary for MEF part "{0}".</value>

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -862,7 +862,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 if (metadataViewProvider == null)
                 {
-                    throw new NotSupportedException(Strings.TypeOfMetadataViewUnsupported);
+                    throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Strings.TypeOfMetadataViewUnsupported, metadataView.FullName));
                 }
 
                 lock (this.typeAndSelectedMetadataViewProviderCache)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -27,10 +27,20 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(metadataViewsAndProviders, nameof(metadataViewsAndProviders));
             Requires.NotNull(resolver, nameof(resolver));
 
-            if (!parts.Any() || !metadataViewsAndProviders.Any())
+            var invalidArgExceptionMsg = "Invalid arguments passed to generate runtime composition.";
+            var invalidArgExceptionData = "InvalidCompositionException";
+            if (!parts.Any())
             {
-                var exception = new ArgumentException("Invalid arguments passed to generate runtime composition.");
-                exception.Data.Add("InvalidCompositionException", true);
+                var exception = new ArgumentException(invalidArgExceptionMsg, nameof(parts));
+                exception.Data.Add(invalidArgExceptionData, true);
+
+                throw exception;
+            }
+
+            if (!metadataViewsAndProviders.Any())
+            {
+                var exception = new ArgumentException(invalidArgExceptionMsg, nameof(metadataViewsAndProviders));
+                exception.Data.Add(invalidArgExceptionData, true);
 
                 throw exception;
             }

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -21,11 +21,21 @@ namespace Microsoft.VisualStudio.Composition
         private readonly IReadOnlyDictionary<string, IReadOnlyCollection<RuntimeExport>> exportsByContractName;
         private readonly IReadOnlyDictionary<TypeRef, RuntimeExport> metadataViewsAndProviders;
 
+        public const string InvalidCompositionException = nameof(InvalidCompositionException);
+
         private RuntimeComposition(IEnumerable<RuntimePart> parts, IReadOnlyDictionary<TypeRef, RuntimeExport> metadataViewsAndProviders, Resolver resolver)
         {
             Requires.NotNull(parts, nameof(parts));
             Requires.NotNull(metadataViewsAndProviders, nameof(metadataViewsAndProviders));
             Requires.NotNull(resolver, nameof(resolver));
+
+            if (!parts.Any() || !metadataViewsAndProviders.Any())
+            {
+                var exception = new ArgumentException("Invalid arguments passed to generate runtime composition.");
+                exception.Data.Add(InvalidCompositionException, true);
+
+                throw exception;
+            }
 
             this.parts = ImmutableHashSet.CreateRange(parts);
             this.metadataViewsAndProviders = metadataViewsAndProviders;

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -21,8 +21,6 @@ namespace Microsoft.VisualStudio.Composition
         private readonly IReadOnlyDictionary<string, IReadOnlyCollection<RuntimeExport>> exportsByContractName;
         private readonly IReadOnlyDictionary<TypeRef, RuntimeExport> metadataViewsAndProviders;
 
-        public const string InvalidCompositionException = nameof(InvalidCompositionException);
-
         private RuntimeComposition(IEnumerable<RuntimePart> parts, IReadOnlyDictionary<TypeRef, RuntimeExport> metadataViewsAndProviders, Resolver resolver)
         {
             Requires.NotNull(parts, nameof(parts));
@@ -32,7 +30,7 @@ namespace Microsoft.VisualStudio.Composition
             if (!parts.Any() || !metadataViewsAndProviders.Any())
             {
                 var exception = new ArgumentException("Invalid arguments passed to generate runtime composition.");
-                exception.Data.Add(InvalidCompositionException, true);
+                exception.Data.Add("InvalidCompositionException", true);
 
                 throw exception;
             }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
@@ -10,8 +10,10 @@
         {
             var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
             var composition = RuntimeComposition.CreateRuntimeComposition(configuration);
-            var exports = composition.GetExports(typeof(IDisposable).ToString());
-            Assert.Equal(0, exports.Count);
+            var factory = composition.CreateExportProviderFactory();
+            var provider = factory.CreateExportProvider();
+            var exports = provider.GetExports<IDisposable>();
+            Assert.Empty(exports);
         }
     }
 }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
@@ -1,6 +1,9 @@
 ﻿namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.VisualStudio.Composition.Reflection;
     using Xunit;
 
     public class RuntimeCompositionTests
@@ -14,6 +17,24 @@
             var provider = factory.CreateExportProvider();
             var exports = provider.GetExports<IDisposable>();
             Assert.Empty(exports);
+        }
+
+        [Fact]
+        public void TestEmptyPartsThrowsException()
+        {
+            var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
+            var validComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
+
+            Assert.Throws<ArgumentException>(() => RuntimeComposition.CreateRuntimeComposition(Enumerable.Empty<RuntimeComposition.RuntimePart>(), validComposition.MetadataViewsAndProviders, Resolver.DefaultInstance));
+        }
+
+        [Fact]
+        public void TestEmptyMetadataViewProviderThrowsException()
+        {
+            var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
+            var validComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
+
+            Assert.Throws<ArgumentException>(() => RuntimeComposition.CreateRuntimeComposition(validComposition.Parts, ImmutableDictionary<TypeRef, RuntimeComposition.RuntimeExport>.Empty, Resolver.DefaultInstance));
         }
     }
 }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System;
+    using Xunit;
+
+    public class RuntimeCompositionTests
+    {
+        [Fact]
+        public void TestEmptyCatalogTest()
+        {
+            var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
+            var composition = RuntimeComposition.CreateRuntimeComposition(configuration);
+            var exports = composition.GetExports(typeof(IDisposable).ToString());
+            Assert.Equal(0, exports.Count);
+        }
+    }
+}


### PR DESCRIPTION
Add more information to metadata view exception.  Catch invalid runtime composition and throw exception.