### PR TITLE
AppHost fixes

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
@@ -72,11 +72,13 @@ namespace Microsoft.VisualStudio.Composition.AppHost
         /// <summary>
         /// Gets or sets a value indicating whether to continue when errors occur while scanning MEF assemblies.
         /// </summary>
+        /// <value>The default is <c>false</c>, causing build failure.</value>
         public bool ContinueOnDiscoveryErrors { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to continue when errors occur while composing the graph.
         /// </summary>
+        /// <value>The default is <c>false</c>, causing build failure.</value>
         public bool ContinueOnCompositionErrors { get; set; }
 
         [Required]
@@ -275,6 +277,12 @@ namespace Microsoft.VisualStudio.Composition.AppHost
                         {
                             return fullPath;
                         }
+
+                        fullPath = Path.Combine(Path.GetFullPath(searchDir.ItemSpec), assemblyName.Name + ".exe");
+                        if (File.Exists(fullPath))
+                        {
+                            return fullPath;
+                        }
                     }
                 }
                 catch (ArgumentException)
@@ -443,6 +451,9 @@ namespace Microsoft.VisualStudio.Composition.AppHost
             }
             catch (IOException ex)
             {
+                // Don't emit an error code. This should rarely happen, and when it does it should call attention to folks
+                // that they may have an overbuild / multiproc build problem.
+                // Adding an error code would make it suppressible.
                 this.Log.LogWarning("Unable to write log file: \"{0}\". {1}", filePath, ex.Message);
             }
         }

--- a/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
@@ -369,8 +369,17 @@ namespace Microsoft.VisualStudio.Composition.AppHost
 
                 if (name.Version >= minimumVersion)
                 {
-                    assembly = Assembly.Load(name);
-                    return true;
+                    try
+                    {
+                        assembly = Assembly.Load(name);
+                        return true;
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        // This happens for some reference assemblies that can only be loaded in a reflection-only context.
+                        // But we're not allowed in an assembly resolve event to return reflection-only loaded assemblies.
+                        // So just return false to communicate the failure.
+                    }
                 }
             }
 

--- a/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
@@ -1,4 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+// Elements of this file taken from:
+// https://github.com/dotnet/buildtools/blob/647d79ca86350646be4b87b889221d9a1de9b710/src/common/AssemblyResolver.cs#L31-L107
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file https://github.com/dotnet/buildtools/blob/master/LICENSE for more information.
 
 namespace Microsoft.VisualStudio.Composition.AppHost
 {
@@ -18,12 +23,11 @@ namespace Microsoft.VisualStudio.Composition.AppHost
 
     public class CreateComposition : AppDomainIsolatedTask, ICancelableTask
     {
-        private static readonly string[] AssembliesToResolve = new string[]
-        {
-            "System.Composition.AttributedModel",
-            "Validation",
-            "System.Collections.Immutable",
-        };
+        private const string DiscoveryErrorCode = "MEF0001";
+
+        private const string CompositionErrorCode = "MEF0002";
+
+        private readonly Lazy<HashSet<string>> skipCodes;
 
         /// <summary>
         /// The source of the <see cref="CancellationToken" /> that is canceled when
@@ -31,68 +35,388 @@ namespace Microsoft.VisualStudio.Composition.AppHost
         /// </summary>
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
 
+        /// <summary>
+        /// A copy of <see cref="CatalogAssemblies"/> but transformed to be full paths
+        /// instead of a mixture of assembly names and various paths.
+        /// </summary>
+        private readonly List<string> catalogAssemblyPaths = new List<string>();
+
+        public CreateComposition()
+        {
+            this.skipCodes = new Lazy<HashSet<string>>(() => new HashSet<string>(this.NoWarn, StringComparer.OrdinalIgnoreCase));
+        }
+
         /// <summary>Gets a token that is canceled when MSBuild is requesting that we abort.</summary>
         public CancellationToken CancellationToken => this.cts.Token;
 
-        public ITaskItem[] CatalogAssemblies { get; set; }
+        public ITaskItem[] CatalogAssemblies { get; set; } = new ITaskItem[0];
+
+        /// <summary>
+        /// Gets or sets the paths to assemblies that may be loaded as part of MEF discovery (because they are referenced by an assembly in the <see cref="CatalogAssemblies"/>.)
+        /// </summary>
+        public ITaskItem[] ReferenceAssemblies { get; set; } = new ITaskItem[0];
+
+        /// <summary>
+        /// Gets or sets a list of paths to directories to search for MEF catalog assemblies.
+        /// </summary>
+        public ITaskItem[] CatalogAssemblySearchPath { get; set; } = new ITaskItem[0];
+
+        /// <summary>
+        /// Gets or sets a list of codes to suppress warnings for.
+        /// </summary>
+        public string[] NoWarn { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to continue when errors occur while scanning MEF assemblies.
+        /// </summary>
+        public bool ContinueOnDiscoveryErrors { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to continue when errors occur while composing the graph.
+        /// </summary>
+        public bool ContinueOnCompositionErrors { get; set; }
 
         [Required]
         public string CompositionCacheFile { get; set; }
 
         public string DgmlOutputPath { get; set; }
 
+        /// <summary>
+        /// Gets or sets the directory to write the discovery and composition log files.
+        /// </summary>
+        [Required]
+        public string LogOutputPath { get; set; }
+
         /// <inheritdoc />
         public void Cancel() => this.cts.Cancel();
 
         public override bool Execute()
         {
-            var resolver = Resolver.DefaultInstance;
-            var discovery = PartDiscovery.Combine(new AttributedPartDiscoveryV1(resolver), new AttributedPartDiscovery(resolver, isNonPublicSupported: true));
+            this.catalogAssemblyPaths.AddRange(this.CatalogAssemblies.Select(this.GetMEFAssemblyFullPath));
+            this.LogLines(this.GetLogFilePath("CatalogAssemblies"), this.catalogAssemblyPaths.Select(Path.GetFileNameWithoutExtension), this.CancellationToken);
 
-            this.CancellationToken.ThrowIfCancellationRequested();
-
-            var parts = discovery.CreatePartsAsync(this.CatalogAssemblies.Select(item => item.ItemSpec)).GetAwaiter().GetResult();
-            foreach (var error in parts.DiscoveryErrors)
+            AppDomain.CurrentDomain.AssemblyResolve += this.CurrentDomain_AssemblyResolve;
+            try
             {
-                this.Log.LogWarningFromException(error);
-            }
+                var loadableAssemblies = this.catalogAssemblyPaths
+                    .Concat(this.ReferenceAssemblies.Select(i => i.GetMetadata("FullPath")) ?? Enumerable.Empty<string>());
+                var resolver = new Resolver(new AssemblyLoader(loadableAssemblies));
+                var discovery = PartDiscovery.Combine(
+                    new AttributedPartDiscoveryV1(resolver),
+                    new AttributedPartDiscovery(resolver, isNonPublicSupported: true));
 
-            this.CancellationToken.ThrowIfCancellationRequested();
-            var catalog = ComposableCatalog.Create(resolver)
-                .AddParts(parts.Parts);
-            this.CancellationToken.ThrowIfCancellationRequested();
-            var configuration = CompositionConfiguration.Create(catalog);
+                this.CancellationToken.ThrowIfCancellationRequested();
 
-            if (!string.IsNullOrEmpty(this.DgmlOutputPath))
-            {
-                configuration.CreateDgml().Save(this.DgmlOutputPath);
-            }
-
-            this.CancellationToken.ThrowIfCancellationRequested();
-            if (!configuration.CompositionErrors.IsEmpty)
-            {
-                foreach (var error in configuration.CompositionErrors.Peek())
+                var parts = discovery.CreatePartsAsync(this.catalogAssemblyPaths).GetAwaiter().GetResult();
+                var catalog = ComposableCatalog.Create(resolver)
+                    .AddParts(parts.Parts);
+                string catalogErrorFilePath = this.GetLogFilePath("CatalogErrors");
+                if (catalog.DiscoveredParts.DiscoveryErrors.IsEmpty)
                 {
-                    this.Log.LogError(error.Message);
+                    File.Delete(catalogErrorFilePath);
+                }
+                else
+                {
+                    this.LogLines(catalogErrorFilePath, GetCatalogErrorLines(catalog), this.CancellationToken);
+                    foreach (var error in catalog.DiscoveredParts.DiscoveryErrors)
+                    {
+                        string message = error.GetUserMessage();
+                        if (this.ContinueOnDiscoveryErrors)
+                        {
+                            this.LogWarning(DiscoveryErrorCode, message);
+                        }
+                        else
+                        {
+                            this.Log.LogError(null, DiscoveryErrorCode, null, null, 0, 0, 0, 0, message);
+                        }
+                    }
+
+                    if (!this.ContinueOnDiscoveryErrors)
+                    {
+                        return false;
+                    }
                 }
 
-                return false;
+                this.CancellationToken.ThrowIfCancellationRequested();
+                var configuration = CompositionConfiguration.Create(catalog);
+
+                if (!string.IsNullOrEmpty(this.DgmlOutputPath))
+                {
+                    configuration.CreateDgml().Save(this.DgmlOutputPath);
+                }
+
+                this.CancellationToken.ThrowIfCancellationRequested();
+                string compositionLogPath = this.GetLogFilePath("CompositionErrors");
+                if (configuration.CompositionErrors.IsEmpty)
+                {
+                    File.Delete(compositionLogPath);
+                }
+                else
+                {
+                    this.LogLines(compositionLogPath, GetCompositionErrorLines(configuration), this.CancellationToken);
+                    foreach (var error in configuration.CompositionErrors.Peek())
+                    {
+                        if (this.ContinueOnCompositionErrors)
+                        {
+                            this.LogWarning(CompositionErrorCode, error.Message);
+                        }
+                        else
+                        {
+                            this.Log.LogError(null, CompositionErrorCode, null, null, 0, 0, 0, 0, error.Message);
+                        }
+                    }
+
+                    if (!this.ContinueOnCompositionErrors)
+                    {
+                        return false;
+                    }
+                }
+
+                this.CancellationToken.ThrowIfCancellationRequested();
+
+                string cachePath = Path.GetFullPath(this.CompositionCacheFile);
+                this.Log.LogMessage("Producing IoC container \"{0}\"", cachePath);
+                using (var cacheStream = File.Open(cachePath, FileMode.Create))
+                {
+                    this.CancellationToken.ThrowIfCancellationRequested();
+                    var runtime = RuntimeComposition.CreateRuntimeComposition(configuration);
+                    this.CancellationToken.ThrowIfCancellationRequested();
+                    var runtimeCache = new CachedComposition();
+                    runtimeCache.SaveAsync(runtime, cacheStream, this.CancellationToken).GetAwaiter().GetResult();
+                }
+
+                return !this.Log.HasLoggedErrors;
             }
-
-            this.CancellationToken.ThrowIfCancellationRequested();
-
-            string cachePath = Path.GetFullPath(this.CompositionCacheFile);
-            this.Log.LogMessage("Producing IoC container \"{0}\"", cachePath);
-            using (var cacheStream = File.Open(cachePath, FileMode.Create))
+            finally
             {
-                this.CancellationToken.ThrowIfCancellationRequested();
-                var runtime = RuntimeComposition.CreateRuntimeComposition(configuration);
-                this.CancellationToken.ThrowIfCancellationRequested();
-                var runtimeCache = new CachedComposition();
-                runtimeCache.SaveAsync(runtime, cacheStream, this.CancellationToken).GetAwaiter().GetResult();
+                AppDomain.CurrentDomain.AssemblyResolve -= this.CurrentDomain_AssemblyResolve;
+            }
+        }
+
+        private void LogWarning(string code, string message)
+        {
+            if (!this.skipCodes.Value.Contains(code))
+            {
+                this.Log.LogWarning(null, code, null, null, 0, 0, 0, 0, message);
+            }
+        }
+
+        /// <summary>
+        /// Gets the full path to an assembly.
+        /// </summary>
+        /// <param name="taskItem">The assembly name or path to an assembly.</param>
+        /// <returns>The full path to the assembly.</returns>
+        private string GetMEFAssemblyFullPath(ITaskItem taskItem)
+        {
+            // So long as it doesn't obviously look like a path...
+            if (!taskItem.ItemSpec.Contains(Path.DirectorySeparatorChar) &&
+                !taskItem.ItemSpec.Contains(Path.AltDirectorySeparatorChar) &&
+                !taskItem.ItemSpec.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
+                !taskItem.ItemSpec.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    // ... try parsing it as if it were an assembly name (so we can parse out just the simple name).
+                    var assemblyName = new AssemblyName(taskItem.ItemSpec);
+                    foreach (var searchDir in this.CatalogAssemblySearchPath)
+                    {
+                        string fullPath = Path.Combine(Path.GetFullPath(searchDir.ItemSpec), assemblyName.Name + ".dll");
+                        if (File.Exists(fullPath))
+                        {
+                            return fullPath;
+                        }
+                    }
+                }
+                catch (ArgumentException)
+                {
+                }
             }
 
-            return !this.Log.HasLoggedErrors;
+            // Fall back to assuming it's a path.
+            return Path.GetFullPath(taskItem.GetMetadata("FullPath"));
+        }
+
+        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            // apply any existing policy
+            AssemblyName referenceName = new AssemblyName(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
+
+            string fileName = referenceName.Name + ".dll";
+            Assembly assm;
+
+            // Look through user-specified assembly lists.
+            foreach (var candidate in this.catalogAssemblyPaths.Concat(this.ReferenceAssemblies.Select(i => i.GetMetadata("FullPath"))))
+            {
+                if (string.Equals(referenceName.Name, Path.GetFileNameWithoutExtension(candidate), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (Probe(candidate, referenceName.Version, out assm))
+                    {
+                        return assm;
+                    }
+                }
+            }
+
+            string probingPath;
+            foreach (var searchDir in this.CatalogAssemblySearchPath)
+            {
+                probingPath = Path.Combine(searchDir.GetMetadata("FullPath"), fileName);
+                Debug.WriteLine($"Considering {probingPath} based on catalog assembly search path");
+                if (Probe(probingPath, referenceName.Version, out assm))
+                {
+                    return assm;
+                }
+            }
+
+            // look next to requesting assembly
+            string assemblyPath = args.RequestingAssembly?.Location;
+            if (!string.IsNullOrEmpty(assemblyPath))
+            {
+                probingPath = Path.Combine(Path.GetDirectoryName(assemblyPath), fileName);
+                Debug.WriteLine($"Considering {probingPath} based on RequestingAssembly");
+                if (Probe(probingPath, referenceName.Version, out assm))
+                {
+                    return assm;
+                }
+            }
+
+            // look next to the executing assembly
+            assemblyPath = Assembly.GetExecutingAssembly().Location;
+            if (!string.IsNullOrEmpty(assemblyPath))
+            {
+                probingPath = Path.Combine(Path.GetDirectoryName(assemblyPath), fileName);
+
+                Debug.WriteLine($"Considering {probingPath} based on ExecutingAssembly");
+                if (Probe(probingPath, referenceName.Version, out assm))
+                {
+                    return assm;
+                }
+            }
+
+            // look in AppDomain base directory
+            probingPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+            Debug.WriteLine($"Considering {probingPath} based on BaseDirectory");
+            if (Probe(probingPath, referenceName.Version, out assm))
+            {
+                return assm;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Considers a path to load for satisfying an assembly ref and loads it
+        /// if the file exists and version is sufficient.
+        /// </summary>
+        /// <param name="filePath">Path to consider for load</param>
+        /// <param name="minimumVersion">Minimum version to consider</param>
+        /// <param name="assembly">loaded assembly</param>
+        /// <returns>true if assembly was loaded</returns>
+        private static bool Probe(string filePath, Version minimumVersion, out Assembly assembly)
+        {
+            if (File.Exists(filePath))
+            {
+                AssemblyName name = AssemblyName.GetAssemblyName(filePath);
+
+                if (name.Version >= minimumVersion)
+                {
+                    assembly = Assembly.Load(name);
+                    return true;
+                }
+            }
+
+            assembly = null;
+            return false;
+        }
+
+        private static IEnumerable<string> GetCatalogErrorLines(ComposableCatalog catalog)
+        {
+            foreach (var error in catalog.DiscoveredParts.DiscoveryErrors)
+            {
+                yield return error.ToString();
+                yield return string.Empty;
+            }
+        }
+
+        private static IEnumerable<string> GetCompositionErrorLines(CompositionConfiguration composition)
+        {
+            int level = 1;
+            foreach (var errors in composition.CompositionErrors)
+            {
+                yield return $"******************* Composition error level {level++} ********************";
+                foreach (var error in errors)
+                {
+                    yield return error.Message;
+                }
+
+                yield return string.Empty;
+            }
+        }
+
+        private void LogLines(string filePath, IEnumerable<string> lines, CancellationToken cancellationToken)
+        {
+            Requires.NotNullOrEmpty(filePath, nameof(filePath));
+            Requires.NotNull(lines, nameof(lines));
+
+            cancellationToken.ThrowIfCancellationRequested();
+            using (var writer = new StreamWriter(new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read)))
+            {
+                foreach (string line in lines)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    writer.WriteLine(line);
+                }
+
+                writer.Flush();
+            }
+        }
+
+        private string GetLogFilePath(string partialFileName)
+        {
+            return Path.Combine(this.LogOutputPath, $"Microsoft.VisualStudio.Composition.AppHost.{partialFileName}.log");
+        }
+
+        private class AssemblyLoader : IAssemblyLoader
+        {
+            private readonly Dictionary<string, string> assemblyNamesToPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            internal AssemblyLoader(IEnumerable<string> assemblyPaths)
+            {
+                Requires.NotNull(assemblyPaths, nameof(assemblyPaths));
+
+                foreach (string path in assemblyPaths)
+                {
+                    string assemblyName = Path.GetFileNameWithoutExtension(path);
+                    if (!this.assemblyNamesToPaths.ContainsKey(assemblyName))
+                    {
+                        this.assemblyNamesToPaths.Add(assemblyName, path);
+                    }
+                }
+            }
+
+            public Assembly LoadAssembly(string assemblyFullName, string codeBasePath)
+            {
+                Requires.NotNullOrEmpty(assemblyFullName, nameof(assemblyFullName));
+
+                var assemblyName = new AssemblyName(assemblyFullName);
+#if NETFRAMEWORK
+                if (!string.IsNullOrEmpty(codeBasePath))
+                {
+                    assemblyName.CodeBase = codeBasePath;
+                }
+#endif
+
+                return this.LoadAssembly(assemblyName);
+            }
+
+            public Assembly LoadAssembly(AssemblyName assemblyName)
+            {
+                if (string.IsNullOrEmpty(assemblyName.CodeBase) && this.assemblyNamesToPaths.TryGetValue(assemblyName.Name, out string path))
+                {
+                    assemblyName.CodeBase = path;
+                }
+
+                return Assembly.Load(assemblyName);
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.AppHost/ExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/ExportProviderFactory.cs
@@ -12,11 +12,12 @@ namespace $rootnamespace$
 {
     using System.IO;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition;
 
     internal static class ExportProviderFactory
     {
-        internal static IExportProviderFactory LoadDefault()
+        internal static async Task<IExportProviderFactory> LoadDefaultAsync()
         {
             var cacheManager = new CachedComposition();
             string cachePath = Path.Combine(
@@ -24,7 +25,7 @@ namespace $rootnamespace$
                 "$ConfigurationAssemblyName$");
             using (var cacheStream = File.OpenRead(cachePath))
             {
-                return cacheManager.LoadExportProviderFactoryAsync(cacheStream, Resolver.DefaultInstance).GetAwaiter().GetResult();
+                return await cacheManager.LoadExportProviderFactoryAsync(cacheStream, Resolver.DefaultInstance);
             }
         }
    }

--- a/src/Microsoft.VisualStudio.Composition.AppHost/Readme.txt
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/Readme.txt
@@ -1,11 +1,14 @@
-Microsoft.VisualStudio.Composition
-==================================
+# Microsoft.VisualStudio.Composition.AppHost
+
+## How to initialize MEF at runtime
 
 Initialize your IoC container and extract your first export using code such as the following:
 
-    var exportProviderFactory = ExportProviderFactory.LoadDefault();
+    var exportProviderFactory = await ExportProviderFactory.LoadDefaultAsync();
     var exportProvider = exportProviderFactory.CreateExportProvider();
     var program = exportProvider.GetExportedValue<Program>();
+
+## Customizing your MEF catalog
 
 To include assembly or project references in the MEF catalog,
 set the MEFAssembly metadata on those references to "true", such as:
@@ -15,3 +18,12 @@ set the MEFAssembly metadata on those references to "true", such as:
       <MEFAssembly>true</MEFAssembly>
     </ProjectReference>
   </ItemGroup>
+
+Alternatively, include assemblies in the `MEFCatalogAssembly` item list.
+If doing this from a target, add the target to the $(GenerateMEFCompositionCacheDependsOn) property.
+
+## Troubleshooting your MEF catalog
+
+If build-time catalog creation produces MEF discovery errors due to the inability to find
+assemblies referenced from your MEF catalog assemblies, include the referenced assemblies
+in the `MEFReferenceAssembly` MSBuild item list.

--- a/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
@@ -13,6 +13,10 @@
     <GenerateMEFCompositionCacheDependsOn>
       ResolveReferences;
     </GenerateMEFCompositionCacheDependsOn>
+    <GetCopyToOutputDirectoryItemsDependsOn>
+      $(GetCopyToOutputDirectoryItemsDependsOn);
+      GenerateMEFCompositionCache;
+    </GetCopyToOutputDirectoryItemsDependsOn>
   </PropertyGroup>
 
   <UsingTask TaskName="CreateComposition" AssemblyFile="$(MicrosoftVisualStudioCompositionAppHostToolsPath)Microsoft.VisualStudio.Composition.AppHost.dll" />
@@ -40,6 +44,12 @@
       <FileWrites Include="$(OutputPath)$(CompositionConfigurationCacheName)" />
       <MEFCatalogAssemblySearchPath Include="$(TargetDir)" />
       <MEFReferenceAssembly Include="@(ReferencePath)" />
+      <!-- Register the cache as a content item so that if this project is just a library, the .exe will get the cache file. -->
+      <ContentWithTargetPath Include="$(OutputPath)$(CompositionConfigurationCacheName)">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <TargetPath>$(CompositionConfigurationCacheName)</TargetPath>
+        <Visible>false</Visible>
+      </ContentWithTargetPath>
     </ItemGroup>
 
     <CreateComposition

--- a/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
@@ -39,7 +39,7 @@
 
   <Target Name="GenerateMEFCompositionCache" AfterTargets="Build" DependsOnTargets="$(GenerateMEFCompositionCacheDependsOn)">
     <ItemGroup>
-      <MEFCatalogAssembly Include="$(TargetPath)" />
+      <MEFCatalogAssembly Include="@(IntermediateAssembly)" />
       <MEFCatalogAssembly Include="@(ReferencePath)" Condition=" '%(ReferencePath.MEFAssembly)'=='true' " />
       <FileWrites Include="$(OutputPath)$(CompositionConfigurationCacheName)" />
       <MEFCatalogAssemblySearchPath Include="$(TargetDir)" />

--- a/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
@@ -4,11 +4,15 @@
     <MicrosoftVisualStudioCompositionAppHostToolsPath Condition=" '$(MicrosoftVisualStudioCompositionAppHostToolsPath)' == '' ">$(MicrosoftVisualStudioCompositionAppHostToolsRootPath)$(MicrosoftVisualStudioCompositionAppHostToolsSubPath)</MicrosoftVisualStudioCompositionAppHostToolsPath>
     <CompositionConfigurationBaseName>$(TargetName).Composition</CompositionConfigurationBaseName>
     <CompositionConfigurationCacheName>$(CompositionConfigurationBaseName).cache</CompositionConfigurationCacheName>
+    <MEFLogOutputPath Condition=" '$(LogOutputPath)' == '' ">$(IntermediateOutputPath)</MEFLogOutputPath>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <PrepareResourceNamesDependsOn>
       GenerateCompositionBootstrapSourceFile;
       $(PrepareResourceNamesDependsOn)
     </PrepareResourceNamesDependsOn>
+    <GenerateMEFCompositionCacheDependsOn>
+      ResolveReferences;
+    </GenerateMEFCompositionCacheDependsOn>
   </PropertyGroup>
 
   <UsingTask TaskName="CreateComposition" AssemblyFile="$(MicrosoftVisualStudioCompositionAppHostToolsPath)Microsoft.VisualStudio.Composition.AppHost.dll" />
@@ -29,15 +33,24 @@
       CompositionCacheFile="$(CompositionConfigurationCacheName)"/>
   </Target>
 
-  <Target Name="GenerateCompositionConfigurationAssembly" AfterTargets="Build" DependsOnTargets="ResolveReferences">
+  <Target Name="GenerateMEFCompositionCache" AfterTargets="Build" DependsOnTargets="$(GenerateMEFCompositionCacheDependsOn)">
     <ItemGroup>
-      <CompositionConfigurationAssembly Include="$(TargetPath)" />
-      <CompositionConfigurationAssembly Include="@(ReferencePath)" Condition=" '%(ReferencePath.MEFAssembly)'=='true' " />
+      <MEFCatalogAssembly Include="$(TargetPath)" />
+      <MEFCatalogAssembly Include="@(ReferencePath)" Condition=" '%(ReferencePath.MEFAssembly)'=='true' " />
+      <FileWrites Include="$(OutputPath)$(CompositionConfigurationCacheName)" />
+      <MEFCatalogAssemblySearchPath Include="$(TargetDir)" />
+      <MEFReferenceAssembly Include="@(ReferencePath)" />
     </ItemGroup>
 
     <CreateComposition
-      CatalogAssemblies="@(CompositionConfigurationAssembly)"
-      DgmlOutputPath="$(OutputPath)$(CompositionConfigurationBaseName).dgml"
-      CompositionCacheFile="$(OutputPath)$(CompositionConfigurationCacheName)" />
+      CatalogAssemblies="@(MEFCatalogAssembly)"
+      ReferenceAssemblies="@(MEFReferenceAssembly)"
+      ContinueOnDiscoveryErrors="$(ContinueOnMEFDiscoveryErrors)"
+      ContinueOnCompositionErrors="$(ContinueOnMEFCompositionErrors)"
+      DgmlOutputPath="$(MEFLogOutputPath)$(CompositionConfigurationBaseName).dgml"
+      CompositionCacheFile="$(OutputPath)$(CompositionConfigurationCacheName)"
+      CatalogAssemblySearchPath="@(MEFCatalogAssemblySearchPath)"
+      LogOutputPath="$(MEFLogOutputPath)"
+      NoWarn="$(NoWarn)" />
   </Target>
 </Project>

--- a/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/build/Microsoft.VisualStudio.Composition.AppHost.targets
@@ -61,6 +61,8 @@
       CompositionCacheFile="$(OutputPath)$(CompositionConfigurationCacheName)"
       CatalogAssemblySearchPath="@(MEFCatalogAssemblySearchPath)"
       LogOutputPath="$(MEFLogOutputPath)"
-      NoWarn="$(NoWarn)" />
+      NoWarn="$(NoWarn)">
+      <Output TaskParameter="FileWrites" ItemName="FileWrites" />
+    </CreateComposition>
   </Target>
 </Project>

--- a/src/Microsoft.VisualStudio.Composition.sln
+++ b/src/Microsoft.VisualStudio.Composition.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26614.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28606.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Composition", "Microsoft.VisualStudio.Composition\Microsoft.VisualStudio.Composition.csproj", "{1CA6A92C-5DD9-4BE5-B5B7-EE4A1318B4C2}"
 EndProject
@@ -24,10 +24,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Comp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{28B65BDB-4470-4946-BAC3-4EE840F40B37}"
 	ProjectSection(SolutionItems) = preProject
-		..\.appveyor.yml = ..\.appveyor.yml
-		..\.vsts-ci.yml = ..\.vsts-ci.yml
+		..\azure-pipelines\build.yml = ..\azure-pipelines\build.yml
 		Directory.Build.props = Directory.Build.props
 		nuget.config = nuget.config
+		..\azure-pipelines\testfx.yml = ..\azure-pipelines\testfx.yml
 		version.json = version.json
 	EndProjectSection
 EndProject


### PR DESCRIPTION
* Log the catalog assemblies, catalog errors, and compositional errors.
* Fix build break in msbuild task when no .exe has been produced by a prior build.
* Add support for reference assemblies and search paths
* Make the inserted .cs file expose the async nature of loading from cache.
* Add support for `NoWarn` property.
* Support for MSBuild incremental clean.
* Add basic support for the AppHost being installed in a library where the .cache file must propagate to the .exe's bin directory.

Closes #110