### PR TITLE
Better handling of properties with default value attribute

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -15,13 +15,18 @@ namespace Microsoft.VisualStudio.Composition
 
         public bool IsMetadataViewSupported(Type metadataType)
         {
-            return FindImplClassConstructor(metadataType) != null;
+            return HasMetadataViewImplementation(metadataType);
         }
 
         public object CreateProxy(IReadOnlyDictionary<string, object> metadata, IReadOnlyDictionary<string, object> defaultValues, Type metadataViewType)
         {
             var ctor = FindImplClassConstructor(metadataViewType);
             return ctor.Invoke(new object[] { metadata });
+        }
+
+        internal static bool HasMetadataViewImplementation(Type metadataType)
+        {
+            return FindImplClassConstructor(metadataType) != null;
         }
 
         private static ConstructorInfo FindImplClassConstructor(Type metadataType)

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -20,15 +20,17 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.IsType<MetadataViewClass>(export.Metadata);
             Assert.Equal("1", export.Metadata.A);
             Assert.Null(export.Metadata.B);
+            Assert.Equal(10, export.Metadata.PropertyWithMetadataThatDoesNotMatchType);
         }
 
-        [MefFact(CompositionEngines.V1)]
+        [MefFact(CompositionEngines.V1Compat)]
         public void MetadataViewImplementationViaImport(IContainer container)
         {
             var importingPart = container.GetExportedValue<ImportingPart>();
             Assert.IsType<MetadataViewClass>(importingPart.ImportingProperty.Metadata);
             Assert.Equal("1", importingPart.ImportingProperty.Metadata.A);
             Assert.Null(importingPart.ImportingProperty.Metadata.B);
+            Assert.Equal(10, importingPart.ImportingProperty.Metadata.PropertyWithMetadataThatDoesNotMatchType);
         }
 
         [MefV1.Export]
@@ -40,6 +42,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [MefV1.Export]
         [MefV1.ExportMetadata("A", "1")]
+        [MefV1.ExportMetadata("PropertyWithMetadataThatDoesNotMatchType", "valueThatDoesNotMatchType")]
         public class ExportingPart { }
 
         [MefV1.MetadataViewImplementation(typeof(MetadataViewClass))]
@@ -49,6 +52,9 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             [DefaultValue("default")]
             string B { get; }
+
+            [DefaultValue("default")]
+            int PropertyWithMetadataThatDoesNotMatchType { get; }
         }
 
         public class MetadataViewClass : IMetadataView
@@ -57,11 +63,14 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 this.A = (string)(metadata.ContainsKey("A") ? metadata["A"] : null);
                 this.B = (string)(metadata.ContainsKey("B") ? metadata["B"] : null);
+                this.PropertyWithMetadataThatDoesNotMatchType = metadata.ContainsKey("PropertyWithMetadataThatDoesNotMatchType") ? 10 : 20;
             }
 
             public string A { get; set; }
 
             public string B { get; set; }
+
+            public int PropertyWithMetadataThatDoesNotMatchType { get; set; }
         }
     }
 }


### PR DESCRIPTION
# Justification
VS MEF does not handle properties with the default value attribute on metadata views the same way that V1 of MEF handles them. Specifically if the metadata view is tagged with the attribute specifying a metadataview implementation, v1 of MEF ignores any export metadata associated with properties that have a default value attribute.

Our team really wants to update to VS MEF, but we have some unique scenarios where a lot of our code uses this pattern of setting the export metadata to something that is a different data type than the property itself, and we interpret that to set the property correctly in the constructor of our metadata view implementation. Currently in VS MEF this fails. The problem is the check in ImportMetadataViewConstraint.IsSatisfiedBy. In this check the constraint determines there is export metadata, and it makes sure it can be assigned to the property.

# Implementation
It seemed straight forward to just not create a MetadatumRequirement in the scenario that we had a metadataview implementation and the default value attribute was defined.  In all the testing I did V1 of MEF just completely ignored export metadata for these kinds of properties.

# Testing
I added a new property and new export data in the MetadataViewImplementationTests test class that cover this scenario.