### PR TITLE
Add test to prove no memory leak when using ExportFactory<T> with non-shared parts

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using System.Collections.Generic;
     using System.Composition;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading.Tasks;
     using Xunit;
@@ -37,6 +38,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.True(weakRefs.All(r => !r.IsAlive));
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static WeakReference[] DisposableNonSharedPartDisposedWithContainerForAllInstancesAndThenReleased_Helper(IContainer container)
         {
             var weakRefs = new WeakReference[3];


### PR DESCRIPTION
Demonstrates way to fix an app with a memory leak due to creating non-shared exports using `ExportProvider.GetExportedValue<T>()`.