### PR TITLE
Adapt to new naming guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NuGet package](https://img.shields.io/nuget/v/Microsoft.VisualStudio.Composition.svg)](https://nuget.org/packages/Microsoft.VisualStudio.Composition)
 [![Build Status](https://dev.azure.com/azure-public/vside/_apis/build/status/vs-mef)](https://dev.azure.com/azure-public/vside/_build/latest?definitionId=17)
-[![codecov](https://codecov.io/gh/Microsoft/vs-mef/branch/master/graph/badge.svg)](https://codecov.io/gh/Microsoft/vs-mef)
+[![codecov](https://codecov.io/gh/Microsoft/vs-mef/branch/main/graph/badge.svg)](https://codecov.io/gh/Microsoft/vs-mef)
 [![Join the chat at https://gitter.im/vs-mef/Lobby](https://badges.gitter.im/vs-mef/Lobby.svg)](https://gitter.im/vs-mef/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Features

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 trigger:
   branches:
-    include: ["master", "v*"]
+    include: ["main", "v*"]
   paths:
     exclude: ["doc", "*.md"]
 

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -1,6 +1,6 @@
 trigger:
   branches:
-    include: ["master", "v*"]
+    include: ["main", "v*"]
   paths:
     exclude: ["doc", "*.md"]
 pr: none

--- a/doc/why.md
+++ b/doc/why.md
@@ -39,4 +39,4 @@ Learn more about [the differences between .NET MEF, NuGet MEF, and this library]
 
 [MEFv2Pkg]: https://www.nuget.org/packages/system.composition
 [Differences]: mef_library_differences.md
-[Hosting]: https://github.com/microsoft/vs-mef/blob/master/doc/hosting.md#hosting-mef-in-an-extensible-application
+[Hosting]: https://github.com/microsoft/vs-mef/blob/main/doc/hosting.md#hosting-mef-in-an-extensible-application

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Composition.Analyzers
         /// <returns>The URL for the analyzer's documentation.</returns>
         internal static string GetHelpLink(string analyzerId)
         {
-            return $"https://github.com/Microsoft/vs-mef/blob/master/doc/analyzers/{analyzerId}.md";
+            return $"https://github.com/Microsoft/vs-mef/blob/main/doc/analyzers/{analyzerId}.md";
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
+++ b/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.Composition
 
                     if (x.GetType() != y.GetType())
                     {
-                        // Whitelist Type[] and RuntimeType[] arrays as equivalent.
+                        // Consider Type[] and RuntimeType[] arrays as equivalent.
                         if (!(x.GetType().IsArray && y.GetType().IsArray &&
                             typeof(Type).GetTypeInfo().IsAssignableFrom(x.GetType().GetElementType()) &&
                             typeof(Type).GetTypeInfo().IsAssignableFrom(y.GetType().GetElementType())))

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "16.6-alpha",
   "publicReleaseRefSpec": [
-    "^refs/heads/master$",
+    "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {


### PR DESCRIPTION
This PR corrects a few places in code to bring the repo's source in-line with the new naming guidelines.

Known action items:
- Rename the default branch to 'main'
- `IBCMergeBranch` is still `master`, this will need to be updated when the VS repo updates its naming.