### PR TITLE
Build analyzers tests to its own directory

### DIFF
--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Microsoft.VisualStudio.Composition.Analyzers.Tests.csproj
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Microsoft.VisualStudio.Composition.Analyzers.Tests.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Do not contribute to the one test directory that all the others do, because we're unrelated
+         and most importantly our analyzer test dependencies bring their own copy of vs-mef, leading to a 'last one wins' file overwrite
+         issue if we were to share a directory with vs-mef tests that makes testing unstable. -->
+    <BaseOutputPath>$(MSBuildThisFileDirectory)..\..\..\bin\Tests\Microsoft.VisualStudio.Composition.Analyzers.Tests</BaseOutputPath>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Microsoft.VisualStudio.Composition.Analyzers.Tests.csproj
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Microsoft.VisualStudio.Composition.Analyzers.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20059.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20059.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20478.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20478.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />


### PR DESCRIPTION
We had a test failure in Azure Pipelines that was due to the fact that analyzer tests build to the same directory as vs-mef tests, but the analyzer tests bring in a very old copy of vs-mef (courtesy of our analyzer test dependency) and our own vs-mef tests should bring in the vs-mef that was just built.