### PR TITLE
Make `CompositionFailedException` serializable

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/CompositionFailedException.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionFailedException.cs
@@ -5,23 +5,53 @@ namespace Microsoft.VisualStudio.Composition
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Text;
 
+    /// <summary>
+    /// An exception thrown when failures occur during composition.
+    /// </summary>
+    [Serializable]
     public class CompositionFailedException : Exception
     {
+        private string? errorsAsString;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositionFailedException"/> class.
+        /// </summary>
         public CompositionFailedException()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositionFailedException"/> class.
+        /// </summary>
+        /// <param name="message"><inheritdoc cref="Exception(string?)" path="/param[@name='message']"/></param>
         public CompositionFailedException(string? message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositionFailedException"/> class.
+        /// </summary>
+        /// <param name="message"><inheritdoc cref="Exception(string?, Exception?)" path="/param[@name='message']"/></param>
+        /// <param name="innerException"><inheritdoc cref="Exception(string?, Exception?)" path="/param[@name='innerException']"/></param>
         public CompositionFailedException(string? message, Exception? innerException)
             : base(message, innerException)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositionFailedException"/> class.
+        /// </summary>
+        /// <param name="message"><inheritdoc cref="CompositionFailedException(string?)" path="/param[@name='message']"/></param>
+        /// <param name="errors">
+        /// The errors that occurred during composition.
+        /// <inheritdoc cref="CompositionConfiguration.CompositionErrors" path="/remarks"/>
+        /// </param>
         public CompositionFailedException(string? message, IImmutableStack<IReadOnlyCollection<ComposedPartDiagnostic>> errors)
             : this(message)
         {
@@ -29,6 +59,51 @@ namespace Microsoft.VisualStudio.Composition
             this.Errors = errors;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositionFailedException"/> class.
+        /// </summary>
+        /// <param name="info"><inheritdoc cref="Exception(SerializationInfo, StreamingContext)" path="/param[@name='info']"/></param>
+        /// <param name="context"><inheritdoc cref="Exception(SerializationInfo, StreamingContext)" path="/param[@name='context']"/></param>
+        protected CompositionFailedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            this.errorsAsString = info.GetString(nameof(this.ErrorsAsString));
+        }
+
+        /// <summary>
+        /// Gets the compositional errors that occurred.
+        /// </summary>
+        /// <remarks>
+        /// This collection is not serialized via the <see cref="ISerializable"/> interface.
+        /// Refer to <see cref="ErrorsAsString"/> for a serialized form of these errors.
+        /// </remarks>
         public IImmutableStack<IReadOnlyCollection<ComposedPartDiagnostic>>? Errors { get; private set; }
+
+        /// <summary>
+        /// Gets a string representation of the compositional errors that are described in <see cref="Errors"/>
+        /// (or were, before serialization dropped that data).
+        /// </summary>
+        public string? ErrorsAsString
+        {
+            get
+            {
+                if (this.errorsAsString is null && this.Errors is object)
+                {
+                    using var writer = new StringWriter();
+                    Utilities.WriteErrors(writer, this.Errors);
+                    this.errorsAsString = writer.ToString();
+                }
+
+                return this.errorsAsString;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            info.AddValue(nameof(this.ErrorsAsString), this.ErrorsAsString);
+       }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
@@ -1,5 +1,8 @@
+Microsoft.VisualStudio.Composition.CompositionFailedException.CompositionFailedException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+Microsoft.VisualStudio.Composition.CompositionFailedException.ErrorsAsString.get -> string?
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExport(Microsoft.VisualStudio.Composition.Export! export) -> void
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExport<T>(System.Lazy<T>! export) -> void
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExports(System.Collections.Generic.IEnumerable<Microsoft.VisualStudio.Composition.Export!>! exports) -> void
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExports<T, TMetadataView>(System.Collections.Generic.IEnumerable<System.Lazy<T, TMetadataView>!>! exports) -> void
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExports<T>(System.Collections.Generic.IEnumerable<System.Lazy<T>!>! exports) -> void
+override Microsoft.VisualStudio.Composition.CompositionFailedException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/Microsoft.VisualStudio.Composition/Utilities.cs
+++ b/src/Microsoft.VisualStudio.Composition/Utilities.cs
@@ -6,15 +6,35 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
 
     internal static class Utilities
     {
+        private const string CompositionErrorHeaderFormat = "----- CompositionError level {0} ------";
+
+        internal static void WriteErrors(TextWriter textWriter, IImmutableStack<IReadOnlyCollection<ComposedPartDiagnostic>> errorStack)
+        {
+            int level = 1;
+            foreach (IReadOnlyCollection<ComposedPartDiagnostic> errors in errorStack)
+            {
+                textWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, CompositionErrorHeaderFormat, level++));
+                foreach (ComposedPartDiagnostic error in errors)
+                {
+                    textWriter.WriteLine(error.Message);
+                    foreach (ComposedPart part in error.Parts)
+                    {
+                        textWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, "   part definition {0}", part.Definition.Type));
+                    }
+
+                    textWriter.WriteLine();
+                }
+            }
+        }
+
         internal static ComposablePartDefinition GetMetadataViewProviderPartDefinition(Type providerType, int orderPrecedence, Resolver resolver)
         {
             Requires.NotNull(providerType, nameof(providerType));

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionFailedExceptionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionFailedExceptionTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
     public class CompositionFailedExceptionTests
     {
-        [Fact(Skip = "Not yet implemented.")]
+        [Fact]
         public void ExceptionIsSerializable()
         {
             var discovery = TestUtilities.V2Discovery;
@@ -39,10 +39,14 @@ namespace Microsoft.VisualStudio.Composition.Tests
             ms.Position = 0;
             var actual = (CompositionFailedException)formatter.Deserialize(ms);
             Assert.Equal(exception!.Message, actual.Message);
-            Assert.NotNull(actual.Errors);
-            Assert.False(actual.Errors!.IsEmpty);
-            Assert.Equal(1, actual.Errors.Peek().Count);
-            Assert.Equal(exception.Errors!.Peek().Single().Message, actual.Errors.Peek().Single().Message);
+
+            Assert.Equal(exception.ErrorsAsString, actual.ErrorsAsString);
+
+            // At present, we do not implement serialization of the Errors collection.
+            Assert.Null(actual.Errors);
+            ////Assert.False(actual.Errors!.IsEmpty);
+            ////Assert.Equal(1, actual.Errors.Peek().Count);
+            ////Assert.Equal(exception.Errors!.Peek().Single().Message, actual.Errors.Peek().Single().Message);
         }
 
         [Export]


### PR DESCRIPTION
Note I chose to take a shortcut here. Rather than make a very large tree of types all serializable via the `BinaryFormatter`, I am serializing the details of the exception as a string instead. This cut what might be a few days of work to just an hour, and I think will still deliver what the requesting party originally needed.

Closes #187