### PR TITLE
Make PartDiscoveryException serializable

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/PartDiscoveryException.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscoveryException.cs
@@ -3,25 +3,69 @@
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
+    using System.Runtime.Serialization;
 
+    /// <summary>
+    /// An exception that may be thrown during MEF part discovery.
+    /// </summary>
+    [Serializable]
     public class PartDiscoveryException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartDiscoveryException"/> class.
+        /// </summary>
         public PartDiscoveryException()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartDiscoveryException"/> class.
+        /// </summary>
+        /// <param name="message"><inheritdoc cref="Exception(string?)" path="/param[@name='message']"/></param>
         public PartDiscoveryException(string message)
             : base(message)
         {
         }
 
-        public PartDiscoveryException(string message, Exception inner)
-            : base(message, inner)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartDiscoveryException"/> class.
+        /// </summary>
+        /// <param name="message"><inheritdoc cref="Exception(string?, Exception?)" path="/param[@name='message']"/></param>
+        /// <param name="innerException"><inheritdoc cref="Exception(string?, Exception?)" path="/param[@name='innerException']"/></param>
+        public PartDiscoveryException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartDiscoveryException"/> class.
+        /// </summary>
+        /// <param name="info"><inheritdoc cref="Exception(SerializationInfo, StreamingContext)" path="/param[@name='info']"/></param>
+        /// <param name="context"><inheritdoc cref="Exception(SerializationInfo, StreamingContext)" path="/param[@name='context']"/></param>
+        protected PartDiscoveryException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            this.AssemblyPath = info.GetString(nameof(this.AssemblyPath));
+            this.ScannedType = (Type?)info.GetValue(nameof(this.ScannedType), typeof(Type));
+        }
+
+        /// <summary>
+        /// Gets or sets the path to the assembly involved in the failure.
+        /// </summary>
         public string? AssemblyPath { get; set; }
 
+        /// <summary>
+        /// Gets or sets the type where .NET Reflection failed.
+        /// </summary>
         public Type? ScannedType { get; set; }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            info.AddValue(nameof(this.AssemblyPath), this.AssemblyPath);
+            info.AddValue(nameof(this.ScannedType), this.ScannedType);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Shipped.txt
@@ -238,7 +238,7 @@ Microsoft.VisualStudio.Composition.PartDiscoveryException.AssemblyPath.get -> st
 Microsoft.VisualStudio.Composition.PartDiscoveryException.AssemblyPath.set -> void
 Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException() -> void
 Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string! message) -> void
-Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string! message, System.Exception! inner) -> void
+Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string! message, System.Exception! innerException) -> void
 Microsoft.VisualStudio.Composition.PartDiscoveryException.ScannedType.get -> System.Type?
 Microsoft.VisualStudio.Composition.PartDiscoveryException.ScannedType.set -> void
 Microsoft.VisualStudio.Composition.Reflection.FieldRef

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
@@ -5,4 +5,6 @@ Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExport<T>(System.Lazy<T
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExports(System.Collections.Generic.IEnumerable<Microsoft.VisualStudio.Composition.Export!>! exports) -> void
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExports<T, TMetadataView>(System.Collections.Generic.IEnumerable<System.Lazy<T, TMetadataView>!>! exports) -> void
 Microsoft.VisualStudio.Composition.ExportProvider.ReleaseExports<T>(System.Collections.Generic.IEnumerable<System.Lazy<T>!>! exports) -> void
+Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override Microsoft.VisualStudio.Composition.CompositionFailedException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+override Microsoft.VisualStudio.Composition.PartDiscoveryException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryExceptionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryExceptionTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System.IO;
+    using Xunit;
+
+    public class PartDiscoveryExceptionTests
+    {
+#if !NETCOREAPP
+        [Fact]
+        public void ExceptionIsSerializable()
+        {
+            var exception = new PartDiscoveryException("msg") { AssemblyPath = "/some path", ScannedType = typeof(string) };
+
+            var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+            var ms = new MemoryStream();
+            formatter.Serialize(ms, exception);
+
+            ms.Position = 0;
+            var actual = (PartDiscoveryException)formatter.Deserialize(ms);
+            Assert.Equal(exception!.Message, actual.Message);
+            Assert.Equal(exception.ScannedType, actual.ScannedType);
+            Assert.Equal(exception.AssemblyPath, actual.AssemblyPath);
+        }
+#endif
+    }
+}


### PR DESCRIPTION
This rounds out the #189 change by making both exceptions defined by VS-MEF serializable.
It is also required to satisfy a static analysis rule that will be added to the repo soon.