### PR TITLE
Analyzer fixes

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.Analyzers/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Resources;
+
+[assembly: NeutralResourcesLanguage("en-US")]

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Analyzers
 {

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF001PropertyMustHaveSetter.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF001PropertyMustHaveSetter.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Analyzers
 {

--- a/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
@@ -1,9 +1,13 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // Elements of this file taken from:
 // https://github.com/dotnet/buildtools/blob/647d79ca86350646be4b87b889221d9a1de9b710/src/common/AssemblyResolver.cs#L31-L107
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file https://github.com/dotnet/buildtools/blob/master/LICENSE for more information.
+
+#pragma warning disable CA1819 // Properties should not return arrays
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
 
 namespace Microsoft.VisualStudio.Composition.AppHost
 {
@@ -62,17 +66,17 @@ namespace Microsoft.VisualStudio.Composition.AppHost
         /// <summary>Gets a token that is canceled when MSBuild is requesting that we abort.</summary>
         public CancellationToken CancellationToken => this.cts.Token;
 
-        public ITaskItem[] CatalogAssemblies { get; set; } = new ITaskItem[0];
+        public ITaskItem[] CatalogAssemblies { get; set; } = Array.Empty<ITaskItem>();
 
         /// <summary>
         /// Gets or sets the paths to assemblies that may be loaded as part of MEF discovery (because they are referenced by an assembly in the <see cref="CatalogAssemblies"/>.)
         /// </summary>
-        public ITaskItem[] ReferenceAssemblies { get; set; } = new ITaskItem[0];
+        public ITaskItem[] ReferenceAssemblies { get; set; } = Array.Empty<ITaskItem>();
 
         /// <summary>
         /// Gets or sets a list of paths to directories to search for MEF catalog assemblies.
         /// </summary>
-        public ITaskItem[] CatalogAssemblySearchPath { get; set; } = new ITaskItem[0];
+        public ITaskItem[] CatalogAssemblySearchPath { get; set; } = Array.Empty<ITaskItem>();
 
         /// <summary>
         /// Gets or sets a list of codes to suppress warnings for.

--- a/src/Microsoft.VisualStudio.Composition.AppHost/CreateContainerFactoryBootstrapFile.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/CreateContainerFactoryBootstrapFile.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppHost
 {

--- a/src/Microsoft.VisualStudio.Composition.AppHost/ExceptionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/ExceptionHelpers.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppHost
 {

--- a/src/Microsoft.VisualStudio.Composition.Configuration/TypeForwarders.cs
+++ b/src/Microsoft.VisualStudio.Composition.Configuration/TypeForwarders.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.Composition;
 

--- a/src/Microsoft.VisualStudio.Composition.NetFxAttributes/TypeForwarders.cs
+++ b/src/Microsoft.VisualStudio.Composition.NetFxAttributes/TypeForwarders.cs
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel.Composition;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.VisualStudio.Composition/ArrayRental`1.cs
+++ b/src/Microsoft.VisualStudio.Composition/ArrayRental`1.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/AttributeServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/AttributeServices.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ByValueEquality+AssemblyNameComparer.cs
+++ b/src/Microsoft.VisualStudio.Composition/ByValueEquality+AssemblyNameComparer.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ByValueEquality+BufferComparer.cs
+++ b/src/Microsoft.VisualStudio.Composition/ByValueEquality+BufferComparer.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
+++ b/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/CollectionServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/CollectionServices.cs
@@ -1,4 +1,5 @@
-﻿// This file originated from System.ComponentModel.Composition.dll
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ComposableCatalog.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposableCatalog.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ComposablePartDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposablePartDefinition.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -182,13 +182,14 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(import, nameof(import));
 
+            var memberName = import.ImportingParameter is object ? ("ctor(" + import.ImportingParameter.Name + ")") :
+                             import.ImportingMemberRef is object ? import.ImportingMemberRef.Name :
+                             "(unknown)";
             return string.Format(
                 CultureInfo.CurrentCulture,
                 "{0}.{1}",
                 import.ComposablePartType.FullName,
-                import.ImportingParameter is object ? ("ctor(" + import.ImportingParameter.Name + ")") :
-                import.ImportingMemberRef is object ? import.ImportingMemberRef.Name :
-                "(unknown)");
+                memberName);
         }
 
         private static string? GetDiagnosticLocation(ExportDefinitionBinding export)

--- a/src/Microsoft.VisualStudio.Composition/ComposedPartDiagnostic.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPartDiagnostic.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/CompositionConstants.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConstants.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/CompositionFailedException.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionFailedException.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/CompressedUInt.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompressedUInt.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/ExportMetadataViewInterfaceEmitProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/ExportMetadataViewInterfaceEmitProxy.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewGenerator.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewGenerator.cs
@@ -1,4 +1,7 @@
-﻿/********************************************************
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/********************************************************
 *                                                        *
 *   © Copyright (C) Microsoft. All rights reserved.      *
 *                                                        *

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/NetFxAdapters.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/NetFxAdapters.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Configuration/NetFxAdapters.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/NetFxAdapters.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+
 namespace Microsoft.VisualStudio.Composition
 {
     using System;

--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -1,4 +1,7 @@
-﻿#if DEBUG
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
 ////#define TRACESTATS
 ////#define TRACESERIALIZATION
 #endif

--- a/src/Microsoft.VisualStudio.Composition/ContractNameServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/ContractNameServices.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/CreationPolicy.cs
+++ b/src/Microsoft.VisualStudio.Composition/CreationPolicy.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/DelegateServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/DelegateServices.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Dgml.cs
+++ b/src/Microsoft.VisualStudio.Composition/Dgml.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/DiscoveredParts.cs
+++ b/src/Microsoft.VisualStudio.Composition/DiscoveredParts.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/DiscoveryProgress.cs
+++ b/src/Microsoft.VisualStudio.Composition/DiscoveryProgress.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/DisposableWithAction.cs
+++ b/src/Microsoft.VisualStudio.Composition/DisposableWithAction.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Export.cs
+++ b/src/Microsoft.VisualStudio.Composition/Export.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportDefinition.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportDefinitionBinding.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportDefinitionBinding.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportFactory.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportMetadataValueImportConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportMetadataValueImportConstraint.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider+NonSharedExport.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider+NonSharedExport.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider+NonSharedLazy`2.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider+NonSharedLazy`2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.Composition
 
         protected static readonly Lazy<object> NotInstantiablePartLazy = new Lazy<object>(() => CannotInstantiatePartWithNoImportingConstructor());
 
-        protected static readonly Type[] EmptyTypeArray = new Type[0];
+        protected static readonly Type[] EmptyTypeArray = Array.Empty<Type>();
 
         protected static readonly object[] EmptyObjectArray = EmptyTypeArray; // Covariance allows us to reuse the derived type empty array.
 
@@ -1705,7 +1705,9 @@ namespace Microsoft.VisualStudio.Composition
             {
             }
 
+#pragma warning disable CA2215 // Dispose methods should call base class dispose
             protected override void Dispose(bool disposing)
+#pragma warning restore CA2215 // Dispose methods should call base class dispose
             {
                 throw new InvalidOperationException(Strings.CannotDirectlyDisposeAnImport);
             }

--- a/src/Microsoft.VisualStudio.Composition/ExportTypeIdentityConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportTypeIdentityConstraint.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ExportedDelegate.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportedDelegate.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IAssemblyLoader.cs
+++ b/src/Microsoft.VisualStudio.Composition/IAssemblyLoader.cs
@@ -1,8 +1,5 @@
-﻿/********************************************************
-*                                                        *
-*   © Copyright (C) Microsoft. All rights reserved.      *
-*                                                        *
-*********************************************************/
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ICompositionCacheManager.cs
+++ b/src/Microsoft.VisualStudio.Composition/ICompositionCacheManager.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IDescriptiveToString.cs
+++ b/src/Microsoft.VisualStudio.Composition/IDescriptiveToString.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/IExportProviderFactory.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IFaultReportingExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/IFaultReportingExportProviderFactory.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IImportSatisfiabilityConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/IImportSatisfiabilityConstraint.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IMetadataViewProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/IMetadataViewProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IRuntimeCompositionCacheManager.cs
+++ b/src/Microsoft.VisualStudio.Composition/IRuntimeCompositionCacheManager.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ImportCardinality.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportCardinality.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ImportDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportDefinition.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ImportDefinitionBinding.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportDefinitionBinding.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/ImportMetadataViewConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportMetadataViewConstraint.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/IndentingTextWriter.cs
+++ b/src/Microsoft.VisualStudio.Composition/IndentingTextWriter.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
+++ b/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
+++ b/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
@@ -15,7 +15,8 @@ namespace Microsoft.VisualStudio.Composition
 
     internal class LazyMetadataWrapper : ExportProvider.IMetadataDictionary
     {
-        private static readonly HashSet<Assembly> AlwaysLoadedAssemblies = new HashSet<Assembly>(new[] {
+        private static readonly HashSet<Assembly> AlwaysLoadedAssemblies = new HashSet<Assembly>(new[]
+        {
             typeof(CreationPolicy).GetTypeInfo().Assembly,
             typeof(string).GetTypeInfo().Assembly,
         });

--- a/src/Microsoft.VisualStudio.Composition/LazyServices.cs
+++ b/src/Microsoft.VisualStudio.Composition/LazyServices.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/MetadataTokenType.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataTokenType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/NullableBool.cs
+++ b/src/Microsoft.VisualStudio.Composition/NullableBool.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/PartCreationPolicyConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartCreationPolicyConstraint.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -614,7 +614,9 @@ namespace Microsoft.VisualStudio.Composition
                     value = new DiscoveryProgress(value.CompletedSteps, this.totalTypes, value.Status);
 
                     bool update = false;
+#pragma warning disable CA2002 // Do not lock on objects with weak identity
                     lock (this)
+#pragma warning restore CA2002 // Do not lock on objects with weak identity
                     {
                         // Only report progress if completion or status has changed significantly.
                         if (Math.Abs(value.Completion - this.lastReportedProgress.Completion) > .01 || value.Status != this.lastReportedProgress.Status)

--- a/src/Microsoft.VisualStudio.Composition/PartDiscoveryException.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscoveryException.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/PassthroughMetadataViewProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/PassthroughMetadataViewProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.Composition/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Resources;

--- a/src/Microsoft.VisualStudio.Composition/Reflection/FieldRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/FieldRef.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MemberRef.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/MethodRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/MethodRef.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ParameterRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ParameterRef.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/PropertyRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/PropertyRef.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/SkipClrVisibilityChecks.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/SkipClrVisibilityChecks.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/StrongAssemblyIdentity.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/StrongAssemblyIdentity.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition
 {
     using System;
     using System.Diagnostics;

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
@@ -419,7 +419,9 @@ namespace Microsoft.VisualStudio.Composition.Reflection
             }
             else
             {
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
                 throw new ArgumentException();
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
         }
 

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeRefFlags.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeRefFlags.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Reflection
 {

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -110,6 +110,10 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     return Assignability.DefinitelyNot;
                 }
+                catch (TargetParameterCountException)
+                {
+                    return Assignability.DefinitelyNot;
+                }
             }
             else
             {

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Rental`1.cs
+++ b/src/Microsoft.VisualStudio.Composition/Rental`1.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Resolver.cs
+++ b/src/Microsoft.VisualStudio.Composition/Resolver.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/StandardAssemblyLoader.cs
+++ b/src/Microsoft.VisualStudio.Composition/StandardAssemblyLoader.cs
@@ -1,8 +1,5 @@
-﻿/********************************************************
-*                                                        *
-*   © Copyright (C) Microsoft. All rights reserved.      *
-*                                                        *
-*********************************************************/
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/UniquePropertyNameComparer.cs
+++ b/src/Microsoft.VisualStudio.Composition/UniquePropertyNameComparer.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/Microsoft.VisualStudio.Composition/Utilities.cs
+++ b/src/Microsoft.VisualStudio.Composition/Utilities.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition
 {

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -2,9 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft",
-      "xmlHeader": false,
-      "fileNamingConvention": "metadata"
+      "companyName": "Microsoft Corporation",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName} license. See {licenseFile} file in the project root for full license information.",
+      "variables": {
+        "licenseName": "MIT",
+        "licenseFile": "LICENSE"
+      },
+      "fileNamingConvention": "metadata",
+      "xmlHeader": false
     }
   }
 }

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/ReferencesHelper.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/ReferencesHelper.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifier`2+Test.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifier`2.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifier`2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF001PropertyMustHaveSetterTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF001PropertyMustHaveSetterTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExport.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExport.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExportOnMember.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExportOnMember.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System.Composition;
 

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExportWithExternalMetadataType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExportWithExternalMetadataType.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExportWithLazy.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/ExternalExportWithLazy.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/OpenGenericExport`1.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/OpenGenericExport`1.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatImportsExportedMember.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatImportsExportedMember.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithMetadataOfCustomType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithMetadataOfCustomType.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaDictionary.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaDictionary.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaTMetadata.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaTMetadata.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AppDomainTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/AnExportWithMetadataTypeValue.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/AnExportWithMetadataTypeValue.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppDomainTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/CustomMetadataAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/CustomMetadataAttribute.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppDomainTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/ExportWithCustomMetadata.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/ExportWithCustomMetadata.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppDomainTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/ExportedMember.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/ExportedMember.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppDomainTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/YetAnotherExport.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AppDomainTests2/YetAnotherExport.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AppDomainTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/AConditionalClass.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/AConditionalClass.cs
@@ -1,4 +1,7 @@
-﻿#if NETFRAMEWORK // See comments below
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK // See comments below
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/AssemblyInfo.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/DiscoverablePart1.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/DiscoverablePart1.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/DiscoverablePart2.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/DiscoverablePart2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/IInternalMetadataView.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/IInternalMetadataView.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/ISomeInterface.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/ISomeInterface.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NestedPart.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NestedPart.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {
     using System;

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NestedPart.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NestedPart.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonDiscoverablePart.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonDiscoverablePart.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonDiscoverablePartV1.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonDiscoverablePartV1.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonDiscoverablePartV2.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonDiscoverablePartV2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonPart.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/NonPart.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/SomeEnum.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/SomeEnum.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/SomeMetadataAttributeFromAnotherAssemblyAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/SomeMetadataAttributeFromAnotherAssemblyAttribute.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {
     using System;
     using System.Composition;

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/TypeWithMissingAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests/TypeWithMissingAttribute.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests2/IBlankInterface.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests2/IBlankInterface.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests2/SomeOtherEnum.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests2/SomeOtherEnum.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.AssemblyDiscoveryTests2
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/GoodType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/GoodType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.BrokenAssemblyTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/PartInAssemblyWithBadTypes.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/PartInAssemblyWithBadTypes.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.BrokenAssemblyTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/PartInAssemblyWithBadTypes.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/PartInAssemblyWithBadTypes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.VisualStudio.Composition.BrokenAssemblyTests
 {
     using System.Composition;

--- a/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/TypeWithMissingBaseType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.BrokenAssemblyTests/TypeWithMissingBaseType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.BrokenAssemblyTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.EmbeddedTypeReceiver/PartThatImportsLazyOfEmbeddedType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.EmbeddedTypeReceiver/PartThatImportsLazyOfEmbeddedType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.EmbeddedTypeReceiver
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.MissingAssemblyTests/NotFoundAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.MissingAssemblyTests/NotFoundAttribute.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.MissingAssemblyTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.MissingAssemblyTests/NotFoundBaseType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.MissingAssemblyTests/NotFoundBaseType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.MissingAssemblyTests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.NonEmbeddingTypeReceiver/PartThatImportsLazyOfNonEmbeddedType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.NonEmbeddingTypeReceiver/PartThatImportsLazyOfNonEmbeddedType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.NonEmbeddingTypeReceiver
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.NonEmbeddingTypeReceiver/PartThatImportsLazyOfNonEmbeddedType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.NonEmbeddingTypeReceiver/PartThatImportsLazyOfNonEmbeddedType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.VisualStudio.Composition.NonEmbeddingTypeReceiver
 {
     using System;

--- a/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/AssemblyInfo.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/IVsReference.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/IVsReference.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Shell.Interop
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Shell.Interop
 {
     using System.Runtime.InteropServices;
 

--- a/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/ImportedFromTypeLibAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/ImportedFromTypeLibAttribute.cs
@@ -3,6 +3,7 @@
 
 namespace System.Runtime.InteropServices
 {
+    [AttributeUsage(AttributeTargets.Assembly)]
     internal sealed class ImportedFromTypeLibAttribute : Attribute
     {
         public ImportedFromTypeLibAttribute(string tlbFile)

--- a/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/ImportedFromTypeLibAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.TestEmbeddableTypes/ImportedFromTypeLibAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace System.Runtime.InteropServices
 {
     internal sealed class ImportedFromTypeLibAttribute : Attribute

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AmbiguousPartNamesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AmbiguousPartNamesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedDataFileCacheTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedDataFileCacheTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -82,9 +82,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CatalogGetInputAssembliesDoesNotLoadLazyExports()
         {
+            SkipOnMono();
             var catalog = TestUtilities.EmptyCatalog.AddParts(
                 await TestUtilities.V2Discovery.CreatePartsAsync(typeof(ExternalExportWithExternalMetadataType), typeof(ExternalExportWithExternalMetadataTypeArray), typeof(ExternalExportWithExternalMetadataEnum32)));
             var catalogCache = await this.SaveCatalogAsync(catalog);

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -25,7 +25,9 @@ namespace Microsoft.VisualStudio.Composition.Tests
     {
         private ICompositionCacheManager cacheManager;
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private TempFileCollection tfc;
+#pragma warning restore CA2213 // Disposable fields should be disposed
 
         protected AssembliesLazyLoadedTests(ICompositionCacheManager cacheManager)
         {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AssemblyReferencingTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AssemblyReferencingTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryCombinedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryCombinedTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTestBase.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTestBase.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryV1Tests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryV1Tests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/BaseGenericTypeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/BaseGenericTypeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ByValueEqualityTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ByValueEqualityTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CacheAndReloadTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CacheAndReloadTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CacheResiliencyTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CacheResiliencyTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK
 

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CardinalityMismatchTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CardinalityMismatchTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CircularDependencyTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CircularDependencyTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ClosedGenericExportedTypeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ClosedGenericExportedTypeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ComposableCatalogTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ComposableCatalogTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ComposableCatalogTests2.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ComposableCatalogTests2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ComposablePartDefinitionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ComposablePartDefinitionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionConfigurationTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionConfigurationTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionEngines.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionEngines.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionFailedExceptionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionFailedExceptionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionServiceTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompositionServiceTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompressedUIntTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompressedUIntTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 for (uint i = 0; i < uint.MaxValue; i = checked((i * 5) + 1))
                 {
-                    //this.output.WriteLine("0x{0:x8} {0,7}", i);
+                    ////this.output.WriteLine("0x{0:x8} {0,7}", i);
                     Test(i, writer, reader);
                 }
             }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CompressedUIntTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CompressedUIntTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ContainerIsolationTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ContainerIsolationTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataValueTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/CustomMetadataValueTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DataFileCacheAndReloadTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DataFileCacheAndReloadTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DelegateServicesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DelegateServicesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DelegatingExportProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DelegatingExportProviderTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DgmlProductionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DgmlProductionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/DynamicImportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/DynamicImportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/EmbeddableTypesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/EmbeddableTypesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/EmbeddedableTypesMixedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/EmbeddedableTypesMixedTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExplicitImportIdentityTypeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExplicitImportIdentityTypeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportDefinitionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportDefinitionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportFactoryOfNonSharedImportingSharingBoundaryTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportFactoryOfNonSharedImportingSharingBoundaryTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportFactoryTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportImportViaBaseType.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportImportViaBaseType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataNameCollisionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataNameCollisionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataNonStringValuesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataNonStringValuesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataViewNameCollisionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportMetadataViewNameCollisionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportProviderTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportingMembersTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ExportingMembersTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/FaultyPartsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/FaultyPartsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/GenericImportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/GenericImportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/GuidMetadataTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/GuidMetadataTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/IContainer.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/IContainer.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportDefinitionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportDefinitionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportManyTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportManyTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportMetadataConstraintTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportMetadataConstraintTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportOfTResolvedByDerivedClassTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportOfTResolvedByDerivedClassTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportSiteCreationPolicyTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportSiteCreationPolicyTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportedExportProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportedExportProviderTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportingConstructorTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportingConstructorTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public ImportManyArrayLazyWithMetadataConstructorPart([MefV1.ImportMany] Lazy<IRandomExport, FeatureMetadata>[] exports)
             {
                 Assert.NotNull(exports);
-                Assert.Equal(1, exports.Count());
+                Assert.Equal(1, exports.Length);
                 Assert.Equal("1", exports.First().Metadata.SomeMetadata);
                 Assert.IsType<RandomExport>(exports.First().Value);
             }
@@ -279,7 +279,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public ImportManyCollectionLazyWithMetadataConstructorPart([MefV1.ImportMany] Collection<Lazy<IRandomExport, FeatureMetadata>> exports)
             {
                 Assert.NotNull(exports);
-                Assert.Equal(1, exports.Count());
+                Assert.Equal(1, exports.Count);
                 Assert.Equal("1", exports.First().Metadata.SomeMetadata);
                 Assert.IsType<RandomExport>(exports.First().Value);
             }

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportingConstructorTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ImportingConstructorTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/InheritedExportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/InheritedExportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/InheritedImportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/InheritedImportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/InvalidGraphTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/InvalidGraphTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/LazyImportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/LazyImportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/LazyServicesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/LazyServicesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MefV1ExportProviderAdapterTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MefV1ExportProviderAdapterTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             var importDefinition = new MefV1.Primitives.ContractBasedImportDefinition(
                 MefV1.AttributedModelServices.GetTypeIdentity(typeof(SomeDelegate)),
                 MefV1.AttributedModelServices.GetTypeIdentity(typeof(SomeDelegate)),
-                new KeyValuePair<string, Type>[0],
+                Array.Empty<KeyValuePair<string, Type>>(),
                 MefV1.Primitives.ImportCardinality.ZeroOrMore,
                 false,
                 true,
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             var importDefinition = new MefV1.Primitives.ContractBasedImportDefinition(
                 MefV1.AttributedModelServices.GetTypeIdentity(typeof(SomeDelegate)),
                 MefV1.AttributedModelServices.GetTypeIdentity(typeof(SomeDelegate)),
-                new KeyValuePair<string, Type>[0],
+                Array.Empty<KeyValuePair<string, Type>>(),
                 MefV1.Primitives.ImportCardinality.ZeroOrMore,
                 false,
                 true,

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MefV1ExportProviderAdapterTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MefV1ExportProviderAdapterTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewClassDefaultCtorProviderTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MixedGenericExportsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MixedGenericExportsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MultipleExportsOnPartTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MultipleExportsOnPartTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/MultipleSharingBoundariesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/MultipleSharingBoundariesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/NameAndAgeAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/NameAndAgeAttribute.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/NamedTypedExportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/NamedTypedExportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/NestedTypeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/NestedTypeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/NonPublicImportsExportsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/NonPublicImportsExportsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/NonSharedPartTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/NonSharedPartTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ObsoleteAttributeTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ObsoleteAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/OnImportsSatisfiedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/OnImportsSatisfiedTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/OpenGenericExportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/OpenGenericExportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryExceptionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryExceptionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ProjectSystemMockTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ProjectSystemMockTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/Reflection/MethodRefTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/Reflection/MethodRefTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests.Reflection
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests.Reflection
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/RejectionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/RejectionTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ReportFaultDelegateTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ReportFaultDelegateTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.Tests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
     using System.Collections.Immutable;

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharedNoBoundaryExportsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharedNoBoundaryExportsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryAcquiresSharedRootScopeExport.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryAcquiresSharedRootScopeExport.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryInvalidTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryInvalidTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryMixedAttributesTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryMixedAttributesTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryTwoPathsToPartTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryTwoPathsToPartTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithMixedMefParts.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithMixedMefParts.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithNestedBoundaryFactoryTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithNestedBoundaryFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithNonNestedBoundaryFactoryTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithNonNestedBoundaryFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithNonSharedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithNonSharedTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/SimpleImportExportTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/SimpleImportExportTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/StaticFactoryMethodTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/StaticFactoryMethodTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/StaticMemberExportsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/StaticMemberExportsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/StrongAssemblyIdentityTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/StrongAssemblyIdentityTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/TestUtilities.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/TestUtilities.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ThreadSafetyTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ThreadSafetyTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/ThrowingPartsTests.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/ThrowingPartsTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertEx.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertEx.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.Tests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
     using System.Collections.Generic;

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertFailedException.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/AssertFailedException.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.VisualStudio.Composition.Tests
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
     using System.Runtime.Serialization;

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/CatalogScrambler.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/CatalogScrambler.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/LegacyMefTestCaseRunner.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/LegacyMefTestCaseRunner.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             try
             {
-                parts = parts ?? new Type[0];
+                parts = parts ?? Array.Empty<Type>();
                 var loadedAssemblies = assemblies != null ? assemblies.Select(an => Assembly.Load(new AssemblyName(an))).ToImmutableList() : ImmutableList<Assembly>.Empty;
 
                 if (attributesVersion.HasFlag(CompositionEngines.V1))

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/LegacyMefTestCaseRunner.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/LegacyMefTestCaseRunner.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/Mef3DiscoveryTestCaseRunner.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/Mef3DiscoveryTestCaseRunner.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/Mef3TestCaseRunner.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/Mef3TestCaseRunner.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/MefFactAttribute.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/MefFactAttribute.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/MefFactDiscoverer.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/MefFactDiscoverer.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 }
                 else
                 {
-                    var v3DiscoveryTest = new Mef3DiscoveryTestCaseRunner(this, "V3 composition", null, constructorArguments, messageBus, aggregator, cancellationTokenSource, this.compositionVersions, this.parts ?? new Type[0], this.assemblies ?? ImmutableList<string>.Empty, this.invalidConfiguration);
+                    var v3DiscoveryTest = new Mef3DiscoveryTestCaseRunner(this, "V3 composition", null, constructorArguments, messageBus, aggregator, cancellationTokenSource, this.compositionVersions, this.parts ?? Array.Empty<Type>(), this.assemblies ?? ImmutableList<string>.Empty, this.invalidConfiguration);
                     runSummary.Aggregate(await v3DiscoveryTest.RunAsync());
 
                     if (v3DiscoveryTest.Passed && (!this.invalidConfiguration || this.compositionVersions.HasFlag(CompositionEngines.V3AllowConfigurationWithErrors)))

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/MefFactDiscoverer.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/MefFactDiscoverer.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {

--- a/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/Traits.cs
+++ b/src/tests/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/Traits.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.Composition.Tests
 {


### PR DESCRIPTION
- Apply copyright header update
- Address several other static analyzer issues before we activate the analyzers
- Accommodate mono runtime differences

**Reviewers**: go by commit in order to quickly see the kind of changes being made.