### PR TITLE
Build unique assembly versions for every commit for the analyzers

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.Analyzers/version.json
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "inherit": true,
+  "assemblyVersion": {
+    "precision": "revision"
+  }
+}


### PR DESCRIPTION
Fixes #204 the same way we do it in vs-threading and vssdk-analyzers: a new version.json file that simply indicates that we want very precise assembly versions, but only for the analyzer project.