### PR TITLE
Reduce delegate allocations from method groups

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedCatalog.cs
@@ -56,18 +56,24 @@ namespace Microsoft.VisualStudio.Composition
 
         private class SerializationContext : SerializationContextBase
         {
-            private Func<IImportSatisfiabilityConstraint?>? readIImportSatisfiabilityConstraint;
-            private Func<ImportDefinitionBinding>? readImportDefinitionBinding;
-            private Func<ExportDefinition>? readExportDefinition;
+            private readonly Func<IImportSatisfiabilityConstraint?> readIImportSatisfiabilityConstraintDelegate;
+            private readonly Func<ImportDefinitionBinding> readImportDefinitionBindingDelegate;
+            private readonly Func<ExportDefinition> readExportDefinitionDelegate;
 
             internal SerializationContext(BinaryReader reader, Resolver resolver)
                 : base(reader, resolver)
             {
+                this.readIImportSatisfiabilityConstraintDelegate = this.ReadIImportSatisfiabilityConstraint;
+                this.readImportDefinitionBindingDelegate = this.ReadImportDefinitionBinding;
+                this.readExportDefinitionDelegate = this.ReadExportDefinition;
             }
 
             internal SerializationContext(BinaryWriter writer, int estimatedObjectCount, Resolver resolver)
                 : base(writer, estimatedObjectCount, resolver)
             {
+                this.readIImportSatisfiabilityConstraintDelegate = this.ReadIImportSatisfiabilityConstraint;
+                this.readImportDefinitionBindingDelegate = this.ReadImportDefinitionBinding;
+                this.readExportDefinitionDelegate = this.ReadExportDefinition;
             }
 
             private enum ConstraintTypes
@@ -129,29 +135,23 @@ namespace Microsoft.VisualStudio.Composition
                 }
             }
 
-            private Func<ImportDefinitionBinding> ReadImportDefinitionBindingDelegate => this.readImportDefinitionBinding ??= this.ReadImportDefinitionBinding;
-
-            private Func<ExportDefinition> ReadExportDefinitionDelegate => this.readExportDefinition ??= this.ReadExportDefinition;
-
-            private Func<IImportSatisfiabilityConstraint?> ReadIImportSatisfiabilityConstraintDelegate => this.readIImportSatisfiabilityConstraint ??= this.ReadIImportSatisfiabilityConstraint;
-
             private ComposablePartDefinition ReadComposablePartDefinition()
             {
                 using (this.Trace(nameof(ComposablePartDefinition)))
                 {
                     var partType = this.ReadTypeRef()!;
                     var partMetadata = this.ReadMetadata();
-                    var exportedTypes = this.ReadList(this.ReadExportDefinitionDelegate);
+                    var exportedTypes = this.ReadList(this.readExportDefinitionDelegate);
                     var exportingMembers = ImmutableDictionary.CreateBuilder<MemberRef, IReadOnlyCollection<ExportDefinition>>();
                     uint exportedMembersCount = this.ReadCompressedUInt();
                     for (int i = 0; i < exportedMembersCount; i++)
                     {
                         var member = this.ReadMemberRef()!;
-                        var exports = this.ReadList(this.ReadExportDefinitionDelegate);
+                        var exports = this.ReadList(this.readExportDefinitionDelegate);
                         exportingMembers.Add(member, exports);
                     }
 
-                    var importingMembers = this.ReadList(this.ReadImportDefinitionBindingDelegate);
+                    var importingMembers = this.ReadList(this.readImportDefinitionBindingDelegate);
                     var sharingBoundary = this.ReadString();
                     var onImportsSatisfied = this.ReadMethodRef();
 
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.Composition
                     if (this.reader!.ReadBoolean())
                     {
                         importingConstructor = this.ReadMethodRef();
-                        importingConstructorImports = this.ReadList(this.ReadImportDefinitionBindingDelegate);
+                        importingConstructorImports = this.ReadList(this.readImportDefinitionBindingDelegate);
                     }
 
                     var creationPolicy = this.ReadCreationPolicy();
@@ -236,8 +236,8 @@ namespace Microsoft.VisualStudio.Composition
                     var contractName = this.ReadString()!;
                     var cardinality = this.ReadImportCardinality();
                     var metadata = this.ReadMetadata();
-                    var constraints = this.ReadList(this.ReadIImportSatisfiabilityConstraintDelegate);
-                    var sharingBoundaries = this.ReadList(this.ReadStringDelegate);
+                    var constraints = this.ReadList(this.readIImportSatisfiabilityConstraintDelegate);
+                    var sharingBoundaries = this.ReadList(this.readStringDelegate);
                     return new ImportDefinition(contractName, cardinality, metadata, constraints!, sharingBoundaries!);
                 }
             }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -77,17 +77,21 @@ namespace Microsoft.VisualStudio.Composition
 
         private class SerializationContext : SerializationContextBase
         {
-            private Func<RuntimeComposition.RuntimeExport?>? readRuntimeExport;
-            private Func<RuntimeComposition.RuntimeImport>? readRuntimeImport;
+            private readonly Func<RuntimeComposition.RuntimeExport?> readRuntimeExportDelegate;
+            private readonly Func<RuntimeComposition.RuntimeImport> readRuntimeImportDelegate;
 
             internal SerializationContext(BinaryReader reader, Resolver resolver)
                 : base(reader, resolver)
             {
+                this.readRuntimeExportDelegate = this.ReadRuntimeExport;
+                this.readRuntimeImportDelegate = this.ReadRuntimeImport;
             }
 
             internal SerializationContext(BinaryWriter writer, int estimatedObjectCount, Resolver resolver)
                 : base(writer, estimatedObjectCount, resolver)
             {
+                this.readRuntimeExportDelegate = this.ReadRuntimeExport;
+                this.readRuntimeImportDelegate = this.ReadRuntimeImport;
             }
 
             private enum RuntimeImportFlags : byte
@@ -196,10 +200,6 @@ namespace Microsoft.VisualStudio.Composition
                 }
             }
 
-            private Func<RuntimeComposition.RuntimeExport?> ReadRuntimeExportDelegate => this.readRuntimeExport ??= this.ReadRuntimeExport;
-
-            private Func<RuntimeComposition.RuntimeImport> ReadRuntimeImportDelegate => this.readRuntimeImport ??= this.ReadRuntimeImport;
-
             private RuntimeComposition.RuntimePart ReadRuntimePart()
             {
                 using (this.Trace("RuntimePart"))
@@ -208,15 +208,15 @@ namespace Microsoft.VisualStudio.Composition
                     IReadOnlyList<RuntimeComposition.RuntimeImport> importingCtorArguments = ImmutableList<RuntimeComposition.RuntimeImport>.Empty;
 
                     var type = this.ReadTypeRef()!;
-                    var exports = this.ReadList(this.reader!, this.ReadRuntimeExportDelegate);
+                    var exports = this.ReadList(this.reader!, this.readRuntimeExportDelegate);
                     bool hasCtor = this.reader!.ReadBoolean();
                     if (hasCtor)
                     {
                         importingCtor = this.ReadMethodRef();
-                        importingCtorArguments = this.ReadList(this.reader, this.ReadRuntimeImportDelegate);
+                        importingCtorArguments = this.ReadList(this.reader, this.readRuntimeImportDelegate);
                     }
 
-                    var importingMembers = this.ReadList(this.reader, this.ReadRuntimeImportDelegate);
+                    var importingMembers = this.ReadList(this.reader, this.readRuntimeImportDelegate);
                     var onImportsSatisfied = this.ReadMethodRef();
                     var sharingBoundary = this.ReadString();
 
@@ -300,10 +300,10 @@ namespace Microsoft.VisualStudio.Composition
                     var importingSiteTypeRef = this.ReadTypeRef()!;
                     TypeRef importingSiteTypeWithoutCollectionRef =
                         cardinality == ImportCardinality.ZeroOrMore ? this.ReadTypeRef()! : importingSiteTypeRef;
-                    var satisfyingExports = this.ReadList(this.reader, this.ReadRuntimeExportDelegate);
+                    var satisfyingExports = this.ReadList(this.reader, this.readRuntimeExportDelegate);
                     var metadata = this.ReadMetadata();
                     IReadOnlyList<string?> exportFactorySharingBoundaries = isExportFactory
-                        ? this.ReadList(this.reader, this.ReadStringDelegate)
+                        ? this.ReadList(this.reader, this.readStringDelegate)
                         : ImmutableList<string>.Empty;
 
                     return importingMember == null

--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -42,15 +42,15 @@ namespace Microsoft.VisualStudio.Composition
         protected Dictionary<string, int> sizeStats;
 #endif
 
+        private protected readonly Func<string?> readStringDelegate;
+        private readonly Func<object?> readObjectDelegate;
+        private readonly Func<TypeRef?> readTypeRefDelegate;
+
         private readonly ImmutableDictionary<string, object?>.Builder metadataBuilder = ImmutableDictionary.CreateBuilder<string, object?>();
 
         private readonly byte[] guidBuffer = new byte[128 / 8];
 
         private long objectTableCapacityStreamPosition = -1; // -1 indicates the stream isn't capable of seeking.
-
-        private Func<string?>? readString;
-        private Func<TypeRef?>? readTypeRef;
-        private Func<object?>? readObject;
 
         internal SerializationContextBase(BinaryReader reader, Resolver resolver)
         {
@@ -68,6 +68,10 @@ namespace Microsoft.VisualStudio.Composition
 #if TRACESERIALIZATION || TRACESTATS
             this.trace = new IndentingTextWriter(new StreamWriter(File.OpenWrite(Environment.ExpandEnvironmentVariables(@"%TEMP%\VS-MEF.read.log"))));
 #endif
+
+            this.readStringDelegate = this.ReadString;
+            this.readObjectDelegate = this.ReadObject;
+            this.readTypeRefDelegate = this.ReadTypeRef;
         }
 
         internal SerializationContextBase(BinaryWriter writer, int estimatedObjectCount, Resolver resolver)
@@ -91,6 +95,10 @@ namespace Microsoft.VisualStudio.Composition
             Stream writerStream = writer.BaseStream;
             this.objectTableCapacityStreamPosition = writerStream.CanSeek ? writer.BaseStream.Position : -1;
             this.writer.Write(estimatedObjectCount);
+
+            this.readStringDelegate = this.ReadString;
+            this.readObjectDelegate = this.ReadObject;
+            this.readTypeRefDelegate = this.ReadTypeRef;
         }
 
         protected enum ObjectType : byte
@@ -204,12 +212,6 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private Func<TypeRef?> ReadTypeRefDelegate => this.readTypeRef ??= this.ReadTypeRef;
-
-        private Func<object?> ReadObjectDelegate => this.readObject ??= this.ReadObject;
-
-        protected Func<string?> ReadStringDelegate => this.readString ??= this.ReadString;
-
         protected MethodRef? ReadMethodRef()
         {
             using (this.Trace(nameof(MethodRef)))
@@ -221,8 +223,8 @@ namespace Microsoft.VisualStudio.Composition
                     var metadataToken = this.ReadCompressedMetadataToken(MetadataTokenType.Method);
                     var name = this.ReadString();
                     var isStatic = this.ReadCompressedUInt() != 0;
-                    var parameterTypes = this.ReadList(this.reader, this.ReadTypeRefDelegate).ToImmutableArray();
-                    var genericMethodArguments = this.ReadList(this.reader, this.ReadTypeRefDelegate).ToImmutableArray();
+                    var parameterTypes = this.ReadList(this.reader, this.readTypeRefDelegate).ToImmutableArray();
+                    var genericMethodArguments = this.ReadList(this.reader, this.readTypeRefDelegate).ToImmutableArray();
                     return new MethodRef(declaringType, metadataToken, name, isStatic, parameterTypes!, genericMethodArguments!);
                 }
                 else
@@ -474,12 +476,12 @@ namespace Microsoft.VisualStudio.Composition
                     var fullName = this.ReadString();
                     var flags = (TypeRefFlags)this.ReadCompressedUInt();
                     int genericTypeParameterCount = (int)this.ReadCompressedUInt();
-                    var genericTypeArguments = this.ReadList(this.reader, this.ReadTypeRefDelegate).ToImmutableArray();
+                    var genericTypeArguments = this.ReadList(this.reader, this.readTypeRefDelegate).ToImmutableArray();
 
                     var shallow = this.ReadCompressedUInt() != 0;
                     var baseTypes = shallow
                         ? ImmutableArray<TypeRef?>.Empty
-                        : this.ReadList(this.reader, this.ReadTypeRefDelegate).ToImmutableArray();
+                        : this.ReadList(this.reader, this.readTypeRefDelegate).ToImmutableArray();
 
                     var hasElementType = this.ReadCompressedUInt() != 0;
                     var elementType = hasElementType
@@ -1020,7 +1022,7 @@ namespace Microsoft.VisualStudio.Composition
                         return null;
                     case ObjectType.Array:
                         Type? elementType = this.ReadTypeRef().Resolve();
-                        return this.ReadArray(this.reader, this.ReadObjectDelegate, elementType);
+                        return this.ReadArray(this.reader, this.readObjectDelegate, elementType);
                     case ObjectType.BoolTrue:
                         return true;
                     case ObjectType.BoolFalse:
@@ -1065,7 +1067,7 @@ namespace Microsoft.VisualStudio.Composition
                         TypeRef? typeRef = this.ReadTypeRef();
                         return new LazyMetadataWrapper.TypeSubstitution(typeRef);
                     case ObjectType.TypeArraySubstitution:
-                        IReadOnlyList<TypeRef?> typeRefArray = this.ReadList(this.reader, this.ReadTypeRefDelegate);
+                        IReadOnlyList<TypeRef?> typeRefArray = this.ReadList(this.reader, this.readTypeRefDelegate);
                         return new LazyMetadataWrapper.TypeArraySubstitution(typeRefArray!, this.Resolver);
                     case ObjectType.BinaryFormattedObject:
                         var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();


### PR DESCRIPTION
Using the VS allocation profiler to watch VS startup, it's allocating ~230K `Func<>` delegates, almost all of which are coming from Microsoft.VisualStudio.Composition.  After this commit, that number drops to ~15K.