### PR TITLE
Avoid allocating empty arrays in ReadList

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -658,6 +658,11 @@ namespace Microsoft.VisualStudio.Composition
                     throw new NotSupportedException();
                 }
 
+                if (count == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
                 var list = new T[count];
                 for (int i = 0; i < list.Length; i++)
                 {


### PR DESCRIPTION
Appx 90K empty arrays are being created in ReadList at VS startup, mostly for TypeRef[].