### PR TITLE
Fix `PartDiscovery` assembly loading

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/CreateComposition.cs
@@ -537,7 +537,7 @@ namespace Microsoft.VisualStudio.Composition.AppHost
                 }
             }
 
-            public Assembly LoadAssembly(string assemblyFullName, string codeBasePath)
+            public Assembly LoadAssembly(string assemblyFullName, string? codeBasePath)
             {
                 Requires.NotNullOrEmpty(assemblyFullName, nameof(assemblyFullName));
 

--- a/src/Microsoft.VisualStudio.Composition/IAssemblyLoader.cs
+++ b/src/Microsoft.VisualStudio.Composition/IAssemblyLoader.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <param name="codeBasePath">The path to the assembly to load. May be null.</param>
         /// <returns>The loaded assembly. Never <c>null</c>.</returns>
         /// <exception cref="Exception">May be thrown if the assembly cannot be found or fails to load.</exception>
-        Assembly LoadAssembly(string assemblyFullName, string codeBasePath);
+        Assembly LoadAssembly(string assemblyFullName, string? codeBasePath);
 
         /// <summary>
         /// Loads an assembly with the specified name.

--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     try
                     {
-                        return new Assembly[] { Assembly.Load(AssemblyName.GetAssemblyName(path)) };
+                        return new Assembly[] { this.Resolver.AssemblyLoader.LoadAssembly(Utilities.GetAssemblyNameWithCodebasePath(path)) };
                     }
                     catch (Exception ex)
                     {

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Shipped.txt
@@ -155,7 +155,7 @@ Microsoft.VisualStudio.Composition.ExportedDelegate.CreateDelegate(System.Type! 
 Microsoft.VisualStudio.Composition.ExportedDelegate.ExportedDelegate(object? target, System.Reflection.MethodInfo! method) -> void
 Microsoft.VisualStudio.Composition.IAssemblyLoader
 Microsoft.VisualStudio.Composition.IAssemblyLoader.LoadAssembly(System.Reflection.AssemblyName! assemblyName) -> System.Reflection.Assembly!
-Microsoft.VisualStudio.Composition.IAssemblyLoader.LoadAssembly(string! assemblyFullName, string! codeBasePath) -> System.Reflection.Assembly!
+Microsoft.VisualStudio.Composition.IAssemblyLoader.LoadAssembly(string! assemblyFullName, string? codeBasePath) -> System.Reflection.Assembly!
 Microsoft.VisualStudio.Composition.ICompositionCacheManager
 Microsoft.VisualStudio.Composition.ICompositionCacheManager.LoadExportProviderFactoryAsync(System.IO.Stream! cacheStream, Microsoft.VisualStudio.Composition.Resolver! resolver, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Composition.IExportProviderFactory!>!
 Microsoft.VisualStudio.Composition.ICompositionCacheManager.SaveAsync(Microsoft.VisualStudio.Composition.CompositionConfiguration! configuration, System.IO.Stream! cacheStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.Composition/Resolver.cs
+++ b/src/Microsoft.VisualStudio.Composition/Resolver.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.Composition
             }
 
             /// <inheritdoc />
-            public Assembly LoadAssembly(string assemblyFullName, string codeBasePath)
+            public Assembly LoadAssembly(string assemblyFullName, string? codeBasePath)
             {
                 var assembly = this.inner.LoadAssembly(assemblyFullName, codeBasePath);
                 this.resolver.NotifyAssemblyLoaded(assembly, null);

--- a/src/Microsoft.VisualStudio.Composition/StandardAssemblyLoader.cs
+++ b/src/Microsoft.VisualStudio.Composition/StandardAssemblyLoader.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.Composition
         }
 
         /// <inheritdoc />
-        public Assembly LoadAssembly(string assemblyFullName, string codeBasePath)
+        public Assembly LoadAssembly(string assemblyFullName, string? codeBasePath)
         {
             Requires.NotNullOrEmpty(assemblyFullName, nameof(assemblyFullName));
 

--- a/src/Microsoft.VisualStudio.Composition/Utilities.cs
+++ b/src/Microsoft.VisualStudio.Composition/Utilities.cs
@@ -17,6 +17,22 @@ namespace Microsoft.VisualStudio.Composition
     {
         private const string CompositionErrorHeaderFormat = "----- CompositionError level {0} ------";
 
+        /// <summary>
+        /// Creates an <see cref="AssemblyName"/> that is guaranteed to have its <see cref="AssemblyName.CodeBase"/> property set.
+        /// </summary>
+        /// <param name="path">The path to the assembly to get the name for.</param>
+        /// <returns>An initialized <see cref="AssemblyName"/> instance.</returns>
+        internal static AssemblyName GetAssemblyNameWithCodebasePath(string path)
+        {
+            AssemblyName assemblyName = AssemblyName.GetAssemblyName(path);
+
+            // .NET Framework sets this, but .NET Core does not.
+            // .NET Core also *ignores* this even if set, by default. But a custom AssemblyLoadContext resolver could honor it if we preserve it.
+            assemblyName.CodeBase = path;
+
+            return assemblyName;
+        }
+
         internal static void WriteErrors(TextWriter textWriter, IImmutableStack<IReadOnlyCollection<ComposedPartDiagnostic>> errorStack)
         {
             int level = 1;

--- a/test/Microsoft.VisualStudio.Composition.Tests/CacheResiliencyTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/CacheResiliencyTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 this.substitutedAssemblyPath = substitutedAssemblyPath;
             }
 
-            public Assembly LoadAssembly(string assemblyFullName, string codeBasePath)
+            public Assembly LoadAssembly(string assemblyFullName, string? codeBasePath)
             {
                 return Assembly.LoadFile(codeBasePath);
             }


### PR DESCRIPTION
- Fix `PartDiscovery` to use `IAssemblyLoader`
- Fix nullable ref annotation on `IAssemblyLoader.LoadAssembly(string, string?)`