### PR TITLE
Additional Method to specify Resolver when combining PartDiscovery instances

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscovery.cs
@@ -36,6 +36,17 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>The aggregate PartDiscovery instance.</returns>
         public static PartDiscovery Combine(params PartDiscovery[] discoveryMechanisms)
         {
+            return Combine(Resolver.DefaultInstance, discoveryMechanisms);
+        }
+
+        /// <summary>
+        /// Creates an aggregate <see cref="PartDiscovery"/> instance that delegates to a series of other part discovery extensions.
+        /// </summary>
+        /// <param name="resolverToUse">The <see cref="Composition.Resolver"/> that the aggregate PartDiscovery instance should use.</param>
+        /// <param name="discoveryMechanisms">The discovery extensions to use. In some cases, extensions defined earlier in the list are preferred.</param>
+        /// <returns>The aggregate PartDiscovery instance with the specified resolver.</returns>
+        public static PartDiscovery Combine(Resolver resolverToUse, params PartDiscovery[] discoveryMechanisms)
+        {
             Requires.NotNull(discoveryMechanisms, nameof(discoveryMechanisms));
 
             if (discoveryMechanisms.Length == 1)
@@ -43,7 +54,7 @@ namespace Microsoft.VisualStudio.Composition
                 return discoveryMechanisms[0];
             }
 
-            return new CombinedPartDiscovery(discoveryMechanisms);
+            return new CombinedPartDiscovery(resolverToUse, discoveryMechanisms);
         }
 
         /// <summary>
@@ -638,8 +649,10 @@ namespace Microsoft.VisualStudio.Composition
         {
             private readonly IReadOnlyList<PartDiscovery> discoveryMechanisms;
 
-            internal CombinedPartDiscovery(IReadOnlyList<PartDiscovery> discoveryMechanisms)
-                : base(Resolver.DefaultInstance)
+            internal CombinedPartDiscovery(
+                Resolver resolverToUse,
+                IReadOnlyList<PartDiscovery> discoveryMechanisms)
+                : base(resolverToUse)
             {
                 Requires.NotNull(discoveryMechanisms, nameof(discoveryMechanisms));
                 this.discoveryMechanisms = discoveryMechanisms;

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Unshipped.txt
@@ -10,3 +10,4 @@ Microsoft.VisualStudio.Composition.ImportMetadataViewConstraint.MetadatumRequire
 Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override Microsoft.VisualStudio.Composition.CompositionFailedException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override Microsoft.VisualStudio.Composition.PartDiscoveryException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+static Microsoft.VisualStudio.Composition.PartDiscovery.Combine(Microsoft.VisualStudio.Composition.Resolver! resolverToUse, params Microsoft.VisualStudio.Composition.PartDiscovery![]! discoveryMechanisms) -> Microsoft.VisualStudio.Composition.PartDiscovery!

--- a/test/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/PartDiscoveryTests.cs
@@ -61,6 +61,17 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task DiscoveriesCombinedWithResolver()
+        {
+            LoggingAssemblyLoader assemblyLoader = new();
+            Resolver assemblyResolver = new(assemblyLoader);
+            var discovery = PartDiscovery.Combine(assemblyResolver, TestUtilities.V2Discovery, TestUtilities.V1Discovery);
+            string testAssemblyPath = typeof(PartDiscoveryTests).Assembly.Location;
+            await discovery.CreatePartsAsync(new string[] { testAssemblyPath });
+            Assert.Equal(new[] { testAssemblyPath }, assemblyLoader.AttemptedAssemblyPaths);
+        }
+
+        [Fact]
         public async Task Combined_CreatePartsAsync_AssemblyPathEnumerable()
         {
             var discovery = PartDiscovery.Combine(TestUtilities.V2Discovery, TestUtilities.V1Discovery);


### PR DESCRIPTION
- Added static method `Combine(Resolver resolverToUse, params PartDiscovery[] discoveryMechanisms)` to `PartDiscovery`