### PR TITLE
Remove LINQ/capture class allocations

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
+++ b/src/Microsoft.VisualStudio.Composition/LazyMetadataWrapper.cs
@@ -479,9 +479,9 @@ namespace Microsoft.VisualStudio.Composition
 
             internal static bool TrySubstituteValue(object value, Resolver resolver, [NotNullWhen(true)] out ISubstitutedValue? substitutedValue)
             {
-                if (value is Type[])
+                if (value is Type[] types)
                 {
-                    substitutedValue = new TypeArraySubstitution(((Type[])value).Select(t => TypeRef.Get(t, resolver)).ToImmutableArray(), resolver);
+                    substitutedValue = new TypeArraySubstitution(ReflectionHelpers.TypesToTypeRefs(types, resolver), resolver);
                     return true;
                 }
 

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -150,6 +150,20 @@ namespace Microsoft.VisualStudio.Composition
                 ?? ImmutableArray<TypeRef>.Empty;
         }
 
+        internal static IReadOnlyList<TypeRef> TypesToTypeRefs(Type[] types, Resolver resolver)
+        {
+            Requires.NotNull(types, nameof(types));
+
+            // This is a hot path during solution load, avoid allocating using LINQ
+            var builder = ImmutableArray.CreateBuilder<TypeRef>(types.Length);
+            foreach (Type type in types)
+            {
+                builder.Add(TypeRef.Get(type, resolver));
+            }
+
+            return builder.MoveToImmutable();
+        }
+
         internal static IEnumerable<PropertyInfo> EnumProperties(this Type type)
         {
             Requires.NotNull(type, nameof(type));

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -374,7 +374,7 @@ namespace Microsoft.VisualStudio.Composition
                     {
                         IEnumerable<TypeRef> typeArgs = typeArgsObject is LazyMetadataWrapper.TypeArraySubstitution
                             ? ((LazyMetadataWrapper.TypeArraySubstitution)typeArgsObject).TypeRefArray
-                            : ((Type[])typeArgsObject).Select(t => TypeRef.Get(t, part.TypeRef.Resolver));
+                            : ReflectionHelpers.TypesToTypeRefs((Type[])typeArgsObject, part.TypeRef.Resolver);
 
                         return part.TypeRef.MakeGenericTypeRef(typeArgs.ToImmutableArray());
                     }


### PR DESCRIPTION
This is a hot path during solution load.

![image](https://user-images.githubusercontent.com/1103906/143182117-8e6d178c-e350-488d-a520-1334d0871a00.png)

