### PR TITLE
Fix activation of open generic exports with multiple constructors

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/ResolverExtensions.cs
@@ -213,12 +213,22 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                     continue;
                 }
 
+                bool parameterMismatch = false;
                 for (int i = 0; i < parameters.Length; i++)
                 {
-                    if (!parameterTypes[i].Equals(parameters[i].ParameterType))
+                    // The TypeRef.Equals(Type) method calls TypeRef.Get(Type), which doesn't support generic type parameters.
+                    // We don't support generic type parameters appearing in importing constructors anyway, so if this
+                    // is a generic type parameter, disqualify this candidate entirely and skip the Equals check that would throw.
+                    if (parameters[i].ParameterType.IsGenericParameter || !parameterTypes[i].Equals(parameters[i].ParameterType))
                     {
-                        continue;
+                        parameterMismatch = true;
+                        break;
                     }
+                }
+
+                if (parameterMismatch)
+                {
+                    continue;
                 }
 
                 return member;

--- a/src/Microsoft.VisualStudio.Composition/Reflection/StrongAssemblyIdentity.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/StrongAssemblyIdentity.cs
@@ -83,17 +83,19 @@ namespace Microsoft.VisualStudio.Composition
         public override bool Equals(object? obj) => this.Equals(obj as StrongAssemblyIdentity);
 
         /// <inheritdoc/>
-        public bool Equals(StrongAssemblyIdentity? other)
-        {
-            return other != null
-                && ByValueEquality.AssemblyNameNoFastCheck.Equals(this.Name, other.Name)
-                && this.Mvid == other.Mvid;
-        }
+        public bool Equals(StrongAssemblyIdentity? other) => this.Equals(other, allowMvidMismatch: false);
 
         /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.Mvid.GetHashCode();
+        }
+
+        internal bool Equals(StrongAssemblyIdentity? other, bool allowMvidMismatch)
+        {
+            return other != null
+                && ByValueEquality.AssemblyNameNoFastCheck.Equals(this.Name, other.Name)
+                && (allowMvidMismatch || this.Mvid == other.Mvid);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -10,9 +10,6 @@ namespace Microsoft.VisualStudio.Composition
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
 
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
@@ -532,19 +529,21 @@ namespace Microsoft.VisualStudio.Composition
                         return null;
                     }
 
-                    var constructedPartType = GetPartConstructedTypeRef(this.partDefinition, this.importMetadata);
+                    var constructedPartTypeRef = GetPartConstructedTypeRef(this.partDefinition, this.importMetadata);
                     var ctorArgs = this.partDefinition.ImportingConstructorArguments
                         .Select(import => this.OwningExportProvider.GetValueForImportSite(this, import).Value).ToArray();
-                    MethodBase? importingConstructor = this.partDefinition.ImportingConstructorOrFactoryMethod!;
-                    if (importingConstructor.ContainsGenericParameters)
+                    MethodBase? importingConstructorOrFactoryMethod = this.partDefinition.ImportingConstructorOrFactoryMethod!;
+                    if (importingConstructorOrFactoryMethod.ContainsGenericParameters)
                     {
-                        // TODO: fix this to find the precise match, including cases where the matching constructor includes a generic type parameter.
-                        importingConstructor = constructedPartType.Resolve().GetTypeInfo().DeclaredConstructors.First(ctor => true);
+                        MethodBase? importingConstructorOrFactoryMethodOnClosedGeneric = ReflectionHelpers.MapOpenGenericMemberToClosedGeneric(
+                            importingConstructorOrFactoryMethod,
+                            constructedPartTypeRef.Resolve().GetTypeInfo()) ?? throw ReflectionHelpers.ThrowUnsupportedImportingConstructor(importingConstructorOrFactoryMethod);
+                        importingConstructorOrFactoryMethod = importingConstructorOrFactoryMethodOnClosedGeneric;
                     }
 
                     try
                     {
-                        object? part = importingConstructor.Instantiate(ctorArgs);
+                        object? part = importingConstructorOrFactoryMethod.Instantiate(ctorArgs);
                         return part;
                     }
                     catch (TargetInvocationException ex)

--- a/test/Microsoft.VisualStudio.Composition.Tests/OpenGenericExportTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/OpenGenericExportTests.cs
@@ -256,5 +256,41 @@ namespace Microsoft.VisualStudio.Composition.Tests
         internal class InternalUseful<T> : Useful<T> { }
 
         #endregion
+
+        #region ImportingConstructor with a generic type argument as a parameter
+
+        [MefFact(CompositionEngines.V1Compat | CompositionEngines.V2Compat, typeof(OpenGenericExportWithSeveralCtors<>), typeof(SimpleExport))]
+        public void ImportingConstructorWithGenericTypeArgumentSelection(IContainer container)
+        {
+            OpenGenericExportWithSeveralCtors<int> export = container.GetExportedValue<OpenGenericExportWithSeveralCtors<int>>();
+            Assert.NotNull(export);
+        }
+
+        [Export]
+        [MefV1.Export]
+        [MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
+        public class OpenGenericExportWithSeveralCtors<T>
+        {
+            public OpenGenericExportWithSeveralCtors(T arg)
+            {
+            }
+
+            [ImportingConstructor]
+            [MefV1.ImportingConstructor]
+            public OpenGenericExportWithSeveralCtors(SimpleExport arg1)
+            {
+            }
+
+            public OpenGenericExportWithSeveralCtors(string one, int two)
+            {
+            }
+        }
+
+        [Export]
+        [MefV1.Export]
+        [MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
+        public class SimpleExport { }
+
+        #endregion
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.VisualStudio.Composition.Tests.Reflection
         }
 
         [Fact]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         public void ThrowTypeLoadExceptionWhenArgIsNull()
         {
             var testGuid = new Guid("00000000-0000-0000-0000-000000000001");


### PR DESCRIPTION
A few bugs were fixed here:

1. The first goal was to resolve the "TODO" comment around selection of the right importing constructor on an open generic export. This fixes #281.
2. This led to discovery of a bug in `ResolverExtensions.FindMethodByParameters` that would match on methods without regard to parameter types matching. When a parameter type mismatched, it just moved onto the next parameter instead of skipping the method.
3. This in turn led to discovery of a bug in comparing `TypeRef` to `Type` where a mismatched MVID would reject the match, leading our 'slow reflection' tests to fail once the above bugs were fixed.