### PR TITLE
Improve error messages around part discovery

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
@@ -301,7 +301,7 @@ namespace Microsoft.VisualStudio.Composition
             var sharingBoundaryAttribute = member.GetFirstAttribute<SharingBoundaryAttribute>();
             if (sharingBoundaryAttribute != null)
             {
-                Verify.Operation(importingType.IsExportFactoryTypeV2(), Strings.IsExpectedOnlyOnImportsOfExportFactoryOfT, typeof(SharingBoundaryAttribute).Name);
+                Verify.Operation(importingType.IsExportFactoryTypeV2(), Strings.IsExpectedOnlyOnImportsOfExportFactoryOfTV2, typeof(SharingBoundaryAttribute).Name, importingType.FullName);
                 sharingBoundaries = sharingBoundaries.Union(sharingBoundaryAttribute.SharingBoundaryNames);
             }
 

--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscovery.cs
@@ -8,10 +8,9 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Immutable;
     using System.Composition;
     using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
 
     public class AttributedPartDiscovery : PartDiscovery
@@ -142,32 +141,46 @@ namespace Microsoft.VisualStudio.Composition
 
             foreach (var member in declaredProperties)
             {
-                var importAttribute = member.GetFirstAttribute<ImportAttribute>();
-                var importManyAttribute = member.GetFirstAttribute<ImportManyAttribute>();
-                Requires.Argument(!(importAttribute != null && importManyAttribute != null), "partType", Strings.MemberContainsBothImportAndImportMany, member.Name);
-
-                var importConstraints = GetImportConstraints(member);
-                ImportDefinition? importDefinition;
-                if (this.TryCreateImportDefinition(ReflectionHelpers.GetMemberType(member), member, importConstraints, out importDefinition))
+                try
                 {
-                    var importDefinitionBinding = new ImportDefinitionBinding(
-                        importDefinition,
-                        TypeRef.Get(partType, this.Resolver),
-                        MemberRef.Get(member, this.Resolver),
-                        TypeRef.Get(member.PropertyType, this.Resolver),
-                        TypeRef.Get(GetImportingSiteTypeWithoutCollection(importDefinition, member.PropertyType), this.Resolver));
-                    imports.Add(importDefinitionBinding);
+                    var importAttribute = member.GetFirstAttribute<ImportAttribute>();
+                    var importManyAttribute = member.GetFirstAttribute<ImportManyAttribute>();
+                    Requires.Argument(!(importAttribute != null && importManyAttribute != null), "partType", Strings.MemberContainsBothImportAndImportMany, member.Name);
+
+                    var importConstraints = GetImportConstraints(member);
+                    ImportDefinition? importDefinition;
+                    if (this.TryCreateImportDefinition(ReflectionHelpers.GetMemberType(member), member, importConstraints, out importDefinition))
+                    {
+                        var importDefinitionBinding = new ImportDefinitionBinding(
+                            importDefinition,
+                            TypeRef.Get(partType, this.Resolver),
+                            MemberRef.Get(member, this.Resolver),
+                            TypeRef.Get(member.PropertyType, this.Resolver),
+                            TypeRef.Get(GetImportingSiteTypeWithoutCollection(importDefinition, member.PropertyType), this.Resolver));
+                        imports.Add(importDefinitionBinding);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw ThrowErrorScanningMember(member, ex);
                 }
             }
 
             MethodInfo? onImportsSatisfied = null;
             foreach (var method in partTypeInfo.GetMethods(this.PublicVsNonPublicFlags | BindingFlags.Instance))
             {
-                if (method.IsAttributeDefined<OnImportsSatisfiedAttribute>())
+                try
                 {
-                    Verify.Operation(method.GetParameters().Length == 0, Strings.OnImportsSatisfiedTakeNoParameters);
-                    Verify.Operation(onImportsSatisfied == null, Strings.OnlyOneOnImportsSatisfiedMethodIsSupported);
-                    onImportsSatisfied = method;
+                    if (method.IsAttributeDefined<OnImportsSatisfiedAttribute>())
+                    {
+                        Verify.Operation(method.GetParameters().Length == 0, Strings.OnImportsSatisfiedTakeNoParameters);
+                        Verify.Operation(onImportsSatisfied == null, Strings.OnlyOneOnImportsSatisfiedMethodIsSupported);
+                        onImportsSatisfied = method;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw ThrowErrorScanningMember(method, ex);
                 }
             }
 
@@ -209,6 +222,8 @@ namespace Microsoft.VisualStudio.Composition
                 importingConstructorParameters.ToImmutable(),
                 partCreationPolicy,
                 assemblyNamesForMetadataAttributes);
+
+            static Exception ThrowErrorScanningMember(MemberInfo member, Exception ex) => throw new PartDiscoveryException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorWhileScanningMember, member.Name), ex);
         }
 
         public override bool IsExportFactoryType(Type type)

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -24,4 +24,17 @@
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
@@ -178,6 +178,15 @@ namespace Microsoft.VisualStudio.Composition {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error occurred while scanning member: &quot;{0}&quot;.
+        /// </summary>
+        internal static string ErrorWhileScanningMember {
+            get {
+                return ResourceManager.GetString("ErrorWhileScanningMember", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import &quot;{0}&quot; could not be satisfied..
         /// </summary>
         internal static string ErrorWhileSettingImport {

--- a/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.VisualStudio.Composition {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.Composition {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.Composition {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.Composition.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.Composition.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -557,19 +556,17 @@ namespace Microsoft.VisualStudio.Composition {
                 return ResourceManager.GetString("ReflectionTypeLoadExceptionWhileEnumeratingTypes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}: expected exactly 1 export matching constraints:
         ///{1} but the matching part has been invalidated..
         /// </summary>
-        internal static string RequiredImportHasBeenInvalidated
-        {
-            get
-            {
+        internal static string RequiredImportHasBeenInvalidated {
+            get {
                 return ResourceManager.GetString("RequiredImportHasBeenInvalidated", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Scanning MEF assemblies....
         /// </summary>
@@ -607,7 +604,7 @@ namespace Microsoft.VisualStudio.Composition {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type of metadata view is unsupported..
+        ///   Looks up a localized string similar to The type {0} is an unsupported type of metadata view..
         /// </summary>
         internal static string TypeOfMetadataViewUnsupported {
             get {

--- a/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
@@ -342,11 +342,11 @@ namespace Microsoft.VisualStudio.Composition {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is expected only on imports of ExportFactory&lt;T&gt;..
+        ///   Looks up a localized string similar to {0} is expected only on imports of System.Composition.ExportFactory&lt;T&gt; or System.Composition.ExportFactory&lt;T, TMetadata&gt;, but found {1} instead..
         /// </summary>
-        internal static string IsExpectedOnlyOnImportsOfExportFactoryOfT {
+        internal static string IsExpectedOnlyOnImportsOfExportFactoryOfTV2 {
             get {
-                return ResourceManager.GetString("IsExpectedOnlyOnImportsOfExportFactoryOfT", resourceCulture);
+                return ResourceManager.GetString("IsExpectedOnlyOnImportsOfExportFactoryOfTV2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -282,8 +282,8 @@
   <data name="ImportConstraintTypeNotSupported" xml:space="preserve">
     <value>The import constraint type {0} is not supported.</value>
   </data>
-  <data name="IsExpectedOnlyOnImportsOfExportFactoryOfT" xml:space="preserve">
-    <value>{0} is expected only on imports of ExportFactory&lt;T&gt;.</value>
+  <data name="IsExpectedOnlyOnImportsOfExportFactoryOfTV2" xml:space="preserve">
+    <value>{0} is expected only on imports of System.Composition.ExportFactory&lt;T&gt; or System.Composition.ExportFactory&lt;T, TMetadata&gt;, but found {1} instead.</value>
   </data>
   <data name="IsExportFactoryExpectedTrue" xml:space="preserve">
     <value>IsExportFactory is expected to be true.</value>

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -354,4 +354,7 @@
     <value>{0}: expected exactly 1 export matching constraints:
 {1} but the matching part has been invalidated.</value>
   </data>
+  <data name="ErrorWhileScanningMember" xml:space="preserve">
+    <value>Error occurred while scanning member: "{0}"</value>
+  </data>
 </root>


### PR DESCRIPTION
- One particular error message gets improved. 
- Other error messages now get wrapped in another InnerException layer so that more context is available in the overall error message. Specifically, an error while scanning a member now reveals which member was being scanned.