### PR TITLE
Build VSMefX for .NET Framework as well

### DIFF
--- a/Microsoft.VisualStudio.Composition.sln
+++ b/Microsoft.VisualStudio.Composition.sln
@@ -60,6 +60,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Composition.VSMefx", "src\Microsoft.VisualStudio.Composition.VSMefx\Microsoft.VisualStudio.Composition.VSMefx.csproj", "{6C73C7D0-819F-4194-AE36-FF86F248EC9E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VSMefx Test Projects", "VSMefx Test Projects", "{FDF383ED-AFFB-4FFD-833C-159114A986EC}"
+	ProjectSection(SolutionItems) = preProject
+		test\VS.Mefx.Tests\TestFiles\Directory.Build.props = test\VS.Mefx.Tests\TestFiles\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MefCalculator", "test\VS.Mefx.Tests\TestFiles\BasicScripts\MefCalculator\MefCalculator.csproj", "{6D3C3E5B-EAAE-4FF7-B486-2D4C6BABA15A}"
 EndProject

--- a/src/Microsoft.VisualStudio.Composition.VSMefx/Microsoft.VisualStudio.Composition.VSMefx.csproj
+++ b/src/Microsoft.VisualStudio.Composition.VSMefx/Microsoft.VisualStudio.Composition.VSMefx.csproj
@@ -2,19 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>vsmefx</AssemblyName>
     <ToolCommandName>vsmefx</ToolCommandName>
     <PackageId>$(MSBuildProjectName)</PackageId>
     <Description>A diagnostic tool to understand catalogs, compositions and diagnose issues in them.</Description>
+    <!-- Temporarily dispable packing to allow targeting net472. We need to figure out how to build both, and distribute each in a consumable way. -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OpenSoftware.DgmlBuilder" Version="1.15.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
-    <PackageReference Include="Nerdbank.NetStandardBridge" Version="1.1.3-alpha" />
+    <PackageReference Include="Nerdbank.NetStandardBridge" Version="1.1.9-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/VS.Mefx.Tests/TestFiles/BasicScripts/ExtendedOperations/ExtendedOperations.csproj
+++ b/test/VS.Mefx.Tests/TestFiles/BasicScripts/ExtendedOperations/ExtendedOperations.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>

--- a/test/VS.Mefx.Tests/TestFiles/BasicScripts/MefCalculator/MefCalculator.csproj
+++ b/test/VS.Mefx.Tests/TestFiles/BasicScripts/MefCalculator/MefCalculator.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>

--- a/test/VS.Mefx.Tests/TestFiles/Directory.Build.props
+++ b/test/VS.Mefx.Tests/TestFiles/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, Directory.Build.props))\Directory.Build.props" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, Directory.Build.props))' != '' " />
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/test/VS.Mefx.Tests/TestFiles/MatchingScripts/CarOne/CarOne.csproj
+++ b/test/VS.Mefx.Tests/TestFiles/MatchingScripts/CarOne/CarOne.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Composition.AttributedModel" Version="6.0.0" />
   </ItemGroup>

--- a/test/VS.Mefx.Tests/TestFiles/MatchingScripts/CarTwo/CarTwo.csproj
+++ b/test/VS.Mefx.Tests/TestFiles/MatchingScripts/CarTwo/CarTwo.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Composition.AttributedModel" Version="6.0.0" />
   </ItemGroup>

--- a/test/VS.Mefx.Tests/TestFiles/MatchingScripts/Garage/Garage.csproj
+++ b/test/VS.Mefx.Tests/TestFiles/MatchingScripts/Garage/Garage.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Composition.AttributedModel" Version="6.0.0" />
   </ItemGroup>

--- a/test/VS.Mefx.Tests/TestFiles/MatchingScripts/User/User.csproj
+++ b/test/VS.Mefx.Tests/TestFiles/MatchingScripts/User/User.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Composition.AttributedModel" Version="6.0.0" />
   </ItemGroup>

--- a/test/VS.Mefx.Tests/VS.Mefx.Tests.csproj
+++ b/test/VS.Mefx.Tests/VS.Mefx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>


### PR DESCRIPTION
This is important to avoid assembly load failures when scanning net472-targeted MEF catalog assemblies.

The dotnet tool package we were building breaks the build if the project includes .NET Framework targets, so I've disabled the package build for now. Eventually we may have to split this tool into two distinct projects if we want `dotnet tool` to continue to be a means of acquisition for the .NET Core build of the tool. But I wonder if instead we ought to have a single tool with a common front-end and then a separate process backend that can run on either .NET Core or .NET Framework as required to load the assemblies given in the catalog.