### PR TITLE
Avoid func/capture allocations for non-lazy items 

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -305,17 +305,7 @@ namespace Microsoft.VisualStudio.Composition
                 Requires.NotNull(exportingRuntimePart, nameof(exportingRuntimePart));
                 Requires.NotNull(originalPartTypeRef, nameof(originalPartTypeRef));
                 Requires.NotNull(constructedPartTypeRef, nameof(constructedPartTypeRef));
-
-                bool nonSharedInstanceRequired = !exportingRuntimePart.IsShared || import.IsNonSharedInstanceRequired;
-                Requires.Argument(importingPartTracker is object || !nonSharedInstanceRequired, nameof(importingPartTracker), "Value required for non-shared parts.");
-                RuntimePartLifecycleTracker? nonSharedPartOwner = nonSharedInstanceRequired && importingPartTracker!.IsNonShared && !import.IsExportFactory ? importingPartTracker : null;
-                PartLifecycleTracker partLifecycle = this.GetOrCreateValue(
-                    originalPartTypeRef,
-                    constructedPartTypeRef,
-                    exportingRuntimePart.SharingBoundary,
-                    import.Metadata,
-                    nonSharedInstanceRequired,
-                    nonSharedPartOwner);
+                PartLifecycleTracker partLifecycle = this.GetOrCreateValue(import, exportingRuntimePart, originalPartTypeRef, constructedPartTypeRef, importingPartTracker);
                 var faultCallback = this.faultCallback;
 
                 Func<object?> exportedValue = () =>
@@ -324,6 +314,26 @@ namespace Microsoft.VisualStudio.Composition
                 };
 
                 return new ExportedValueConstructor(partLifecycle, exportedValue);
+            }
+
+            private PartLifecycleTracker GetOrCreateValue(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimePart exportingRuntimePart, TypeRef originalPartTypeRef, TypeRef constructedPartTypeRef, RuntimePartLifecycleTracker? importingPartTracker)
+            {
+                Requires.NotNull(import, nameof(import));
+                Requires.NotNull(exportingRuntimePart, nameof(exportingRuntimePart));
+                Requires.NotNull(originalPartTypeRef, nameof(originalPartTypeRef));
+                Requires.NotNull(constructedPartTypeRef, nameof(constructedPartTypeRef));
+
+                bool nonSharedInstanceRequired = !exportingRuntimePart.IsShared || import.IsNonSharedInstanceRequired;
+                Requires.Argument(importingPartTracker is object || !nonSharedInstanceRequired, nameof(importingPartTracker), "Value required for non-shared parts.");
+                RuntimePartLifecycleTracker? nonSharedPartOwner = nonSharedInstanceRequired && importingPartTracker!.IsNonShared && !import.IsExportFactory ? importingPartTracker : null;
+
+                return this.GetOrCreateValue(
+                    originalPartTypeRef,
+                    constructedPartTypeRef,
+                    exportingRuntimePart.SharingBoundary,
+                    import.Metadata,
+                    nonSharedInstanceRequired,
+                    nonSharedPartOwner);
             }
 
             private static object? ConstructExportedValue(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimeExport export, RuntimePartLifecycleTracker? importingPartTracker, PartLifecycleTracker partLifecycle, ReportFaultCallback? faultCallback)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -298,14 +298,14 @@ namespace Microsoft.VisualStudio.Composition
             /// where it captures "this" in the closure for exportedValue, resulting in a memory leak
             /// which caused one of our GC unit tests to fail.
             /// </remarks>
-            private ExportedValueConstructor GetExportedValueHelper(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimeExport export, RuntimeComposition.RuntimePart exportingRuntimePart, TypeRef constructedPartTypeRef, RuntimePartLifecycleTracker? importingPartTracker)
+            private ExportedValueConstructor GetExportedValueHelper(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimeExport export, RuntimeComposition.RuntimePart exportingRuntimePart, TypeRef constructedType, RuntimePartLifecycleTracker? importingPartTracker)
             {
                 Requires.NotNull(import, nameof(import));
                 Requires.NotNull(export, nameof(export));
                 Requires.NotNull(exportingRuntimePart, nameof(exportingRuntimePart));
-                Requires.NotNull(constructedPartTypeRef, nameof(constructedPartTypeRef));
+                Requires.NotNull(constructedType, nameof(constructedType));
 
-                PartLifecycleTracker partLifecycle = this.GetOrCreateValue(import, exportingRuntimePart, exportingRuntimePart.TypeRef, constructedPartTypeRef, importingPartTracker);
+                PartLifecycleTracker partLifecycle = this.GetOrCreateValue(import, exportingRuntimePart, exportingRuntimePart.TypeRef, constructedType, importingPartTracker);
 
                 Func<object?> exportedValue = ConstructLazyExportedValue(import, export, importingPartTracker, partLifecycle, this.faultCallback);
 

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -286,25 +286,6 @@ namespace Microsoft.VisualStudio.Composition
 
                 var constructedType = GetPartConstructedTypeRef(exportingRuntimePart, import.Metadata);
 
-                return this.GetExportedValueHelper(import, export, exportingRuntimePart, constructedType, importingPartTracker);
-            }
-
-            /// <summary>
-            /// Called from <see cref="GetExportedValue(RuntimeComposition.RuntimeImport, RuntimeComposition.RuntimeExport, RuntimePartLifecycleTracker)"/>
-            /// only, as an assisting method. See remarks.
-            /// </summary>
-            /// <remarks>
-            /// This method is separate from its one caller to avoid a csc.exe compiler bug
-            /// where it captures "this" in the closure for exportedValue, resulting in a memory leak
-            /// which caused one of our GC unit tests to fail.
-            /// </remarks>
-            private ExportedValueConstructor GetExportedValueHelper(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimeExport export, RuntimeComposition.RuntimePart exportingRuntimePart, TypeRef constructedType, RuntimePartLifecycleTracker? importingPartTracker)
-            {
-                Requires.NotNull(import, nameof(import));
-                Requires.NotNull(export, nameof(export));
-                Requires.NotNull(exportingRuntimePart, nameof(exportingRuntimePart));
-                Requires.NotNull(constructedType, nameof(constructedType));
-
                 PartLifecycleTracker partLifecycle = this.GetOrCreateValue(import, exportingRuntimePart, exportingRuntimePart.TypeRef, constructedType, importingPartTracker);
 
                 Func<object?> exportedValue = ConstructLazyExportedValue(import, export, importingPartTracker, partLifecycle, this.faultCallback);

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 var constructedType = GetPartConstructedTypeRef(exportingRuntimePart, import.Metadata);
 
-                return this.GetExportedValueHelper(import, export, exportingRuntimePart, exportingRuntimePart.TypeRef, constructedType, importingPartTracker);
+                return this.GetExportedValueHelper(import, export, exportingRuntimePart, constructedType, importingPartTracker);
             }
 
             /// <summary>
@@ -298,15 +298,14 @@ namespace Microsoft.VisualStudio.Composition
             /// where it captures "this" in the closure for exportedValue, resulting in a memory leak
             /// which caused one of our GC unit tests to fail.
             /// </remarks>
-            private ExportedValueConstructor GetExportedValueHelper(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimeExport export, RuntimeComposition.RuntimePart exportingRuntimePart, TypeRef originalPartTypeRef, TypeRef constructedPartTypeRef, RuntimePartLifecycleTracker? importingPartTracker)
+            private ExportedValueConstructor GetExportedValueHelper(RuntimeComposition.RuntimeImport import, RuntimeComposition.RuntimeExport export, RuntimeComposition.RuntimePart exportingRuntimePart, TypeRef constructedPartTypeRef, RuntimePartLifecycleTracker? importingPartTracker)
             {
                 Requires.NotNull(import, nameof(import));
                 Requires.NotNull(export, nameof(export));
                 Requires.NotNull(exportingRuntimePart, nameof(exportingRuntimePart));
-                Requires.NotNull(originalPartTypeRef, nameof(originalPartTypeRef));
                 Requires.NotNull(constructedPartTypeRef, nameof(constructedPartTypeRef));
 
-                PartLifecycleTracker partLifecycle = this.GetOrCreateValue(import, exportingRuntimePart, originalPartTypeRef, constructedPartTypeRef, importingPartTracker);
+                PartLifecycleTracker partLifecycle = this.GetOrCreateValue(import, exportingRuntimePart, exportingRuntimePart.TypeRef, constructedPartTypeRef, importingPartTracker);
 
                 Func<object?> exportedValue = ConstructLazyExportedValue(import, export, importingPartTracker, partLifecycle, this.faultCallback);
 


### PR DESCRIPTION
Non-lazy imports were paying for capture and Func<T> creation, despite the Func<T> being invoked immediately after it was created. Instead take a different path for the lazy versus non-lazy case so that only Lazy<T> exports pays for the allocations.

This was allocating about 100 MB opening and closing Orchard Core, but the end result will depend on how many lazy versus non-lazy items are in the composition graph:

![image](https://user-images.githubusercontent.com/1103906/160767660-6b2e3eb5-1f81-4de9-a8c2-37a1e8fc9345.png)

This one was a bit tricky to approach to avoid leaking "this" and to handle export provider import and I took a few different paths, and ended up with this one. This one is much easier to read commit by commit.