### PR TITLE
Use ordinal comparisons

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/ExportMetadataViewInterfaceEmitProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/ExportMetadataViewInterfaceEmitProxy.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.Composition
                 if (method != null)
                 {
                     return method.IsSpecialName
-                        && method.Name.StartsWith("get_");
+                        && method.Name.StartsWith("get_", StringComparison.Ordinal);
                 }
 
                 return false;

--- a/src/Microsoft.VisualStudio.Composition/ExportFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Composition
             if (type != null && type.GetTypeInfo().IsGenericType)
             {
                 var typeDefinition = type.GetGenericTypeDefinition();
-                if (typeDefinition.FullName?.StartsWith(ExportFactoryV1FullName) ?? false)
+                if (typeDefinition.FullName?.StartsWith(ExportFactoryV1FullName, StringComparison.Ordinal) ?? false)
                 {
                     return true;
                 }
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.Composition
                 int arity = type.GenericTypeParameterCount + type.GenericTypeArguments.Length;
                 if (arity > 0 && arity <= 2)
                 {
-                    if (type.FullName?.StartsWith(ExportFactoryV1FullName) ?? false)
+                    if (type.FullName?.StartsWith(ExportFactoryV1FullName, StringComparison.Ordinal) ?? false)
                     {
                         return true;
                     }
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.Composition
             if (type != null && type.GetTypeInfo().IsGenericType)
             {
                 var typeDefinition = type.GetGenericTypeDefinition();
-                if (typeDefinition.FullName?.StartsWith(ExportFactoryV2FullName) ?? false)
+                if (typeDefinition.FullName?.StartsWith(ExportFactoryV2FullName, StringComparison.Ordinal) ?? false)
                 {
                     return true;
                 }
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.Composition
                 int arity = type.GenericTypeParameterCount + type.GenericTypeArguments.Length;
                 if (arity > 0 && arity <= 2)
                 {
-                    if (type.FullName?.StartsWith(ExportFactoryV2FullName) ?? false)
+                    if (type.FullName?.StartsWith(ExportFactoryV2FullName, StringComparison.Ordinal) ?? false)
                     {
                         return true;
                     }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -675,7 +675,7 @@ namespace Microsoft.VisualStudio.Composition
             if (method != null)
             {
                 // If the method came from a property, return the result of the property getter rather than return the delegate.
-                if (method.IsSpecialName && method.GetParameters().Length == 0 && method.Name.StartsWith("get_"))
+                if (method.IsSpecialName && method.GetParameters().Length == 0 && method.Name.StartsWith("get_", StringComparison.Ordinal))
                 {
                     return method.Invoke(exportingPart, EmptyObjectArray);
                 }


### PR DESCRIPTION
Reduce the time it takes to find v1 and v2 export factory instances, this was costing 200ms in Startup.BuildingMEFCache perf test. These were previously using cultural-aware comparisons.

CPU time:
![image](https://user-images.githubusercontent.com/1103906/174958583-2b080069-85d7-49e8-963a-80130d5d7b74.png)
