### PR TITLE
Cache assembly name retrieval

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ExportDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportDefinition.cs
@@ -69,11 +69,11 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        internal void GetInputAssemblies(ISet<AssemblyName> assemblies)
+        internal void GetInputAssemblies(ISet<AssemblyName> assemblies, Func<Assembly, AssemblyName> nameGetter)
         {
             Requires.NotNull(assemblies, nameof(assemblies));
 
-            ReflectionHelpers.GetInputAssembliesFromMetadata(assemblies, this.Metadata);
+            ReflectionHelpers.GetInputAssembliesFromMetadata(assemblies, this.Metadata, nameGetter);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/ImportDefinition.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportDefinition.cs
@@ -130,12 +130,13 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        internal void GetInputAssemblies(ISet<AssemblyName> assemblies)
+        internal void GetInputAssemblies(ISet<AssemblyName> assemblies, Func<Assembly, AssemblyName> nameRetriever)
         {
             Requires.NotNull(assemblies, nameof(assemblies));
+            Requires.NotNull(nameRetriever, nameof(nameRetriever));
 
             // TODO: consider the assembly dependencies brought in by constraints.
-            ReflectionHelpers.GetInputAssembliesFromMetadata(assemblies, this.Metadata);
+            ReflectionHelpers.GetInputAssembliesFromMetadata(assemblies, this.Metadata, nameRetriever);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/ImportDefinitionBinding.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportDefinitionBinding.cs
@@ -209,11 +209,12 @@ namespace Microsoft.VisualStudio.Composition
             indentingWriter.WriteLine("ImportingSiteType: {0}", this.ImportingSiteType);
         }
 
-        internal void GetInputAssemblies(ISet<AssemblyName> assemblies)
+        internal void GetInputAssemblies(ISet<AssemblyName> assemblies, Func<Assembly, AssemblyName> nameRetriever)
         {
             Requires.NotNull(assemblies, nameof(assemblies));
+            Requires.NotNull(nameRetriever, nameof(nameRetriever));
 
-            this.ImportDefinition.GetInputAssemblies(assemblies);
+            this.ImportDefinition.GetInputAssemblies(assemblies, nameRetriever);
             this.ComposablePartTypeRef.GetInputAssemblies(assemblies);
             this.ImportingMemberRef?.GetInputAssemblies(assemblies);
             this.ImportingParameterRef?.GetInputAssemblies(assemblies);


### PR DESCRIPTION
Assembly.GetName costs a lot both in CPU and allocations, avoid calculating it over and over again.

Allocations:

![image](https://user-images.githubusercontent.com/1103906/174967218-1ff819df-b199-44c0-8cc9-819cdae03e95.png)

CPU:

![image](https://user-images.githubusercontent.com/1103906/174967319-0195a16c-004b-44ad-a74d-de1123acaf49.png)
