### PR TITLE
Increase Windows job timeout to 100 minutes

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -11,6 +11,7 @@ parameters:
 jobs:
 - job: Windows
   pool: ${{ parameters.windowsPool }}
+  timeoutInMinutes: 100
   variables:
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     # https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline


### PR DESCRIPTION
60 minutes was the default and was too short in light of apiscan, which takes over 36 minutes in some cases.