### PR TITLE
Fix CI build by ignoring ibcmerge warnings

### DIFF
--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -46,7 +46,8 @@ stages:
 
 - stage: Build
   variables:
-    MSBuildTreatWarningsAsErrors: true
+    #MSBuildTreatWarningsAsErrors: true # disable till we switch from old ibcmerge data to optprof
+    TreatWarningsAsErrors: true # on while MSBuildTreatWarningsAsErrors is disabled
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     BuildConfiguration: Release
     NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages


### PR DESCRIPTION
The vs-mef CI pipeline has been broken for a while. I thought my last PR would fix it, but it only fixed one part, unblocking the next failure.

This PR should fix it totally. As evidence that it works: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=7486541&view=results