### PR TITLE
Rollback System.Collections.Immutable upgrade for analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <!-- Analyzers need to use older references to work in existing C# compilers. -->
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Update="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Update="System.Reflection.Metadata" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Analyzers must have older references so they work in older compilers.