### PR TITLE
Revert "Bump System.Collections.Immutable from 6.0.0 to 7.0.0 (#376)"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <!-- Analyzers need to use older references to work in existing C# compilers. -->
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Update="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Update="System.Reflection.Metadata" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This reverts commit bb0b0fde04d7f9828aa16ab8908bc4a4b1e02029.

#376 updated the version of SCI specifically that analyzers use, which breaks analyzers since the C# compiler only provides 6.0.0 of that assembly. 