### PR TITLE
Stabilize 17.7

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.7-preview",
+  "version": "17.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Version stabilization for 17.7 is underway for VSSDK packages, which includes vs-mef.

Tested locally with `dotnet pack -p:publicrelease=true` after committing.