### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,11 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableImportCompletion": true,
   "omnisharp.enableRoslynAnalyzers": true,
   "cSpell.words": [
     "dgml",
     "vsmefx"
-  ]
+  ],
+  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+  "dotnet.defaultSolution": "Microsoft.VisualStudio.Composition.sln"
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,8 +36,8 @@
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.console" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageVersion Include="xunit" Version="2.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
     <MicroBuildVersion>2.0.125</MicroBuildVersion>
     <CodeAnalysisVersionForAnalyzers>3.11.0</CodeAnalysisVersionForAnalyzers>
-    <CodeAnalysisVersion>4.4.0</CodeAnalysisVersion>
+    <CodeAnalysisVersion>4.6.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.1</CodefixTestingVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTestBase.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/AttributedPartDiscoveryTestBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             ComposablePartDefinition? result = this.DiscoveryService.CreatePart(typeof(NonSharedPart));
             Assert.NotNull(result);
-            Assert.Equal(1, result!.ExportedTypes.Count);
+            Assert.Single(result!.ExportedTypes);
             Assert.Empty(result.ImportingMembers);
             Assert.False(result.IsShared);
         }
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             ComposablePartDefinition? result = this.DiscoveryService.CreatePart(typeof(SharedPart));
             Assert.NotNull(result);
-            Assert.Equal(1, result!.ExportedTypes.Count);
+            Assert.Single(result!.ExportedTypes);
             Assert.Empty(result.ImportingMembers);
             Assert.True(result.IsShared);
         }

--- a/test/Microsoft.VisualStudio.Composition.Tests/ComposableCatalogTests2.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ComposableCatalogTests2.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             var catalog = ComposableCatalog.Create(discovery.Resolver).AddParts(
                 await discovery.CreatePartsAsync(typeof(NonExportingType), typeof(ExportingType)));
-            Assert.Equal(1, catalog.Parts.Count);
+            Assert.Single(catalog.Parts);
             Assert.Equal(typeof(ExportingType), catalog.Parts.Single().Type);
         }
 
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         [Fact]
         public void GetAssemblyInputs_Empty()
         {
-            Assert.Equal(0, TestUtilities.EmptyCatalog.GetInputAssemblies().Count);
+            Assert.Empty(TestUtilities.EmptyCatalog.GetInputAssemblies());
         }
 
         [Theory]

--- a/test/Microsoft.VisualStudio.Composition.Tests/CompositionFailedExceptionTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/CompositionFailedExceptionTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 configuration.ThrowOnErrors();
-                Assert.True(false, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (CompositionFailedException ex)
             {

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             public UninstantiatedNonSharedPart()
             {
-                Assert.False(true, "This should never be instantiated.");
+                Assert.Fail("This should never be instantiated.");
             }
 
             public void Dispose()
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 container.GetExportedValue<ThrowingPart>();
-                Assert.False(true, "An exception should have been thrown.");
+                Assert.Fail("An exception should have been thrown.");
             }
             catch { }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/ExportingMembersTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ExportingMembersTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 container.GetExportedValue<Func<string, string, bool>>("Method");
-                Assert.False(true, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (MefV1.ImportCardinalityMismatchException) { }
             catch (Microsoft.VisualStudio.Composition.CompositionFailedException) { } // V2/V3

--- a/test/Microsoft.VisualStudio.Composition.Tests/FaultyPartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/FaultyPartsTests.cs
@@ -310,7 +310,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 action();
-                Assert.False(true, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (CompositionFailedException ex)
             {

--- a/test/Microsoft.VisualStudio.Composition.Tests/ImportManyTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ImportManyTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             var extendable = container.GetExportedValue<ExtendableIList>();
             Assert.NotNull(extendable);
             Assert.NotNull(extendable.Extensions);
-            Assert.Equal(0, extendable.Extensions.Count);
+            Assert.Empty(extendable.Extensions);
         }
 
         [MefFact(CompositionEngines.V2Compat, typeof(ExtendableIList), typeof(ExtensionOne))]
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             var extendable = container.GetExportedValue<ExtendableIList>();
             Assert.NotNull(extendable);
             Assert.NotNull(extendable.Extensions);
-            Assert.Equal(1, extendable.Extensions.Count);
+            Assert.Single(extendable.Extensions);
             Assert.IsAssignableFrom<ExtensionOne>(extendable.Extensions.Single());
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/InvalidGraphTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/InvalidGraphTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 var throws = part.ImportOfUncreatablePart.Value;
-                Assert.False(true, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (CompositionFailedException) { }
             catch (MefV1.CompositionException) { }
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 var throws = part.LazyImportOfUncreatablePart.Value;
-                Assert.False(true, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (CompositionFailedException) { }
             catch (MefV1.CompositionException) { }

--- a/test/Microsoft.VisualStudio.Composition.Tests/LazyImportTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/LazyImportTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         public void LazyImportMany(IContainer container)
         {
             var lazyImport = container.GetExportedValue<ExportWithListOfLazyImport>();
-            Assert.Equal(1, lazyImport.AnotherExports.Count);
+            Assert.Single(lazyImport.AnotherExports);
             Assert.Equal(0, AnotherExport.ConstructionCount);
             Assert.False(lazyImport.AnotherExports[0].IsValueCreated);
             AnotherExport anotherExport = lazyImport.AnotherExports[0].Value;

--- a/test/Microsoft.VisualStudio.Composition.Tests/RejectionTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/RejectionTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             try
             {
                 var expectFailure = exports[0].ImportOfBrokenPart.Value;
-                Assert.False(true, "Some type of composition exception was expected here.");
+                Assert.Fail("Some type of composition exception was expected here.");
             }
             catch (CompositionFailedException)
             {

--- a/test/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryInvalidTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryInvalidTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 // But that's not really a tenable prospect and it's harder to reason over anyway.
                 // It makes sense that MEFv2 didn't allow this.
                 root.Factory.CreateExport();
-                Assert.False(true, "Expected exception not thrown.");
+                Assert.Fail("Expected exception not thrown.");
             }
             catch (CompositionFailedException) { }
             catch (System.Composition.Hosting.CompositionFailedException) { }

--- a/test/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/SharingBoundaryWithSharedTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             public SharedRootPartOnlyImportedFromChildScope()
             {
-                Assert.False(true, "This type should ever be constructed. It should be imported lazily and never constructed as part of a GC test.");
+                Assert.Fail("This type should ever be constructed. It should be imported lazily and never constructed as part of a GC test.");
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/LegacyMefTestCaseRunner.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/XunitExtensions/LegacyMefTestCaseRunner.cs
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
                     else if (message is TestPassed)
                     {
                         var passedMessage = (TestPassed)message;
-                        message = new TestFailed(passedMessage.Test, passedMessage.ExecutionTime, passedMessage.Output, new AssertActualExpectedException(false, true, "Expected invalid configuration but no exception thrown."));
+                        message = new TestFailed(passedMessage.Test, passedMessage.ExecutionTime, passedMessage.Output, new XunitException("Expected invalid configuration but no exception thrown."));
                         this.InvertedSuccesses++;
                     }
                 }


### PR DESCRIPTION
- Fix symbol file selection for R2R outputs
- Simplify `nbgv` invocation in ps1 scripts
- Skip compliance checks by default for build.yml
- Bump MicroBuild to 2.0.127
- Bump dotnet-coverage to 17.7.2
- Bump StyleCop.Analyzers.Unstable from 1.2.0.435 to 1.2.0.507 (#207)
- Bump dotnet-coverage from 17.7.2 to 17.7.3 (#208)
- Bump MicroBuildVersion to 2.0.130
- Allow VS Code its changes
- Bump Microsoft.NET.Test.Sdk to 17.6.3
- Bump powershell to 7.3.5
- Automatically include a README.md from the project directory
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump MicroBuildVersion to 2.0.131
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
- Dependabot to ignore dotnet-format
