### PR TITLE
Remove HasFlag usage as it's particularly slow on netfx

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/AttributedPartDiscoveryV1.cs
@@ -397,7 +397,7 @@ namespace Microsoft.VisualStudio.Composition
                             {
                                 if (result.ContainsKey(property.Name))
                                 {
-                                    string memberName = member.MemberType.HasFlag(MemberTypes.TypeInfo) || member.MemberType.HasFlag(MemberTypes.NestedType)
+                                    string memberName = (member.MemberType & (MemberTypes.TypeInfo | MemberTypes.NestedType)) != 0
                                         ? ((TypeInfo)member).FullName!
                                         : $"{member.DeclaringType?.FullName}.{member.Name}";
 

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -281,14 +281,14 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     var flags = (RuntimeImportFlags)this.reader!.ReadByte();
                     var cardinality =
-                        flags.HasFlag(RuntimeImportFlags.CardinalityOneOrZero) ? ImportCardinality.OneOrZero :
-                        flags.HasFlag(RuntimeImportFlags.CardinalityExactlyOne) ? ImportCardinality.ExactlyOne :
+                        (flags & RuntimeImportFlags.CardinalityOneOrZero) == RuntimeImportFlags.CardinalityOneOrZero ? ImportCardinality.OneOrZero :
+                        (flags & RuntimeImportFlags.CardinalityExactlyOne) == RuntimeImportFlags.CardinalityExactlyOne ? ImportCardinality.ExactlyOne :
                         ImportCardinality.ZeroOrMore;
-                    bool isExportFactory = flags.HasFlag(RuntimeImportFlags.IsExportFactory);
+                    bool isExportFactory = (flags & RuntimeImportFlags.IsExportFactory) == RuntimeImportFlags.IsExportFactory;
 
                     MemberRef? importingMember = default(MemberRef);
                     ParameterRef? importingParameter = default(ParameterRef);
-                    if (flags.HasFlag(RuntimeImportFlags.IsParameter))
+                    if ((flags & RuntimeImportFlags.IsParameter) == RuntimeImportFlags.IsParameter)
                     {
                         importingParameter = this.ReadParameterRef();
                     }
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.Composition
                             importingSiteTypeWithoutCollectionRef,
                             cardinality,
                             satisfyingExports!,
-                            flags.HasFlag(RuntimeImportFlags.IsNonSharedInstanceRequired),
+                            (flags & RuntimeImportFlags.IsNonSharedInstanceRequired) == RuntimeImportFlags.IsNonSharedInstanceRequired,
                             isExportFactory,
                             metadata,
                             exportFactorySharingBoundaries!)
@@ -323,7 +323,7 @@ namespace Microsoft.VisualStudio.Composition
                             importingSiteTypeWithoutCollectionRef,
                             cardinality,
                             satisfyingExports!,
-                            flags.HasFlag(RuntimeImportFlags.IsNonSharedInstanceRequired),
+                            (flags & RuntimeImportFlags.IsNonSharedInstanceRequired) == RuntimeImportFlags.IsNonSharedInstanceRequired,
                             isExportFactory,
                             metadata,
                             exportFactorySharingBoundaries!);


### PR DESCRIPTION
HasFlag is boxing the RuntimeImportFlags enum.

Image below is from a trace gathered when opening vs with a up to date MEF cache. IncPats is modified to just include Microsoft.VisualStudio.Composition, which indicates that this boxing is responsible for about 10% of allocations under callstacks including this namespace.

![image](https://github.com/microsoft/vs-mef/assets/6785178/d43b8fb1-2978-4b24-bcb4-8314029b4132)
