### PR TITLE
Fix recursive type discovery

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/PartDiscoveryException.cs
+++ b/src/Microsoft.VisualStudio.Composition/PartDiscoveryException.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
+    using System.Globalization;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -23,7 +24,7 @@ namespace Microsoft.VisualStudio.Composition
         /// Initializes a new instance of the <see cref="PartDiscoveryException"/> class.
         /// </summary>
         /// <param name="message"><inheritdoc cref="Exception(string?)" path="/param[@name='message']"/></param>
-        public PartDiscoveryException(string message)
+        public PartDiscoveryException(string? message)
             : base(message)
         {
         }
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.Composition
         /// </summary>
         /// <param name="message"><inheritdoc cref="Exception(string?, Exception?)" path="/param[@name='message']"/></param>
         /// <param name="innerException"><inheritdoc cref="Exception(string?, Exception?)" path="/param[@name='innerException']"/></param>
-        public PartDiscoveryException(string message, Exception innerException)
+        public PartDiscoveryException(string? message, Exception? innerException)
             : base(message, innerException)
         {
         }
@@ -67,6 +68,27 @@ namespace Microsoft.VisualStudio.Composition
 
             info.AddValue(nameof(this.AssemblyPath), this.AssemblyPath);
             info.AddValue(nameof(this.ScannedType), this.ScannedType);
+        }
+
+        [Serializable]
+        internal class RecursiveTypeException : PartDiscoveryException
+        {
+            public RecursiveTypeException(Type type, Exception? innerException)
+                : base(string.Format(CultureInfo.CurrentCulture, Strings.TypeRefCycle, type.FullName), innerException)
+            {
+                this.ScannedType = type;
+                this.AssemblyPath = type.Assembly.Location;
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="RecursiveTypeException"/> class.
+            /// </summary>
+            /// <param name="info"><inheritdoc cref="Exception(SerializationInfo, StreamingContext)" path="/param[@name='info']"/></param>
+            /// <param name="context"><inheritdoc cref="Exception(SerializationInfo, StreamingContext)" path="/param[@name='context']"/></param>
+            protected RecursiveTypeException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+            {
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Composition/PublicAPI.Shipped.txt
@@ -233,8 +233,8 @@ Microsoft.VisualStudio.Composition.PartDiscoveryException
 Microsoft.VisualStudio.Composition.PartDiscoveryException.AssemblyPath.get -> string?
 Microsoft.VisualStudio.Composition.PartDiscoveryException.AssemblyPath.set -> void
 Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException() -> void
-Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string! message) -> void
-Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string! message, System.Exception! innerException) -> void
+Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string? message) -> void
+Microsoft.VisualStudio.Composition.PartDiscoveryException.PartDiscoveryException(string? message, System.Exception? innerException) -> void
 Microsoft.VisualStudio.Composition.PartDiscoveryException.ScannedType.get -> System.Type?
 Microsoft.VisualStudio.Composition.PartDiscoveryException.ScannedType.set -> void
 Microsoft.VisualStudio.Composition.Reflection.FieldRef

--- a/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
@@ -613,6 +613,15 @@ namespace Microsoft.VisualStudio.Composition {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} is part of a type reference cycle or references a type with a reference cycle..
+        /// </summary>
+        internal static string TypeRefCycle {
+            get {
+                return ResourceManager.GetString("TypeRefCycle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to determine the primary sharing boundary for MEF part &quot;{0}&quot;..
         /// </summary>
         internal static string UnableToDeterminePrimarySharingBoundary {

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -354,4 +354,7 @@
   <data name="ErrorWhileScanningMember" xml:space="preserve">
     <value>Error occurred while scanning member: "{0}"</value>
   </data>
+  <data name="TypeRefCycle" xml:space="preserve">
+    <value>{0} is part of a type reference cycle or references a type with a reference cycle.</value>
+  </data>
 </root>

--- a/test/Microsoft.VisualStudio.Composition.Tests/CacheAndReloadTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/CacheAndReloadTests.cs
@@ -44,36 +44,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(export);
         }
 
-        [Fact]
-        public async Task CacheAndReload_RecursiveType()
-        {
-            ComposableCatalog catalog = TestUtilities.EmptyCatalog.AddParts(
-                await TestUtilities.V2Discovery.CreatePartsAsync(typeof(SomeExport), typeof(DirectlyRecursiveType)));
-            var configuration = CompositionConfiguration.Create(catalog);
-            var ms = new MemoryStream();
-            await this.cacheManager.SaveAsync(configuration, ms);
-            configuration = null;
-
-            ms.Position = 0;
-            var exportProviderFactory = await this.cacheManager.LoadExportProviderFactoryAsync(ms, TestUtilities.Resolver);
-            var container = exportProviderFactory.CreateExportProvider();
-
-            SomeExport export = container.GetExportedValue<SomeExport>();
-            Assert.NotNull(export);
-
-            DirectlyRecursiveType recursiveExport = container.GetExportedValue<DirectlyRecursiveType>();
-            Assert.NotNull(recursiveExport);
-        }
-
         [Export]
         public class SomeExport { }
-
-        [Export]
-        private class DirectlyRecursiveType : IEnumerable<DirectlyRecursiveType>
-        {
-            public IEnumerator<DirectlyRecursiveType> GetEnumerator() => throw new NotImplementedException();
-
-            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
-        }
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/CacheAndReloadTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/CacheAndReloadTests.cs
@@ -44,7 +44,36 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.NotNull(export);
         }
 
+        [Fact]
+        public async Task CacheAndReload_RecursiveType()
+        {
+            ComposableCatalog catalog = TestUtilities.EmptyCatalog.AddParts(
+                await TestUtilities.V2Discovery.CreatePartsAsync(typeof(SomeExport), typeof(DirectlyRecursiveType)));
+            var configuration = CompositionConfiguration.Create(catalog);
+            var ms = new MemoryStream();
+            await this.cacheManager.SaveAsync(configuration, ms);
+            configuration = null;
+
+            ms.Position = 0;
+            var exportProviderFactory = await this.cacheManager.LoadExportProviderFactoryAsync(ms, TestUtilities.Resolver);
+            var container = exportProviderFactory.CreateExportProvider();
+
+            SomeExport export = container.GetExportedValue<SomeExport>();
+            Assert.NotNull(export);
+
+            DirectlyRecursiveType recursiveExport = container.GetExportedValue<DirectlyRecursiveType>();
+            Assert.NotNull(recursiveExport);
+        }
+
         [Export]
         public class SomeExport { }
+
+        [Export]
+        private class DirectlyRecursiveType : IEnumerable<DirectlyRecursiveType>
+        {
+            public IEnumerator<DirectlyRecursiveType> GetEnumerator() => throw new NotImplementedException();
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+        }
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
@@ -83,17 +83,25 @@ namespace Microsoft.VisualStudio.Composition.Tests.Reflection
         [Fact]
         public void Get_DirectlyRecursiveType()
         {
-            TypeRef typeRef = TypeRef.Get(typeof(DirectlyRecursiveType), Resolver.DefaultInstance);
-            Assert.NotNull(typeRef);
-            Assert.Same(typeRef, typeRef.ElementTypeRef);
+            PartDiscoveryException ex = Assert.ThrowsAny<PartDiscoveryException>(() => TypeRef.Get(typeof(DirectlyRecursiveType), Resolver.DefaultInstance));
+            Assert.Same(typeof(DirectlyRecursiveType), ex.ScannedType);
         }
 
         [Fact]
         public void Get_IndirectlyRecursiveType()
         {
-            TypeRef typeRef = TypeRef.Get(typeof(IndirectlyRecursiveTypeA), Resolver.DefaultInstance);
-            Assert.NotNull(typeRef);
-            Assert.Same(typeRef, typeRef.ElementTypeRef.ElementTypeRef);
+            PartDiscoveryException ex = Assert.ThrowsAny<PartDiscoveryException>(() => TypeRef.Get(typeof(IndirectlyRecursiveTypeA), Resolver.DefaultInstance));
+            Assert.Same(typeof(IndirectlyRecursiveTypeA), ex.ScannedType);
+
+            Assert.NotNull(ex.InnerException);
+            ex = (PartDiscoveryException)ex.InnerException;
+            Assert.Same(typeof(IndirectlyRecursiveTypeB), ex.ScannedType);
+
+            Assert.NotNull(ex.InnerException);
+            ex = (PartDiscoveryException)ex.InnerException;
+            Assert.Same(typeof(IndirectlyRecursiveTypeA), ex.ScannedType);
+
+            Assert.Null(ex.InnerException);
         }
 
         private void TestAssemblyNameEqualityNotEqual(string assemblyNameV1String, string assemblyNameV2String, string codeBaseV1, string codeBaseV2, Guid mvidV1, Guid mvidV2)

--- a/test/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/Reflection/TypeRefTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.Composition.Tests.Reflection
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -79,6 +80,22 @@ namespace Microsoft.VisualStudio.Composition.Tests.Reflection
             Assert.Contains("Could not load type 'Fake assembly", actualException.Message);
         }
 
+        [Fact]
+        public void Get_DirectlyRecursiveType()
+        {
+            TypeRef typeRef = TypeRef.Get(typeof(DirectlyRecursiveType), Resolver.DefaultInstance);
+            Assert.NotNull(typeRef);
+            Assert.Same(typeRef, typeRef.ElementTypeRef);
+        }
+
+        [Fact]
+        public void Get_IndirectlyRecursiveType()
+        {
+            TypeRef typeRef = TypeRef.Get(typeof(IndirectlyRecursiveTypeA), Resolver.DefaultInstance);
+            Assert.NotNull(typeRef);
+            Assert.Same(typeRef, typeRef.ElementTypeRef.ElementTypeRef);
+        }
+
         private void TestAssemblyNameEqualityNotEqual(string assemblyNameV1String, string assemblyNameV2String, string codeBaseV1, string codeBaseV2, Guid mvidV1, Guid mvidV2)
         {
             AssemblyName assemblyNameV1 = new AssemblyName(assemblyNameV1String);
@@ -92,6 +109,27 @@ namespace Microsoft.VisualStudio.Composition.Tests.Reflection
             TypeRef typeRefV2 = TypeRef.Get(TestUtilities.Resolver, assemblyIdentityV2, 0x02000001, "SomeType", TypeRefFlags.None, 0, ImmutableArray<TypeRef>.Empty, false, ImmutableArray<TypeRef>.Empty, null);
 
             Assert.NotEqual(typeRefV1, typeRefV2);
+        }
+
+        private class DirectlyRecursiveType : IEnumerable<DirectlyRecursiveType>
+        {
+            public IEnumerator<DirectlyRecursiveType> GetEnumerator() => throw new NotImplementedException();
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+        }
+
+        private class IndirectlyRecursiveTypeA : IEnumerable<IndirectlyRecursiveTypeB>
+        {
+            public IEnumerator<IndirectlyRecursiveTypeB> GetEnumerator() => throw new NotImplementedException();
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+        }
+
+        private class IndirectlyRecursiveTypeB : IEnumerable<IndirectlyRecursiveTypeA>
+        {
+            public IEnumerator<IndirectlyRecursiveTypeA> GetEnumerator() => throw new NotImplementedException();
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
## Bug being fixed
When a type references itself in its declaration (e.g. `class A : IEnumerable<A>`), VS-MEF would crash the process with a stack overflow. 

## Fix
While supporting such a case *may* be fairly simple in principle, serialization of the catalog with reference cycles goes beyond what our current serialization technology can handle. So instead of supporting such cycles by allowing them to be legit types in the catalog, I 'support' them by recognizing and throwing them _out_ of the catalog, and logging the error.

The first of the commits in this PR actually worked toward fully supporting recursive MEF parts, but the subsequent commit buries it. If we ever decide to support it, that commit can be resurrected as it gets us a first step toward supporting it.