### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.2",
+      "version": "7.4.3",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.0",
+      "version": "17.11.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.133",
+      "version": "3.6.139",
       "commands": [
         "nbgv"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 
 # mac-created file to track user view preferences for a directory
 .DS_Store
+
+# Analysis results
+*.sarif

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -57,23 +56,4 @@
       <PackageReleaseNotes Condition="'$(PackageProjectUrl)'!=''">$(PackageProjectUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
-
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  <!--
-    Inspired by https://github.com/dotnet/arcade/blob/cbfa29d4e859622ada3d226f90f103f659665d31/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props#L14-L31
-
-    Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
-    The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
-    It's also not necessary to generate these assets.
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
-    <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
+    <LangVersion Condition="'$(Language)'=='C#'">12</LangVersion>
+    <LangVersion Condition="'$(Language)'=='VB'">16.9</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,10 +56,7 @@
     <GlobalPackageReference Include="Required" Version="1.0.0" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -35,7 +35,7 @@
 .PARAMETER SourceCodeArchivalUri
     The URI to POST the source code archival request to.
     This value will typically come automatically by a variable group associated with your pipeline.
-    You can also look it up at https://dpsrequestforms.azurewebsites.net/#/help -> SCA Request Help -> SCA API Help -> Description
+    You can also look it up at https://dpsopsrequestforms.azurewebsites.net/#/help -> SCA Request Help -> SCA API Help -> Description
 #>
 [CmdletBinding(SupportsShouldProcess = $true, PositionalBinding = $false)]
 param (
@@ -76,7 +76,9 @@ param (
     [Parameter()]
     [string]$ServerPath = '',
     [Parameter()]
-    [Uri]$SourceCodeArchivalUri = $env:SOURCECODEARCHIVALURI
+    [Uri]$SourceCodeArchivalUri = $env:SOURCECODEARCHIVALURI,
+    [Parameter(Mandatory = $true)]
+    [string]$AccessToken
 )
 
 function Invoke-Git() {
@@ -199,9 +201,13 @@ if ($PSCmdlet.ShouldProcess('source archival request', 'post')) {
         exit 1
     }
 
+    $headers = @{
+        'Authorization' = "Bearer $AccessToken"
+    }
+
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-    $Response = Invoke-WebRequest -Uri $SourceCodeArchivalUri -Method POST -Body $RequestJson -ContentType "application/json" -UseBasicParsing -SkipHttpErrorCheck
+    $Response = Invoke-WebRequest -Uri $SourceCodeArchivalUri -Method POST -Headers $headers -Body $RequestJson -ContentType "application/json" -UseBasicParsing -SkipHttpErrorCheck
     Write-Host "Status Code : " -NoNewline
     if ($Response.StatusCode -eq 200) {
         Write-Host $Response.StatusCode -ForegroundColor Green

--- a/azure-pipelines/WIFtoPATauth.yml
+++ b/azure-pipelines/WIFtoPATauth.yml
@@ -1,0 +1,22 @@
+parameters:
+- name: deadPATServiceConnectionId # The GUID of the PAT-based service connection whose access token must be replaced.
+  type: string
+- name: wifServiceConnectionName # The name of the WIF service connection to use to get the access token.
+  type: string
+- name: resource # The scope for which the access token is requested.
+  type: string
+  default: 499b84ac-1321-427f-aa17-267ca6975798 # Azure Artifact feeds (any of them)
+
+steps:
+- task: AzureCLI@2
+  displayName: 🔏 Authenticate with WIF service connection
+  inputs:
+    azureSubscription: ${{ parameters.wifServiceConnectionName }}
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      $accessToken = az account get-access-token --query accessToken --resource '${{ parameters.resource }}' -o tsv
+      # Set the access token as a secret, so it doesn't get leaked in the logs
+      Write-Host "##vso[task.setsecret]$accessToken"
+      # Override the apitoken of the nuget service connection, for the duration of this stage
+      Write-Host "##vso[task.setendpoint id=${{ parameters.deadPATServiceConnectionId }};field=authParameter;key=apitoken]$accessToken"

--- a/azure-pipelines/archive-sourcecode.yml
+++ b/azure-pipelines/archive-sourcecode.yml
@@ -63,7 +63,16 @@ extends:
         - powershell: azure-pipelines/variables/_pipelines.ps1
           failOnStderr: true
           displayName: ⚙ Set pipeline variables based on source
-        - powershell: >
+        - task: AzureCLI@2
+          displayName: 🔏 Authenticate with WIF service connection
+          inputs:
+            azureSubscription: VS Core Source Code Archival
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $accessToken = az account get-access-token --query accessToken --resource api://177cf50a-4bf5-4481-8b7e-f32900dfc8e6 -o tsv
+              Write-Host "##vso[task.setvariable variable=scaToken;issecret=true]$accessToken"
+        - pwsh: >
             $TeamAlias = '$(TeamEmail)'.Substring(0, '$(TeamEmail)'.IndexOf('@'))
 
             azure-pipelines/Archive-SourceCode.ps1
@@ -73,6 +82,7 @@ extends:
             -ProductName '$(SymbolsFeatureName)'
             -ProductLanguage English
             -Notes '${{ parameters.notes }}'
+            -AccessToken '$(scaToken)'
             -Verbose
             -WhatIf:$${{ parameters.whatif }}
           displayName: 🗃️ Submit archival request

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -1,14 +1,23 @@
 parameters:
-  initArgs:
+- name: initArgs
+  type: string
+  default: ''
+- name: needsAzurePublicFeeds
+  type: boolean
+  default: true # If nuget.config pulls from the azure-public account, we need to authenticate when building on the devdiv account.
 
 steps:
+- ${{ if and(parameters.needsAzurePublicFeeds, eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9')) }}:
+  - template: WIFtoPATauth.yml
+    parameters:
+      wifServiceConnectionName: azure-public/vside package pull
+      deadPATServiceConnectionId: 0ae39abc-4d06-4436-a7b5-865833df49db # azure-public/msft_consumption
 
 - task: NuGetAuthenticate@1
   displayName: 🔏 Authenticate NuGet feeds
   inputs:
-    ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
-      nuGetServiceConnections: azure-public/msft_consumption # Only necessary for GitHub-hosted repos
-    forceReinstallCredentialProvider: true
+    ${{ if and(parameters.needsAzurePublicFeeds, eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9')) }}:
+      nuGetServiceConnections: azure-public/msft_consumption
 
 - powershell: |
     $AccessToken = '$(System.AccessToken)' # Avoid specifying the access token directly on the init.ps1 command line to avoid it showing up in errors

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -12,7 +12,7 @@ steps:
   inputs:
     ApprovalListPathForCerts: $(Build.SourcesDirectory)\azure-pipelines\no_authenticode.txt
     TargetFolders: |
-      $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)/NuGet
+      $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - ${{ if parameters.IsOptProf }}:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -23,10 +23,10 @@ parameters:
 # As an entrypoint pipeline yml file, all parameters here show up in the Queue Run dialog.
 # If any paramaters should NOT be queue-time options, they should be removed from here
 # and references to them in this file replaced with hard-coded values.
-- name: RealSign
-  displayName: Real sign?
+- name: ForceOfficialBuild
+  displayName: Official build (sign, compliance, etc.)
   type: boolean
-  default: false
+  default: false # this should remain false so PR builds using this pipeline are unofficial
 - name: ShouldSkipOptimize # Uncomment this and references to it below when setting EnableOptProf to true in build.yml.
   displayName: Skip OptProf optimization
   type: boolean
@@ -39,12 +39,8 @@ parameters:
   displayName: Run tests
   type: boolean
   default: true
-- name: EnableCompliance
-  displayName: Run Compliance Tools
-  type: boolean
-  default: true
 - name: EnableAPIScan
-  displayName: Include APIScan with Compliance tools
+  displayName: Include APIScan with compliance tools
   type: boolean
   default: false # enable in individual repos only AFTER updating TSAOptions.json with your own values
 
@@ -59,18 +55,22 @@ variables:
 - template: GlobalVariables.yml
 
 extends:
-  ${{ if parameters.EnableCompliance }}:
+  ${{ if or(parameters.ForceOfficialBuild, eq(variables['Build.Reason'],'Schedule')) }}:
     template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
     parameters:
       sdl:
         sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+        codeSignValidation:
+          enabled: true
+          break: true
+          additionalTargetsGlobPattern: -|Variables-*\*.ps1;-|APIScanInputs-*\**;-|test_symbols-*\**;-|MicroBuild\**
         policheck:
           enabled: true
           exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
         suppression:
           suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
         sbom:
-          enabled: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }} # Disable the generation for SBOMs for artifacts in unsigned builds since it's slow
+          enabled: true
       stages:
       - stage: Build
         variables:
@@ -79,9 +79,9 @@ extends:
         - template: /azure-pipelines/build.yml@self
           parameters:
             Is1ESPT: true
-            RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+            RealSign: true
             ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
-            EnableAPIScan: ${{ and(parameters.EnableCompliance, parameters.EnableAPIScan, ne(variables['Build.Reason'], 'pullRequest')) }}
+            EnableAPIScan: ${{ and(parameters.EnableAPIScan, ne(variables['Build.Reason'], 'pullRequest')) }}
             windowsPool: VSEngSS-MicroBuild2022-1ES
             linuxPool:
               name: AzurePipelines-EO
@@ -96,7 +96,7 @@ extends:
             RunTests: ${{ parameters.RunTests }}
       - template: /azure-pipelines/prepare-insertion-stages.yml@self
         parameters:
-          RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+          RealSign: true
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
     parameters:
@@ -112,9 +112,9 @@ extends:
         - template: /azure-pipelines/build.yml@self
           parameters:
             Is1ESPT: true
-            RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+            RealSign: false
             ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
-            EnableAPIScan: ${{ and(parameters.EnableCompliance, parameters.EnableAPIScan, ne(variables['Build.Reason'], 'pullRequest')) }}
+            EnableAPIScan: false
             windowsPool: VSEngSS-MicroBuild2022-1ES
             linuxPool:
               name: AzurePipelines-EO
@@ -129,4 +129,4 @@ extends:
             RunTests: ${{ parameters.RunTests }}
       - template: /azure-pipelines/prepare-insertion-stages.yml@self
         parameters:
-          RealSign: ${{ or(parameters.RealSign, eq(variables['Build.Reason'],'Schedule')) }}
+          RealSign: false

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -61,3 +61,7 @@ stages:
       - download: current
         artifact: deployables-Windows
         displayName: 🔻 Download deployables-Windows artifact
+      - template: WIFtoPATauth.yml
+        parameters:
+          wifServiceConnectionName: azure-public/vside package push
+          deadPATServiceConnectionId: 207efd62-fd0f-43e7-aeae-17c4febcc660 # azure-public/vs-impl

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -57,6 +57,7 @@ extends:
             InsertionReviewers: $(Build.RequestedFor),Andrew Arnott,Ankit Varma
             AutoCompletePR: true
             AutoCompleteMergeStrategy: Squash
+            ShallowClone: true
         - powershell: |
             $contentType = 'application/json';
             $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -80,6 +80,7 @@ extends:
             InsertionBuildPolicy: Request Perf DDRITs
             InsertionReviewers: $(Build.RequestedFor)
             AutoCompletePR: false
+            ShallowClone: true
         - powershell: |
             $insertionPRId = azure-pipelines/Get-InsertionPRId.ps1
             $Markdown = @"

--- a/src/AssemblyInfo.vb
+++ b/src/AssemblyInfo.vb
@@ -1,0 +1,6 @@
+' Copyright (c) Microsoft Corporation. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System.Runtime.InteropServices
+
+<Assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" Condition=" '$(Language)'=='C#' " />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.vb" Condition=" '$(Language)'=='VB' " />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />


### PR DESCRIPTION
- Bump dotnet-coverage from 17.11.0 to 17.11.3 (#272)
- Bump Nerdbank.GitVersioning to 3.6.139
- Bump nbgv to 3.6.139
- Enable ShallowClone for VSInsertion
- Ensure Expand-Template uses UTF-8 when replacing placeholders.
- Drop SourceLink package reference
- Remove WPF workarounds for bugs fixed years ago
- Enable codeSignValidation and exclude non-shipping files
- Consolidate official build and real sign switches
- Switch from PAT-based to WIF-based auth
- Fix initArgs required parameter break
- Bump powershell from 7.4.2 to 7.4.3 (#275)
- Authenticate source code archival requests
- Check for signed binaries in a broader scoped path
- Ignore .sarif files
- Add support for VB.NET projects
- Fix template expansion
- Fix copyright notice
