### PR TITLE
Fix support for 2-deep arrays

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
+++ b/src/Microsoft.VisualStudio.Composition/ByValueEquality.cs
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.Composition
 
                     if (x.GetType().IsArray)
                     {
-                        return ArrayEquals((Array)x, (Array)y, v => v);
+                        return this.ArrayEquals((Array)x, (Array)y);
                     }
                     else
                     {
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.Composition
                     }
                 }
 
-                private static bool ArrayEquals(Array xArray, Array yArray, Func<object?, object?> translator)
+                private bool ArrayEquals(Array xArray, Array yArray)
                 {
                     if (xArray.Length != yArray.Length)
                     {
@@ -268,7 +268,9 @@ namespace Microsoft.VisualStudio.Composition
 
                     for (int i = 0; i < xArray.Length; i++)
                     {
-                        if (!EqualityComparer<object?>.Default.Equals(translator(xArray.GetValue(i)), translator(yArray.GetValue(i))))
+                        object? xValue = xArray.GetValue(i);
+                        object? yValue = yArray.GetValue(i);
+                        if (!this.Equals(xValue, yValue))
                         {
                             return false;
                         }

--- a/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
+++ b/src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs
@@ -61,7 +61,6 @@ namespace Microsoft.VisualStudio.Composition.Reflection
             Requires.NotNull(resolver, nameof(resolver));
             Requires.NotNull(assemblyName, nameof(assemblyName));
             Requires.Argument(((MetadataTokenType)metadataToken & MetadataTokenType.Mask) == MetadataTokenType.Type, "metadataToken", Strings.NotATypeSpec);
-            Requires.Argument(metadataToken != (int)MetadataTokenType.Type, "metadataToken", Strings.UnresolvableMetadataToken);
             Requires.NotNullOrEmpty(fullName, nameof(fullName));
 
             this.resolver = resolver;
@@ -200,7 +199,17 @@ namespace Microsoft.VisualStudio.Composition.Reflection
                     Module manifest;
                     if (ResolverExtensions.TryUseFastReflection(this, out manifest))
                     {
-                        resolvedType = manifest.ResolveType(this.MetadataToken);
+                        if (this.MetadataToken == (int)MetadataTokenType.Type)
+                        {
+                            // The only case we know of for this path is an array.
+                            // In which case, resolve the element type, and we'll make it an array below.
+                            Assumes.True(this.IsArray);
+                            resolvedType = this.ElementTypeRef.ResolvedType;
+                        }
+                        else
+                        {
+                            resolvedType = manifest.ResolveType(this.MetadataToken);
+                        }
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition/Strings.Designer.cs
@@ -685,15 +685,6 @@ namespace Microsoft.VisualStudio.Composition {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unresolvable metadata token..
-        /// </summary>
-        internal static string UnresolvableMetadataToken {
-            get {
-                return ResourceManager.GetString("UnresolvableMetadataToken", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unsupported format: {0}..
         /// </summary>
         internal static string UnsupportedFormat {

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -244,9 +244,6 @@
   <data name="PartIsNotShared" xml:space="preserve">
     <value>Part is not shared.</value>
   </data>
-  <data name="UnresolvableMetadataToken" xml:space="preserve">
-    <value>Unresolvable metadata token.</value>
-  </data>
   <data name="WrongLength" xml:space="preserve">
     <value>Wrong length.</value>
   </data>

--- a/test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs
@@ -35,6 +35,23 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Contains("c", metadataValue);
         }
 
+        [MefFact(CompositionEngines.V1Compat | CompositionEngines.V3EmulatingV2, typeof(ImportingPart), typeof(PartWithMultipleStringArrayCustomMetadata))]
+        public void MultipleCustomExportMetadataValuesWithStringArray(IContainer container)
+        {
+            var importingPart = container.GetExportedValue<ImportingPart>();
+            string[] metadataValue = Assert.IsType<string[]>(importingPart.CustomStringArrayMetadataImport?.Metadata["SomeName"]);
+            Assert.Equal(2, metadataValue.Length);
+            Assert.Contains("b", metadataValue);
+            Assert.Contains("c", metadataValue);
+
+            string[][] stringArrayValue = Assert.IsType<string[][]>(importingPart.CustomStringArrayMetadataImport?.Metadata["StringArray"]);
+            Assert.Equal(2, stringArrayValue.Length);
+            int bIndex = metadataValue[0] == "b" ? 0 : 1;
+            int cIndex = bIndex == 0 ? 1 : 0;
+            Assert.Empty(stringArrayValue[cIndex]);
+            Assert.True(new string[] { "First", "Second" }.SequenceEqual(stringArrayValue[bIndex]));
+        }
+
         [MefFact(CompositionEngines.V1Compat, typeof(ImportingPart), typeof(PartWithSingleCustomMetadata))]
         public void SingleCustomExportMetadataValuesForOneKeyV1(IContainer container)
         {
@@ -73,6 +90,12 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
         [Export]
         [MefV1.Export]
+        [CustomMetadataWithStringArray(SomeName = "b", StringArray = ["First", "Second"])]
+        [CustomMetadataWithStringArray(SomeName = "c")]
+        public class PartWithMultipleStringArrayCustomMetadata { }
+
+        [Export]
+        [MefV1.Export]
         public class ImportingPart
         {
             [Import(AllowDefault = true)]
@@ -85,6 +108,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             [Import(AllowDefault = true)]
             [MefV1.Import(AllowDefault = true)]
+            public Lazy<PartWithMultipleStringArrayCustomMetadata, IDictionary<string, object?>>? CustomStringArrayMetadataImport { get; set; }
+
+            [Import(AllowDefault = true)]
+            [MefV1.Import(AllowDefault = true)]
             public Lazy<PartWithSingleCustomMetadata, IDictionary<string, object?>>? SingleCustomMetadataImport { get; set; }
         }
 
@@ -93,6 +120,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
         public class CustomMetadataAttribute : Attribute
         {
             public string? SomeName { get; set; }
+        }
+
+        [MetadataAttribute, MefV1.MetadataAttribute]
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+        public class CustomMetadataWithStringArrayAttribute : CustomMetadataAttribute
+        {
+            public string[] StringArray { get; set; } = [];
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs
@@ -52,6 +52,25 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.True(new string[] { "First", "Second" }.SequenceEqual(stringArrayValue[bIndex]));
         }
 
+        [MefFact(CompositionEngines.V1Compat | CompositionEngines.V3EmulatingV2, typeof(ImportingPartViaMetadataView), typeof(PartWithMultipleStringArrayCustomMetadata))]
+        public void MultipleCustomExportMetadataValuesWithStringArray_MetadataView(IContainer container)
+        {
+            var importingPart = container.GetExportedValue<ImportingPartViaMetadataView>();
+            string?[]? metadataValue = importingPart.CustomStringArrayMetadataViewImport?.Metadata.SomeName;
+            Assert.NotNull(metadataValue);
+            Assert.Equal(2, metadataValue.Length);
+            Assert.Contains("b", metadataValue);
+            Assert.Contains("c", metadataValue);
+
+            string[][]? stringArrayValue = importingPart.CustomStringArrayMetadataViewImport?.Metadata.StringArray;
+            Assert.NotNull(stringArrayValue);
+            Assert.Equal(2, stringArrayValue.Length);
+            int bIndex = metadataValue[0] == "b" ? 0 : 1;
+            int cIndex = bIndex == 0 ? 1 : 0;
+            Assert.Empty(stringArrayValue[cIndex]);
+            Assert.True(new string[] { "First", "Second" }.SequenceEqual(stringArrayValue[bIndex]));
+        }
+
         [MefFact(CompositionEngines.V1Compat, typeof(ImportingPart), typeof(PartWithSingleCustomMetadata))]
         public void SingleCustomExportMetadataValuesForOneKeyV1(IContainer container)
         {
@@ -115,6 +134,15 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public Lazy<PartWithSingleCustomMetadata, IDictionary<string, object?>>? SingleCustomMetadataImport { get; set; }
         }
 
+        [Export]
+        [MefV1.Export]
+        public class ImportingPartViaMetadataView
+        {
+            [Import(AllowDefault = true)]
+            [MefV1.Import(AllowDefault = true)]
+            public Lazy<PartWithMultipleStringArrayCustomMetadata, ICustomMetadataWithStringArray>? CustomStringArrayMetadataViewImport { get; set; }
+        }
+
         [MetadataAttribute, MefV1.MetadataAttribute]
         [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
         public class CustomMetadataAttribute : Attribute
@@ -127,6 +155,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
         public class CustomMetadataWithStringArrayAttribute : CustomMetadataAttribute
         {
             public string[] StringArray { get; set; } = [];
+        }
+
+        public interface ICustomMetadataWithStringArray
+        {
+            string?[] SomeName { get; }
+
+            string[][] StringArray { get; }
         }
     }
 }


### PR DESCRIPTION
##  Add support for nested arrays

For this test, we use a metadata view member typed as a nested array to demonstrate the need for this support. I suspect that it could also manifest as an imported/exported value typed with a nested array.
In the metadata view case, this is useful when a single metadatum has a `T[]` value, and the metadata is provided by an `AllowMultiple=true` attribute, such that all metadata gets an array added to it.

##  Fix testing of `string[]` IsMultiple=true metadata

This isn't likely to impact a shipping scenario, but by-value equality testing didn't handle nested arrays, which upset the new test I was adding.

## Copilot generated explanations

This pull request includes changes to improve array equality checks, resolve metadata tokens more accurately, and add new test cases for custom export metadata values. The changes are divided into enhancements to array equality checks, improvements to metadata token resolution, and additions to test cases.

### Enhancements to Array Equality Checks:
* Modified the `Equals` method to call the instance method `ArrayEquals` directly, removing the need for a translator function in `ByValueEquality.cs`. (`src/Microsoft.VisualStudio.Composition/ByValueEquality.cs`, [src/Microsoft.VisualStudio.Composition/ByValueEquality.csL254-R262](diffhunk://#diff-2336982ba1fb70f3e9c5c6db7c2c75f0d0f4b96337dab0a6bcf5da5427345b26L254-R262))
* Simplified the `ArrayEquals` method by removing the translator function and directly comparing array elements using the `Equals` method. (`src/Microsoft.VisualStudio.Composition/ByValueEquality.cs`, [src/Microsoft.VisualStudio.Composition/ByValueEquality.csL271-R273](diffhunk://#diff-2336982ba1fb70f3e9c5c6db7c2c75f0d0f4b96337dab0a6bcf5da5427345b26L271-R273))

### Improvements to Metadata Token Resolution:
* Removed an unnecessary argument check for `metadataToken` in the `TypeRef` constructor, as it is always valid when the token is a type. (`src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs`, [src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.csL64](diffhunk://#diff-559562fd6b32d39b0af86894b1fa58d549ffec7070996a8f2df15cccb172e4a3L64))
* Added a condition to handle metadata tokens representing arrays in the `ResolvedType` property, ensuring that array element types are resolved correctly. (`src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.cs`, [src/Microsoft.VisualStudio.Composition/Reflection/TypeRef.csR201-R213](diffhunk://#diff-559562fd6b32d39b0af86894b1fa58d549ffec7070996a8f2df15cccb172e4a3R201-R213))
* Removed the unused localized string `UnresolvableMetadataToken` from `Strings.Designer.cs` and `Strings.resx`. (`src/Microsoft.VisualStudio.Composition/Strings.Designer.cs`, [[1]](diffhunk://#diff-c3e25fc77a50a9cbcb837d012c729402959def2b506328fc360be5af3b71948eL687-L695); `src/Microsoft.VisualStudio.Composition/Strings.resx`, [[2]](diffhunk://#diff-7e109510a200007f540b4cc6845712181b317aa92a9314df717dc59b45bc61c7L247-L249)

### Additions to Test Cases:
* Added new test methods to verify handling of multiple custom export metadata values with string arrays in `ExportMetadataMultipleTests.cs`. (`test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs`, [test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.csR38-R73](diffhunk://#diff-eb9fde8361e8feb7b77d0f5dd2973c6f6932278ea0225619c2ba441af62683b9R38-R73))
* Introduced new classes and attributes to support the added test cases for custom metadata with string arrays. (`test/Microsoft.VisualStudio.Composition.Tests/ExportMetadataMultipleTests.cs`, [[1]](diffhunk://#diff-eb9fde8361e8feb7b77d0f5dd2973c6f6932278ea0225619c2ba441af62683b9R110-R115) [[2]](diffhunk://#diff-eb9fde8361e8feb7b77d0f5dd2973c6f6932278ea0225619c2ba441af62683b9R128-R165)