### PR TITLE
Fix dependency on non-existing package

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- This reference is just so the analyzers package is brought in by our NuGet package. -->
-    <ProjectReference Include="..\Microsoft.VisualStudio.Composition.Analyzers\Microsoft.VisualStudio.Composition.Analyzers.csproj">
+    <ProjectReference Include="..\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.csproj">
       <PrivateAssets>none</PrivateAssets>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
The recent introduction of a code-fixes package left the MS.VS.Composition package with a dependency on `Microsoft.VisualStudio.Composition.Analyzers.Only`, which is a package that is never built. Instead, the `Microsoft.VisualStudio.Composition.Analyzers` package now builds in the CodeFixes project. So we need to update the P2P so that the MEF package (still) depends on the package with ID `Microsoft.VisualStudio.Composition.Analyzers`.