### PR TITLE
Modify MetadataViewClassProvider.CreateProxy to potentially avoid allocation

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
@@ -37,9 +37,9 @@ namespace Microsoft.VisualStudio.Composition
             ConstructorInfo? ctor = FindConstructor(metadataViewType.GetTypeInfo());
             Requires.Argument(ctor is not null, nameof(metadataViewType), "No public constructor with the required signature found.");
 
-            // Avoid creating a new ImmutableDictionary if the passed in metadata is already of that form
-            var metadataAsImmutableDictionary = metadata as ImmutableDictionary<string, object?> ?? ImmutableDictionary.CreateRange(metadata);
-            return ctor.Invoke(new object[] { metadataAsImmutableDictionary });
+            // Avoid creating a new ImmutableDictionary if the passed in metadata is already of the form required by the constructor.
+            object metadataMaybeWrapped = ctor.GetParameters()[0].ParameterType.IsAssignableFrom(metadata.GetType()) ? metadata : ImmutableDictionary.CreateRange(metadata);
+            return ctor.Invoke([metadataMaybeWrapped]);
         }
 
         private static ConstructorInfo? FindConstructor(TypeInfo metadataType)

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
@@ -8,9 +8,6 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Immutable;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading.Tasks;
-    using Microsoft.VisualStudio.Composition.Reflection;
 
     /// <summary>
     /// Supports metadata views that are concrete classes with a public constructor
@@ -39,7 +36,10 @@ namespace Microsoft.VisualStudio.Composition
         {
             ConstructorInfo? ctor = FindConstructor(metadataViewType.GetTypeInfo());
             Requires.Argument(ctor is not null, nameof(metadataViewType), "No public constructor with the required signature found.");
-            return ctor.Invoke(new object[] { ImmutableDictionary.CreateRange(metadata) });
+
+            // Avoid creating a new ImmutableDictionary if the passed in metadata is already of that form
+            var metadataAsImmutableDictionary = metadata as ImmutableDictionary<string, object?> ?? ImmutableDictionary.CreateRange(metadata);
+            return ctor.Invoke(new object[] { metadataAsImmutableDictionary });
         }
 
         private static ConstructorInfo? FindConstructor(TypeInfo metadataType)


### PR DESCRIPTION
Reuse the input metadata if it is already an ImmutableDictionary, avoiding allocations and cpu costs

This should go through a speedometer run to see if this improves the costs I'm currently seeing, or if there aren't many callers that are passing in an ImmutableDictionary.

![image](https://github.com/user-attachments/assets/ad41c3ea-9f57-4fd8-8104-cf2dad32a337)