### PR TITLE
Add several new analyzers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Use C#'s file-scoped namespaces for any newly added files, however preserve the style for existing files.

--- a/doc/analyzers/VSMEF004.md
+++ b/doc/analyzers/VSMEF004.md
@@ -181,7 +181,7 @@ class Service
     public Service(string parameter) { }
 }
 
-// MEF v2  
+// MEF v2
 [System.Composition.Export]
 class Service
 {

--- a/doc/analyzers/VSMEF004.md
+++ b/doc/analyzers/VSMEF004.md
@@ -1,0 +1,191 @@
+# VSMEF004 Exported type missing importing constructor
+
+A class that exports itself or has exported members must be instantiable by MEF. If the class defines non-default constructors, it must have either:
+
+1. A parameterless constructor, or
+2. A constructor annotated with `[ImportingConstructor]`
+
+The following class definition would produce a diagnostic from this rule:
+
+```cs
+[Export]
+class Foo
+{
+    public Foo(string parameter)
+    {
+        // Non-default constructor without [ImportingConstructor]
+    }
+}
+```
+
+This class exports itself but only has a non-default constructor that is not annotated with `[ImportingConstructor]`. MEF cannot instantiate this class because it doesn't know how to provide the required `string` parameter.
+
+## Fixing the diagnostic
+
+There are several ways to fix this diagnostic:
+
+### Option 1: Add a parameterless constructor
+
+```cs
+[Export]
+class Foo
+{
+    public Foo()
+    {
+        // Default constructor for MEF
+    }
+
+    public Foo(string parameter)
+    {
+        // Non-default constructor for other uses
+    }
+}
+```
+
+### Option 2: Annotate a constructor with [ImportingConstructor]
+
+```cs
+[Export]
+class Foo
+{
+    [ImportingConstructor]
+    public Foo(string parameter)
+    {
+        // MEF will satisfy the 'parameter' import
+    }
+}
+```
+
+### Option 3: Use importing constructor with MEF imports
+
+```cs
+[Export]
+class Foo
+{
+    [ImportingConstructor]
+    public Foo([Import] IService service)
+    {
+        // MEF will inject the required IService
+    }
+}
+```
+
+## Examples that trigger this rule
+
+### Class-level export with non-default constructor
+
+```cs
+[Export]
+class Service
+{
+    public Service(string connectionString)  // ❌ Error: missing [ImportingConstructor]
+    {
+    }
+}
+```
+
+### Class with exported members and non-default constructor
+
+```cs
+class ServiceProvider
+{
+    [Export]
+    public IService GetService() => new Service();
+
+    public ServiceProvider(string config)  // ❌ Error: missing [ImportingConstructor]
+    {
+    }
+}
+```
+
+### Mixed static and instance exports
+
+```cs
+class MixedExports
+{
+    [Export]
+    public static string StaticValue = "test";  // ✅ OK: static export
+
+    [Export]
+    public string InstanceValue { get; set; }  // ❌ Requires instantiation
+
+    public MixedExports(string parameter)  // ❌ Error: missing [ImportingConstructor]
+    {
+    }
+}
+```
+
+## Examples that do NOT trigger this rule
+
+### Class with only static exports
+
+```cs
+class StaticOnlyExports
+{
+    [Export]
+    public static IService Service { get; } = new Service();
+
+    public StaticOnlyExports(string parameter)  // ✅ OK: no instance exports
+    {
+    }
+}
+```
+
+### Class with default constructor
+
+```cs
+[Export]
+class Service
+{
+    public Service()  // ✅ OK: default constructor
+    {
+    }
+}
+```
+
+### Class with importing constructor
+
+```cs
+[Export]
+class Service
+{
+    [ImportingConstructor]
+    public Service(string connectionString)  // ✅ OK: has [ImportingConstructor]
+    {
+    }
+}
+```
+
+### Abstract class
+
+```cs
+[Export]
+abstract class ServiceBase
+{
+    public ServiceBase(string parameter)  // ✅ OK: abstract classes are not instantiated
+    {
+    }
+}
+```
+
+## Applies to both MEF versions
+
+This rule applies to both MEF v1 (`System.ComponentModel.Composition`) and MEF v2 (`System.Composition`) attributes:
+
+```cs
+// MEF v1
+[System.ComponentModel.Composition.Export]
+class Service
+{
+    [System.ComponentModel.Composition.ImportingConstructor]
+    public Service(string parameter) { }
+}
+
+// MEF v2  
+[System.Composition.Export]
+class Service
+{
+    [System.Composition.ImportingConstructor]
+    public Service(string parameter) { }
+}
+```

--- a/doc/analyzers/VSMEF005.md
+++ b/doc/analyzers/VSMEF005.md
@@ -1,0 +1,89 @@
+# VSMEF005 Multiple importing constructors
+
+A class that exports itself or has exported members can only have one constructor marked with `[ImportingConstructor]`. MEF requires exactly one importing constructor per type to know how to instantiate the class.
+
+The following class definition would produce a diagnostic from this rule:
+
+```cs
+[Export]
+class Foo
+{
+    [ImportingConstructor]
+    public Foo()
+    {
+    }
+
+    [ImportingConstructor]
+    public Foo(string parameter)
+    {
+    }
+}
+```
+
+This class has two constructors both marked with `[ImportingConstructor]`, which creates ambiguity for MEF about which constructor to use for instantiation.
+
+## Fixing the diagnostic
+
+Remove the `[ImportingConstructor]` attribute from all but one constructor. The remaining importing constructor will be used by MEF to create instances of the class.
+
+```cs
+[Export]
+class Foo
+{
+    public Foo()
+    {
+    }
+
+    [ImportingConstructor]
+    public Foo(string parameter)
+    {
+    }
+}
+```
+
+In this corrected version, only one constructor is marked as the importing constructor, and MEF will use it to instantiate the class, providing the required `string` parameter through dependency injection.
+
+## Alternative solutions
+
+If you need multiple constructors for different scenarios:
+
+### Option 1: Use only one importing constructor
+
+Keep only one constructor marked with `[ImportingConstructor]` and use that for MEF instantiation:
+
+```cs
+[Export]
+class Foo
+{
+    // Regular constructor for manual instantiation
+    public Foo()
+    {
+    }
+
+    // MEF importing constructor
+    [ImportingConstructor]
+    public Foo(IService service)
+    {
+        // Initialize with injected dependencies
+    }
+}
+```
+
+### Option 2: Use factory pattern
+
+If you need complex instantiation logic, consider using a factory pattern:
+
+```cs
+[Export]
+class FooFactory
+{
+    [ImportingConstructor]
+    public FooFactory(IService service)
+    {
+        this.service = service;
+    }
+
+    public Foo CreateFoo() => new Foo();
+    public Foo CreateFoo(string parameter) => new Foo(parameter, this.service);
+}
+```

--- a/doc/analyzers/VSMEF006.md
+++ b/doc/analyzers/VSMEF006.md
@@ -1,0 +1,125 @@
+# VSMEF006 Import nullability and AllowDefault mismatch
+
+When using nullable reference types, the nullability of an import should match its `AllowDefault` setting. This analyzer detects mismatches between nullable annotations and the `AllowDefault` property in import attributes.
+
+## Two types of mismatches detected
+
+### 1. Nullable import without AllowDefault = true
+
+The following property definition would produce a diagnostic from this rule:
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+class Foo
+{
+    [Import]
+    public string? SomeProperty { get; set; }
+}
+```
+
+This property is nullable (can accept `null` values) but doesn't have `AllowDefault = true`, which means MEF will throw an exception if no matching export is found instead of setting the property to `null`.
+
+Fix the diagnostic by adding `AllowDefault = true`:
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+class Foo
+{
+    [Import(AllowDefault = true)]
+    public string? SomeProperty { get; set; }
+}
+```
+
+### 2. AllowDefault = true without nullable type
+
+The following property definition would also produce a diagnostic:
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+class Foo
+{
+    [Import(AllowDefault = true)]
+    public string SomeProperty { get; set; }
+}
+```
+
+This property has `AllowDefault = true` (meaning it can be `null` if no export is found) but is declared as non-nullable, creating a potential null reference exception.
+
+## Fixing the diagnostic
+
+### Option 1: Make the type nullable
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+class Foo
+{
+    [Import(AllowDefault = true)]
+    public string? SomeProperty { get; set; }
+}
+```
+
+### Option 2: Remove AllowDefault
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+class Foo
+{
+    [Import]
+    public string SomeProperty { get; set; }
+}
+```
+
+## Additional examples
+
+### Constructor parameters
+
+The same rules apply to constructor parameters:
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+[Export]
+class Foo
+{
+    [ImportingConstructor]
+    public Foo([Import(AllowDefault = true)] string? optionalService)
+    {
+        // optionalService can be null
+    }
+}
+```
+
+### ImportMany with nullable collections
+
+For `ImportMany`, the collection itself typically shouldn't be nullable, but the element type might be:
+
+```cs
+#nullable enable
+using System.ComponentModel.Composition;
+
+class Foo
+{
+    [ImportMany]
+    public IEnumerable<IService?> Services { get; set; } = null!;
+}
+```
+
+## Benefits
+
+Following this analyzer's recommendations helps ensure:
+
+1. **Consistency**: Nullable annotations accurately reflect the runtime behavior
+2. **Safety**: Reduces null reference exceptions at runtime  
+3. **Clarity**: Makes the intent clear to other developers reading the code
+4. **Tooling support**: Enables better IntelliSense and static analysis

--- a/doc/analyzers/VSMEF007.md
+++ b/doc/analyzers/VSMEF007.md
@@ -1,0 +1,207 @@
+# VSMEF007 Duplicate import contract
+
+A MEF type should not import the same contract more than once. When a type imports the same contract multiple times, it creates ambiguity about which import should receive which export, and may indicate a design problem.
+
+The following class definition would produce a diagnostic from this rule:
+
+```cs
+[Export]
+class Foo
+{
+    [Import]
+    public string Value1 { get; set; }
+    
+    [Import]
+    public string Value2 { get; set; }
+}
+```
+
+This class imports the `string` contract twice through different properties, which means both properties would receive the same exported string value.
+
+## Examples of violations
+
+### Duplicate property imports
+
+```cs
+[Export]
+class Service
+{
+    [Import]
+    public ILogger Logger1 { get; set; }
+    
+    [Import]
+    public ILogger Logger2 { get; set; }  // Duplicate import
+}
+```
+
+### Duplicate constructor parameter imports
+
+```cs
+[Export]
+class Service
+{
+    [ImportingConstructor]
+    public Service([Import] ILogger logger1, [Import] ILogger logger2)
+    {
+        // Both parameters would receive the same ILogger instance
+    }
+}
+```
+
+### Mixed property and constructor imports
+
+```cs
+[Export]
+class Service
+{
+    [Import]
+    public ILogger PropertyLogger { get; set; }
+    
+    [ImportingConstructor]
+    public Service([Import] ILogger constructorLogger)
+    {
+        // Both imports target the same contract
+    }
+}
+```
+
+### Duplicate contract names
+
+```cs
+[Export]
+class Service
+{
+    [Import("MyContract")]
+    public string Value1 { get; set; }
+    
+    [Import("MyContract")]
+    public string Value2 { get; set; }  // Same contract name
+}
+```
+
+## Valid scenarios (no diagnostic)
+
+### Different contract types
+
+```cs
+[Export]
+class Service
+{
+    [Import]
+    public ILogger Logger { get; set; }
+    
+    [Import]
+    public IConfiguration Configuration { get; set; }  // Different type
+}
+```
+
+### Different contract names
+
+```cs
+[Export]
+class Service
+{
+    [Import("PrimaryLogger")]
+    public ILogger Logger1 { get; set; }
+    
+    [Import("SecondaryLogger")]
+    public ILogger Logger2 { get; set; }  // Different contract name
+}
+```
+
+### ImportMany for collections
+
+```cs
+[Export]
+class Service
+{
+    [ImportMany]
+    public IEnumerable<IPlugin> Plugins { get; set; }
+    
+    [ImportMany]
+    public IEnumerable<IHandler> Handlers { get; set; }  // Different element type
+}
+```
+
+## Fixing the diagnostic
+
+### Option 1: Use different contract names
+
+If you need multiple instances of the same type, use different contract names:
+
+```cs
+[Export]
+class Service
+{
+    [Import("PrimaryDatabase")]
+    public IDatabase PrimaryDb { get; set; }
+    
+    [Import("SecondaryDatabase")]
+    public IDatabase SecondaryDb { get; set; }
+}
+```
+
+### Option 2: Use ImportMany for collections
+
+If you need all available exports of a contract:
+
+```cs
+[Export]
+class Service
+{
+    [ImportMany]
+    public IEnumerable<ILogger> Loggers { get; set; }
+}
+```
+
+### Option 3: Consolidate imports
+
+If you only need one instance, remove the duplicate import:
+
+```cs
+[Export]
+class Service
+{
+    [Import]
+    public ILogger Logger { get; set; }
+    
+    // Use the same logger instance throughout the class
+}
+```
+
+### Option 4: Use composition pattern
+
+Create a composite that aggregates multiple services:
+
+```cs
+public interface ICompositeService
+{
+    ILogger PrimaryLogger { get; }
+    ILogger SecondaryLogger { get; }
+}
+
+[Export(typeof(ICompositeService))]
+class CompositeService : ICompositeService
+{
+    [ImportingConstructor]
+    public CompositeService(
+        [Import("Primary")] ILogger primaryLogger,
+        [Import("Secondary")] ILogger secondaryLogger)
+    {
+        PrimaryLogger = primaryLogger;
+        SecondaryLogger = secondaryLogger;
+    }
+    
+    public ILogger PrimaryLogger { get; }
+    public ILogger SecondaryLogger { get; }
+}
+```
+
+## Benefits
+
+Following this analyzer's recommendations helps ensure:
+
+1. **Clear intent**: Each import has a distinct purpose
+2. **Avoiding confusion**: No ambiguity about which export goes where
+3. **Better design**: Encourages proper separation of concerns
+4. **Performance**: Avoids unnecessary duplicate imports

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -9,3 +9,5 @@ ID | Title
 VSMEF001 | Importing property must have setter
 VSMEF002 | Avoid mixing MEF attribute libraries
 VSMEF004 | Exported type missing importing constructor
+VSMEF005 | Multiple importing constructors
+VSMEF006 | Import nullability and AllowDefault mismatch

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -7,3 +7,5 @@ to help you avoid common mistakes while authoring MEF parts.
 ID | Title
 --|--
 VSMEF001 | Importing property must have setter
+VSMEF002 | Avoid mixing MEF attribute libraries
+VSMEF004 | Exported type missing importing constructor

--- a/doc/analyzers/index.md
+++ b/doc/analyzers/index.md
@@ -11,3 +11,4 @@ VSMEF002 | Avoid mixing MEF attribute libraries
 VSMEF004 | Exported type missing importing constructor
 VSMEF005 | Multiple importing constructors
 VSMEF006 | Import nullability and AllowDefault mismatch
+VSMEF007 | Duplicate import contract

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.csproj
@@ -20,6 +20,13 @@
   <ItemGroup>
     <None Update="tools\*.ps1" Pack="true" PackagePath="tools\" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="System.Composition" />
+  </ItemGroup>
   <ItemDefinitionGroup>
     <PackageReference>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes/VSMEF004ExportWithoutImportingConstructorCodeFixProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes/VSMEF004ExportWithoutImportingConstructorCodeFixProvider.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers.CodeFixes;
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+/// <summary>
+/// Provides code fixes for VSMEF004: Exported type missing importing constructor.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(VSMEF004ExportWithoutImportingConstructorCodeFixProvider))]
+[Shared]
+public class VSMEF004ExportWithoutImportingConstructorCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(VSMEF004ExportWithoutImportingConstructorAnalyzer.Id);
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.FirstOrDefault(d => d.Id == VSMEF004ExportWithoutImportingConstructorAnalyzer.Id);
+        if (diagnostic is null)
+        {
+            return;
+        }
+
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        var constructorNode = root.FindNode(diagnosticSpan);
+
+        // Find the constructor declaration
+        var constructorDeclaration = constructorNode.FirstAncestorOrSelf<ConstructorDeclarationSyntax>();
+        if (constructorDeclaration is null)
+        {
+            return;
+        }
+
+        var classDeclaration = constructorDeclaration.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+        if (classDeclaration is null)
+        {
+            return;
+        }
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        // Determine which MEF version to use based on existing attributes
+        var mefVersion = DetermineMefVersion(classDeclaration, semanticModel);
+
+        // Primary fix: Add [ImportingConstructor] attribute
+        var addAttributeAction = CodeAction.Create(
+            title: "Add [ImportingConstructor] attribute",
+            createChangedDocument: c => AddImportingConstructorAttributeAsync(context.Document, constructorDeclaration, mefVersion, c),
+            equivalenceKey: "AddImportingConstructorAttribute");
+
+        context.RegisterCodeFix(addAttributeAction, diagnostic);
+
+        // Secondary fix: Add parameterless constructor
+        var addConstructorAction = CodeAction.Create(
+            title: "Add parameterless constructor",
+            createChangedDocument: c => AddParameterlessConstructorAsync(context.Document, classDeclaration, c),
+            equivalenceKey: "AddParameterlessConstructor");
+
+        context.RegisterCodeFix(addConstructorAction, diagnostic);
+    }
+
+    private static async Task<Document> AddImportingConstructorAttributeAsync(
+        Document document,
+        ConstructorDeclarationSyntax constructorDeclaration,
+        MefVersion mefVersion,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        // Create the ImportingConstructor attribute
+        var attributeName = mefVersion == MefVersion.V1
+            ? "System.ComponentModel.Composition.ImportingConstructor"
+            : "System.Composition.ImportingConstructor";
+
+        var attribute = SyntaxFactory.Attribute(SyntaxFactory.ParseName(attributeName));
+        var attributeList = SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(attribute));
+
+        // Add the attribute to the constructor
+        var newConstructor = constructorDeclaration.WithAttributeLists(
+            constructorDeclaration.AttributeLists.Add(attributeList));
+
+        var newRoot = root.ReplaceNode(constructorDeclaration, newConstructor);
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static async Task<Document> AddParameterlessConstructorAsync(
+        Document document,
+        ClassDeclarationSyntax classDeclaration,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        // Create a parameterless constructor
+        var newConstructor = SyntaxFactory.ConstructorDeclaration(classDeclaration.Identifier)
+            .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+            .WithParameterList(SyntaxFactory.ParameterList())
+            .WithBody(SyntaxFactory.Block());
+
+        // Find the position to insert the constructor (after existing constructors)
+        var existingConstructors = classDeclaration.Members.OfType<ConstructorDeclarationSyntax>().ToList();
+        int insertIndex = 0;
+
+        if (existingConstructors.Any())
+        {
+            // Insert after the last constructor
+            var lastConstructor = existingConstructors.Last();
+            insertIndex = classDeclaration.Members.IndexOf(lastConstructor) + 1;
+        }
+        else
+        {
+            // Insert at the beginning of the class
+            insertIndex = 0;
+        }
+
+        var newMembers = classDeclaration.Members.Insert(insertIndex, newConstructor);
+        var newClass = classDeclaration.WithMembers(newMembers);
+
+        var newRoot = root.ReplaceNode(classDeclaration, newClass);
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static MefVersion DetermineMefVersion(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+    {
+        // Check the class and its members for MEF attributes to determine which version to use
+        var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
+        if (classSymbol is null)
+        {
+            return MefVersion.V2; // Default to V2
+        }
+
+        // Check class-level attributes
+        foreach (var attribute in classSymbol.GetAttributes())
+        {
+            if (IsMefV1Attribute(attribute.AttributeClass))
+            {
+                return MefVersion.V1;
+            }
+
+            if (IsMefV2Attribute(attribute.AttributeClass))
+            {
+                return MefVersion.V2;
+            }
+        }
+
+        // Check member-level attributes
+        foreach (var member in classSymbol.GetMembers())
+        {
+            foreach (var attribute in member.GetAttributes())
+            {
+                if (IsMefV1Attribute(attribute.AttributeClass))
+                {
+                    return MefVersion.V1;
+                }
+
+                if (IsMefV2Attribute(attribute.AttributeClass))
+                {
+                    return MefVersion.V2;
+                }
+            }
+        }
+
+        return MefVersion.V2; // Default to V2 if no MEF attributes found
+    }
+
+    private static bool IsMefV1Attribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        var namespaceName = attributeType.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "System.ComponentModel.Composition" ||
+                namespaceName?.StartsWith("System.ComponentModel.Composition.") == true;
+    }
+
+    private static bool IsMefV2Attribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        var namespaceName = attributeType.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "System.Composition" ||
+                namespaceName?.StartsWith("System.Composition.") == true;
+    }
+
+    private enum MefVersion
+    {
+        V1,
+        V2,
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes/VSMEF006ImportNullabilityCodeFixProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CodeFixes/VSMEF006ImportNullabilityCodeFixProvider.cs
@@ -1,0 +1,371 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers.CodeFixes;
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+/// <summary>
+/// Provides code fixes for VSMEF006 import nullability analyzer.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(VSMEF006ImportNullabilityCodeFixProvider))]
+[Shared]
+public class VSMEF006ImportNullabilityCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(VSMEF006ImportNullabilityAnalyzer.Id);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        foreach (var diagnostic in context.Diagnostics.Where(d => this.FixableDiagnosticIds.Contains(d.Id)))
+        {
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var node = root.FindNode(diagnosticSpan);
+
+            // Handle different node types (field, property, parameter)
+            if (node is VariableDeclaratorSyntax variableDeclarator)
+            {
+                await RegisterFixesForField(context, root, diagnostic, variableDeclarator).ConfigureAwait(false);
+            }
+            else if (node is PropertyDeclarationSyntax property)
+            {
+                await RegisterFixesForProperty(context, root, diagnostic, property).ConfigureAwait(false);
+            }
+            else if (node is ParameterSyntax parameter)
+            {
+                await RegisterFixesForParameter(context, root, diagnostic, parameter).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task RegisterFixesForField(CodeFixContext context, SyntaxNode root, Diagnostic diagnostic, VariableDeclaratorSyntax variableDeclarator)
+    {
+        var fieldDeclaration = variableDeclarator.FirstAncestorOrSelf<FieldDeclarationSyntax>();
+        if (fieldDeclaration is null)
+        {
+            return;
+        }
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var fieldSymbol = semanticModel.GetDeclaredSymbol(variableDeclarator, context.CancellationToken) as IFieldSymbol;
+        if (fieldSymbol is null)
+        {
+            return;
+        }
+
+        var importAttribute = GetImportAttribute(fieldSymbol.GetAttributes());
+        if (importAttribute is null)
+        {
+            return;
+        }
+
+        RegisterFixes(context, root, diagnostic, fieldDeclaration, fieldDeclaration.Declaration.Type, fieldDeclaration.AttributeLists, importAttribute);
+    }
+
+    private static async Task RegisterFixesForProperty(CodeFixContext context, SyntaxNode root, Diagnostic diagnostic, PropertyDeclarationSyntax property)
+    {
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var propertySymbol = semanticModel.GetDeclaredSymbol(property, context.CancellationToken) as IPropertySymbol;
+        if (propertySymbol is null)
+        {
+            return;
+        }
+
+        var importAttribute = GetImportAttribute(propertySymbol.GetAttributes());
+        if (importAttribute is null)
+        {
+            return;
+        }
+
+        RegisterFixes(context, root, diagnostic, property, property.Type, property.AttributeLists, importAttribute);
+    }
+
+    private static async Task RegisterFixesForParameter(CodeFixContext context, SyntaxNode root, Diagnostic diagnostic, ParameterSyntax parameter)
+    {
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var parameterSymbol = semanticModel.GetDeclaredSymbol(parameter, context.CancellationToken) as IParameterSymbol;
+        if (parameterSymbol is null)
+        {
+            return;
+        }
+
+        var importAttribute = GetImportAttribute(parameterSymbol.GetAttributes());
+        if (importAttribute is null)
+        {
+            return;
+        }
+
+        RegisterFixes(context, root, diagnostic, parameter, parameter.Type, parameter.AttributeLists, importAttribute);
+    }
+
+    private static void RegisterFixes(CodeFixContext context, SyntaxNode root, Diagnostic diagnostic, SyntaxNode targetNode, TypeSyntax? typeSyntax, SyntaxList<AttributeListSyntax> attributeLists, AttributeData importAttribute)
+    {
+        if (typeSyntax is null)
+        {
+            return;
+        }
+
+        bool isNullable = IsNullableTypeSyntax(typeSyntax);
+        bool hasAllowDefault = GetAllowDefaultValue(importAttribute);
+
+        if (diagnostic.Descriptor == VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+        {
+            // Nullable type but no AllowDefault = true
+            // Fix 1: Add AllowDefault = true
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Add AllowDefault = true",
+                    createChangedDocument: cancellationToken => AddAllowDefaultAsync(context.Document, root, targetNode, attributeLists, cancellationToken),
+                    equivalenceKey: "AddAllowDefault"),
+                diagnostic);
+
+            // Fix 2: Make type non-nullable
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Make type non-nullable",
+                    createChangedDocument: cancellationToken => MakeTypeNonNullableAsync(context.Document, root, targetNode, typeSyntax, cancellationToken),
+                    equivalenceKey: "MakeNonNullable"),
+                diagnostic);
+        }
+        else if (diagnostic.Descriptor == VSMEF006ImportNullabilityAnalyzer.AllowDefaultWithoutNullableDescriptor)
+        {
+            // AllowDefault = true but not nullable
+            // Fix 1: Make type nullable
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Make type nullable",
+                    createChangedDocument: cancellationToken => MakeTypeNullableAsync(context.Document, root, targetNode, typeSyntax, cancellationToken),
+                    equivalenceKey: "MakeNullable"),
+                diagnostic);
+
+            // Fix 2: Remove AllowDefault = true
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Remove AllowDefault = true",
+                    createChangedDocument: cancellationToken => RemoveAllowDefaultAsync(context.Document, root, targetNode, attributeLists, cancellationToken),
+                    equivalenceKey: "RemoveAllowDefault"),
+                diagnostic);
+        }
+    }
+
+    private static bool IsNullableTypeSyntax(TypeSyntax typeSyntax)
+    {
+        return typeSyntax is NullableTypeSyntax;
+    }
+
+    private static AttributeData? GetImportAttribute(ImmutableArray<AttributeData> attributes)
+    {
+        return attributes.FirstOrDefault(attr => IsImportAttribute(attr.AttributeClass));
+    }
+
+    private static bool IsImportAttribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        var name = attributeType.Name;
+        return name == "ImportAttribute" || name == "ImportManyAttribute";
+    }
+
+    private static bool GetAllowDefaultValue(AttributeData importAttribute)
+    {
+        var allowDefaultArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "AllowDefault");
+        if (allowDefaultArg.Key is not null && allowDefaultArg.Value.Value is bool allowDefault)
+        {
+            return allowDefault;
+        }
+
+        return false;
+    }
+
+    private static Task<Document> AddAllowDefaultAsync(Document document, SyntaxNode root, SyntaxNode targetNode, SyntaxList<AttributeListSyntax> attributeLists, CancellationToken cancellationToken)
+    {
+        var importAttributeList = FindImportAttributeList(attributeLists);
+        if (importAttributeList is null)
+        {
+            return Task.FromResult(document);
+        }
+
+        var importAttribute = FindImportAttribute(importAttributeList);
+        if (importAttribute is null)
+        {
+            return Task.FromResult(document);
+        }
+
+        var newAttribute = AddAllowDefaultToAttribute(importAttribute);
+        var newAttributeList = importAttributeList.ReplaceNode(importAttribute, newAttribute);
+        var newRoot = root.ReplaceNode(importAttributeList, newAttributeList);
+
+        return Task.FromResult(document.WithSyntaxRoot(newRoot));
+    }
+
+    private static Task<Document> RemoveAllowDefaultAsync(Document document, SyntaxNode root, SyntaxNode targetNode, SyntaxList<AttributeListSyntax> attributeLists, CancellationToken cancellationToken)
+    {
+        var importAttributeList = FindImportAttributeList(attributeLists);
+        if (importAttributeList is null)
+        {
+            return Task.FromResult(document);
+        }
+
+        var importAttribute = FindImportAttribute(importAttributeList);
+        if (importAttribute is null)
+        {
+            return Task.FromResult(document);
+        }
+
+        var newAttribute = RemoveAllowDefaultFromAttribute(importAttribute);
+        var newAttributeList = importAttributeList.ReplaceNode(importAttribute, newAttribute);
+        var newRoot = root.ReplaceNode(importAttributeList, newAttributeList);
+
+        return Task.FromResult(document.WithSyntaxRoot(newRoot));
+    }
+
+    private static Task<Document> MakeTypeNullableAsync(Document document, SyntaxNode root, SyntaxNode targetNode, TypeSyntax typeSyntax, CancellationToken cancellationToken)
+    {
+        var nullableType = SyntaxFactory.NullableType(typeSyntax).WithTriviaFrom(typeSyntax);
+        var newRoot = root.ReplaceNode(typeSyntax, nullableType);
+        return Task.FromResult(document.WithSyntaxRoot(newRoot));
+    }
+
+    private static Task<Document> MakeTypeNonNullableAsync(Document document, SyntaxNode root, SyntaxNode targetNode, TypeSyntax typeSyntax, CancellationToken cancellationToken)
+    {
+        if (typeSyntax is NullableTypeSyntax nullableType)
+        {
+            var nonNullableType = nullableType.ElementType.WithTriviaFrom(typeSyntax);
+            var newRoot = root.ReplaceNode(typeSyntax, nonNullableType);
+            return Task.FromResult(document.WithSyntaxRoot(newRoot));
+        }
+
+        return Task.FromResult(document);
+    }
+
+    private static AttributeListSyntax? FindImportAttributeList(SyntaxList<AttributeListSyntax> attributeLists)
+    {
+        return attributeLists.FirstOrDefault(list => list.Attributes.Any(attr => IsImportAttributeSyntax(attr)));
+    }
+
+    private static AttributeSyntax? FindImportAttribute(AttributeListSyntax attributeList)
+    {
+        return attributeList.Attributes.FirstOrDefault(attr => IsImportAttributeSyntax(attr));
+    }
+
+    private static bool IsImportAttributeSyntax(AttributeSyntax attribute)
+    {
+        var name = attribute.Name.ToString();
+        return name.Contains("Import") && (name.Contains("ImportAttribute") || name.Contains("Import"));
+    }
+
+    private static AttributeSyntax AddAllowDefaultToAttribute(AttributeSyntax attribute)
+    {
+        var allowDefaultArg = SyntaxFactory.AttributeArgument(
+            SyntaxFactory.NameEquals(SyntaxFactory.IdentifierName("AllowDefault")),
+            null,
+            SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression));
+
+        if (attribute.ArgumentList is null)
+        {
+            return attribute.WithArgumentList(
+                SyntaxFactory.AttributeArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(allowDefaultArg)));
+        }
+
+        var arguments = attribute.ArgumentList.Arguments;
+        var allowDefaultIndex = -1;
+
+        // Check if AllowDefault already exists
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            if (arguments[i].NameEquals?.Name.Identifier.ValueText == "AllowDefault")
+            {
+                allowDefaultIndex = i;
+                break;
+            }
+        }
+
+        if (allowDefaultIndex >= 0)
+        {
+            // Replace existing AllowDefault
+            var newArguments = arguments.Replace(arguments[allowDefaultIndex], allowDefaultArg);
+            return attribute.WithArgumentList(attribute.ArgumentList.WithArguments(newArguments));
+        }
+        else
+        {
+            // Add new AllowDefault
+            var newArguments = arguments.Add(allowDefaultArg);
+            return attribute.WithArgumentList(attribute.ArgumentList.WithArguments(newArguments));
+        }
+    }
+
+    private static AttributeSyntax RemoveAllowDefaultFromAttribute(AttributeSyntax attribute)
+    {
+        if (attribute.ArgumentList is null)
+        {
+            return attribute;
+        }
+
+        var arguments = attribute.ArgumentList.Arguments;
+        var allowDefaultIndex = -1;
+
+        // Find AllowDefault argument
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            if (arguments[i].NameEquals?.Name.Identifier.ValueText == "AllowDefault")
+            {
+                allowDefaultIndex = i;
+                break;
+            }
+        }
+
+        if (allowDefaultIndex >= 0)
+        {
+            var newArguments = arguments.RemoveAt(allowDefaultIndex);
+            if (newArguments.Count == 0)
+            {
+                return attribute.WithArgumentList(null);
+            }
+            else
+            {
+                return attribute.WithArgumentList(attribute.ArgumentList.WithArguments(newArguments));
+            }
+        }
+
+        return attribute;
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,3 +4,4 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+VSMEF004 | Usage | Error | VSMEF004ExportWithoutImportingConstructor

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ Rule ID | Category | Severity | Notes
 VSMEF004 | Usage | Error | VSMEF004ExportWithoutImportingConstructor
 VSMEF005 | Usage | Error | VSMEF005MultipleImportingConstructors
 VSMEF006 | Usage | Warning | VSMEF006ImportNullability
+VSMEF007 | Usage | Warning | VSMEF007DuplicateImportAnalyzer

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 VSMEF004 | Usage | Error | VSMEF004ExportWithoutImportingConstructor
+VSMEF005 | Usage | Error | VSMEF005MultipleImportingConstructors

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 VSMEF004 | Usage | Error | VSMEF004ExportWithoutImportingConstructor
 VSMEF005 | Usage | Error | VSMEF005MultipleImportingConstructors
+VSMEF006 | Usage | Warning | VSMEF006ImportNullability

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/README.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/README.md
@@ -5,3 +5,7 @@ Analyzers for MEF consumers to help identify common errors in MEF parts.
 Analyzer ID | Description
 --|--
 VSMEF001 | Ensures that importing properties define a `set` accessor.
+VSMEF002 | Detects mixing of MEF v1 and MEF v2 attributes on the same type.
+VSMEF004 | Ensures exported types have a parameterless constructor or importing constructor.
+VSMEF005 | Detects multiple constructors marked with `[ImportingConstructor]`.
+VSMEF006 | Ensures import nullability matches `AllowDefault` setting.

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/README.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/README.md
@@ -9,3 +9,4 @@ VSMEF002 | Detects mixing of MEF v1 and MEF v2 attributes on the same type.
 VSMEF004 | Ensures exported types have a parameterless constructor or importing constructor.
 VSMEF005 | Detects multiple constructors marked with `[ImportingConstructor]`.
 VSMEF006 | Ensures import nullability matches `AllowDefault` setting.
+VSMEF007 | Detects when a type imports the same contract multiple times.

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
@@ -158,5 +158,23 @@ namespace Microsoft.VisualStudio.Composition.Analyzers {
                 return ResourceManager.GetString("VSMEF006_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type "{0}" imports the same contract "{1}" multiple times. Each contract should only be imported once per type..
+        /// </summary>
+        internal static string VSMEF007_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSMEF007_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate import contract.
+        /// </summary>
+        internal static string VSMEF007_Title {
+            get {
+                return ResourceManager.GetString("VSMEF007_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
@@ -113,5 +113,23 @@ namespace Microsoft.VisualStudio.Composition.Analyzers {
                 return ResourceManager.GetString("VSMEF004_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type &quot;{0}&quot; has multiple constructors annotated with [ImportingConstructor]. Only one constructor should be marked as importing..
+        /// </summary>
+        internal static string VSMEF005_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSMEF005_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple importing constructors.
+        /// </summary>
+        internal static string VSMEF005_Title {
+            get {
+                return ResourceManager.GetString("VSMEF005_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
@@ -95,5 +95,23 @@ namespace Microsoft.VisualStudio.Composition.Analyzers {
                 return ResourceManager.GetString("VSMEF002_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type &quot;{0}&quot; defines exports but has non-default constructors that are not annotated with [ImportingConstructor]. Add a parameterless constructor, or annotate a constructor with [ImportingConstructor]..
+        /// </summary>
+        internal static string VSMEF004_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSMEF004_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exported type missing importing constructor.
+        /// </summary>
+        internal static string VSMEF004_Title {
+            get {
+                return ResourceManager.GetString("VSMEF004_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.Designer.cs
@@ -131,5 +131,32 @@ namespace Microsoft.VisualStudio.Composition.Analyzers {
                 return ResourceManager.GetString("VSMEF005_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The import "{0}" has AllowDefault = true but is not nullable. Consider making the type nullable or removing AllowDefault..
+        /// </summary>
+        internal static string VSMEF006_AllowDefaultWithoutNullable_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSMEF006_AllowDefaultWithoutNullable_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The import "{0}" is nullable but does not have AllowDefault = true. Consider adding AllowDefault = true or making the type non-nullable..
+        /// </summary>
+        internal static string VSMEF006_NullableWithoutAllowDefault_MessageFormat {
+            get {
+                return ResourceManager.GetString("VSMEF006_NullableWithoutAllowDefault_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Import nullability and AllowDefault mismatch.
+        /// </summary>
+        internal static string VSMEF006_Title {
+            get {
+                return ResourceManager.GetString("VSMEF006_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
@@ -141,4 +141,13 @@
   <data name="VSMEF005_Title" xml:space="preserve">
     <value>Multiple importing constructors</value>
   </data>
+  <data name="VSMEF006_AllowDefaultWithoutNullable_MessageFormat" xml:space="preserve">
+    <value>The import "{0}" has AllowDefault = true but is not nullable. Consider making the type nullable or removing AllowDefault.</value>
+  </data>
+  <data name="VSMEF006_NullableWithoutAllowDefault_MessageFormat" xml:space="preserve">
+    <value>The import "{0}" is nullable but does not have AllowDefault = true. Consider adding AllowDefault = true or making the type non-nullable.</value>
+  </data>
+  <data name="VSMEF006_Title" xml:space="preserve">
+    <value>Import nullability and AllowDefault mismatch</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
@@ -135,4 +135,10 @@
   <data name="VSMEF004_Title" xml:space="preserve">
     <value>Exported type missing importing constructor</value>
   </data>
+  <data name="VSMEF005_MessageFormat" xml:space="preserve">
+    <value>The type "{0}" has multiple constructors annotated with [ImportingConstructor]. Only one constructor should be marked as importing.</value>
+  </data>
+  <data name="VSMEF005_Title" xml:space="preserve">
+    <value>Multiple importing constructors</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
@@ -150,4 +150,10 @@
   <data name="VSMEF006_Title" xml:space="preserve">
     <value>Import nullability and AllowDefault mismatch</value>
   </data>
+  <data name="VSMEF007_MessageFormat" xml:space="preserve">
+    <value>The type "{0}" imports the same contract "{1}" multiple times. Each contract should only be imported once per type.</value>
+  </data>
+  <data name="VSMEF007_Title" xml:space="preserve">
+    <value>Duplicate import contract</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Strings.resx
@@ -129,4 +129,10 @@
   <data name="VSMEF002_Title" xml:space="preserve">
     <value>Avoid mixing MEF attribute varieties</value>
   </data>
+  <data name="VSMEF004_MessageFormat" xml:space="preserve">
+    <value>The type "{0}" defines exports but has non-default constructors that are not annotated with [ImportingConstructor]. Add a parameterless constructor, or annotate a constructor with [ImportingConstructor].</value>
+  </data>
+  <data name="VSMEF004_Title" xml:space="preserve">
+    <value>Exported type missing importing constructor</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
@@ -17,4 +17,208 @@ internal static class Utils
     {
         return $"https://github.com/Microsoft/vs-mef/blob/main/doc/analyzers/{analyzerId}.md";
     }
+
+    public static bool ReferencesMefAttributes(Compilation compilation)
+    {
+        return compilation.ReferencedAssemblyNames.Any(i =>
+            string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static readonly ImmutableArray<string> MefV1ExportAttributeNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ExportAttributeNamespace = ImmutableArray.Create("System", "Composition");
+    private static readonly ImmutableArray<string> MefV1ImportingConstructorNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ImportingConstructorNamespace = ImmutableArray.Create("System", "Composition");
+    private static readonly ImmutableArray<string> MefV1ImportNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ImportNamespace = ImmutableArray.Create("System", "Composition");
+
+    /// <summary>
+    /// Determines whether the specified attribute type is a MEF export attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <returns><see langword="true"/> if the attribute type is an export attribute; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for both MEF v1 and MEF v2 export attributes, including custom attributes that derive from the base export attribute types.
+    /// </remarks>
+    public static bool IsExportAttribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        // Check if it's a direct Export attribute or derived from one
+        return IsAttributeOfType(attributeType, "ExportAttribute", MefV1ExportAttributeNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ExportAttribute", MefV2ExportAttributeNamespace.AsSpan());
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type is a MEF importing constructor attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <returns><see langword="true"/> if the attribute type is an importing constructor attribute; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for both MEF v1 and MEF v2 importing constructor attributes, including custom attributes that derive from the base importing constructor attribute types.
+    /// </remarks>
+    public static bool IsImportingConstructorAttribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        // Check if it's a direct ImportingConstructor attribute or derived from one
+        return IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV1ImportingConstructorNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV2ImportingConstructorNamespace.AsSpan());
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type matches the expected type and namespace, including inheritance hierarchy.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <param name="attributeTypeName">The expected attribute type name.</param>
+    /// <param name="expectedNamespace">The expected namespace components.</param>
+    /// <returns><see langword="true"/> if the attribute type matches; otherwise, <see langword="false"/>.</returns>
+    public static bool IsAttributeOfType(INamedTypeSymbol attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
+    {
+        // Check the attribute type itself and its base types
+        var current = attributeType;
+        while (current is not null)
+        {
+            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified symbol has any MEF export attributes.
+    /// </summary>
+    /// <param name="symbol">The symbol to check for export attributes.</param>
+    /// <returns><see langword="true"/> if the symbol has export attributes; otherwise, <see langword="false"/>.</returns>
+    public static bool HasExportAttribute(ISymbol symbol)
+    {
+        foreach (AttributeData attribute in symbol.GetAttributes())
+        {
+            if (IsExportAttribute(attribute.AttributeClass))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified type has any instance-level MEF exports.
+    /// </summary>
+    /// <param name="symbol">The type symbol to analyze.</param>
+    /// <returns><see langword="true"/> if the type has instance exports; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for export attributes on the type itself or on its instance members (properties, methods, fields).
+    /// Static members with export attributes are ignored since they don't require type instantiation.
+    /// </remarks>
+    public static bool HasInstanceExports(INamedTypeSymbol symbol)
+    {
+        // Check the type itself for Export attributes
+        if (Utils.HasExportAttribute(symbol))
+        {
+            return true;
+        }
+
+        // Check instance members (properties, methods, fields) for Export attributes
+        foreach (ISymbol member in symbol.GetMembers())
+        {
+            // Skip static members and nested types
+            if (member.IsStatic || member is ITypeSymbol)
+            {
+                continue;
+            }
+
+            if (Utils.HasExportAttribute(member))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified constructor has the ImportingConstructor attribute.
+    /// </summary>
+    /// <param name="constructor">The constructor to check.</param>
+    /// <returns><see langword="true"/> if the constructor has the ImportingConstructor attribute; otherwise, <see langword="false"/>.</returns>
+    public static bool HasImportingConstructorAttribute(IMethodSymbol constructor)
+    {
+        foreach (AttributeData attribute in constructor.GetAttributes())
+        {
+            if (IsImportingConstructorAttribute(attribute.AttributeClass))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified namespace matches the expected namespace components.
+    /// </summary>
+    /// <param name="actual">The actual namespace to check.</param>
+    /// <param name="expectedNames">The expected namespace components in reverse order (leaf to root).</param>
+    /// <returns><see langword="true"/> if the namespace matches; otherwise, <see langword="false"/>.</returns>
+    public static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
+    {
+        if (actual is null or { IsGlobalNamespace: true })
+        {
+            return expectedNames.Length == 0;
+        }
+
+        if (expectedNames.Length == 0)
+        {
+            return false;
+        }
+
+        if (actual.Name != expectedNames[expectedNames.Length - 1])
+        {
+            return false;
+        }
+
+        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames.Slice(0, expectedNames.Length - 1));
+    }
+
+    public static AttributeData? GetImportAttribute(ImmutableArray<AttributeData> attributes)
+    {
+        return attributes.FirstOrDefault(attr => IsImportAttribute(attr.AttributeClass));
+    }
+
+    public static bool IsImportAttribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        return IsAttributeOfType(attributeType, "ImportAttribute", MefV1ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportAttribute", MefV2ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportManyAttribute", MefV1ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportManyAttribute", MefV2ImportNamespace.AsSpan());
+    }
+
+    public static bool GetAllowDefaultValue(AttributeData importAttribute)
+    {
+        var allowDefaultArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "AllowDefault");
+        if (allowDefaultArg.Key is not null && allowDefaultArg.Value.Value is bool allowDefault)
+        {
+            return allowDefault;
+        }
+
+        return false; // Default value is false
+    }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/Utils.cs
@@ -1,26 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.VisualStudio.Composition.Analyzers
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-    using Microsoft.CodeAnalysis.Diagnostics;
+namespace Microsoft.VisualStudio.Composition.Analyzers;
 
+/// <summary>
+/// Utility methods for analyzers.
+/// </summary>
+internal static class Utils
+{
     /// <summary>
-    /// Utility methods for analyzers.
+    /// Gets the URL to the help topic for a particular analyzer.
     /// </summary>
-    internal static class Utils
+    /// <param name="analyzerId">The ID of the analyzer.</param>
+    /// <returns>The URL for the analyzer's documentation.</returns>
+    internal static string GetHelpLink(string analyzerId)
     {
-        /// <summary>
-        /// Gets the URL to the help topic for a particular analyzer.
-        /// </summary>
-        /// <param name="analyzerId">The ID of the analyzer.</param>
-        /// <returns>The URL for the analyzer's documentation.</returns>
-        internal static string GetHelpLink(string analyzerId)
-        {
-            return $"https://github.com/Microsoft/vs-mef/blob/main/doc/analyzers/{analyzerId}.md";
-        }
+        return $"https://github.com/Microsoft/vs-mef/blob/main/doc/analyzers/{analyzerId}.md";
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF001PropertyMustHaveSetter.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF001PropertyMustHaveSetter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Composition.Analyzers
         /// <summary>
         /// The descriptor used for diagnostics created by this rule.
         /// </summary>
-        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+        internal static readonly DiagnosticDescriptor Descriptor = new(
             id: Id,
             title: Strings.VSMEF001_Title,
             messageFormat: Strings.VSMEF001_MessageFormat,
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.Composition.Analyzers
             context.RegisterCompilationStartAction(context =>
             {
                 // Only scan further if the compilation references the assemblies that define the attributes we'll be looking for.
-                if (context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase) || string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase)))
+                if (Utils.ReferencesMefAttributes(context.Compilation))
                 {
                     INamedTypeSymbol? mefV1ImportAttribute = context.Compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ImportAttribute");
                     INamedTypeSymbol? mefV2ImportAttribute = context.Compilation.GetTypeByMetadataName("System.Composition.ImportAttribute");

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF002AvoidMixingAttributeVarietiesAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF002AvoidMixingAttributeVarietiesAnalyzer.cs
@@ -8,7 +8,7 @@ public class VSMEF002AvoidMixingAttributeVarietiesAnalyzer : DiagnosticAnalyzer
 {
     public const string Id = "VSMEF002";
 
-    internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+    internal static readonly DiagnosticDescriptor Descriptor = new(
         id: Id,
         title: Strings.VSMEF002_Title,
         messageFormat: Strings.VSMEF002_MessageFormat,

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF004ExportWithoutImportingConstructorAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF004ExportWithoutImportingConstructorAnalyzer.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers;
+
+/// <summary>
+/// Creates a diagnostic when a type with MEF exports defines non-default constructors without marking any with <c>[ImportingConstructor]</c>.
+/// </summary>
+/// <remarks>
+/// This analyzer detects when a class has MEF export attributes (either class-level or instance member exports)
+/// but only defines non-default constructors that are not annotated with <c>[ImportingConstructor]</c>.
+/// MEF cannot instantiate such types because it doesn't know which constructor to use or how to satisfy the parameters.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class VSMEF004ExportWithoutImportingConstructorAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The ID for diagnostics reported by this analyzer.
+    /// </summary>
+    public const string Id = "VSMEF004";
+
+    /// <summary>
+    /// The descriptor used for diagnostics created by this rule.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+        id: Id,
+        title: Strings.VSMEF004_Title,
+        messageFormat: Strings.VSMEF004_MessageFormat,
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly ImmutableArray<string> MefV1ExportAttributeNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ExportAttributeNamespace = ImmutableArray.Create("System", "Composition");
+    private static readonly ImmutableArray<string> MefV1ImportingConstructorNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ImportingConstructorNamespace = ImmutableArray.Create("System", "Composition");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            // Only run if MEF assemblies are referenced
+            bool mefV1AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase));
+            bool mefV2AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase));
+            if (mefV1AttributesPresent || mefV2AttributesPresent)
+            {
+                context.RegisterSymbolAction(context => this.AnalyzeSymbol(context), SymbolKind.NamedType);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Analyzes a named type symbol to check if it has MEF exports but lacks appropriate constructors.
+    /// </summary>
+    /// <param name="context">The symbol analysis context.</param>
+    private void AnalyzeSymbol(SymbolAnalysisContext context)
+    {
+        INamedTypeSymbol symbol = (INamedTypeSymbol)context.Symbol;
+
+        // Skip interfaces, delegates, enums and value types as they don't have constructors in the sense we care about
+        if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract)
+        {
+            return;
+        }
+
+        // Check if the type has any Export attributes (instance exports, not static members)
+        bool hasInstanceExports = HasInstanceExports(symbol);
+        if (!hasInstanceExports)
+        {
+            return;
+        }
+
+        // Get all constructors
+        var constructors = symbol.Constructors.Where(c => !c.IsStatic && !c.IsImplicitlyDeclared).ToList();
+
+        // If there are no explicitly declared constructors, the compiler provides a default parameterless constructor
+        if (constructors.Count == 0)
+        {
+            return; // Default constructor is fine
+        }
+
+        // Check if there's a parameterless constructor
+        var parameterlessConstructor = constructors.FirstOrDefault(c => c.Parameters.Length == 0);
+        if (parameterlessConstructor is not null)
+        {
+            return; // Parameterless constructor is fine, MEF can use it
+        }
+
+        // Check if any constructor has [ImportingConstructor] attribute
+        bool hasImportingConstructor = constructors.Any(c => HasImportingConstructorAttribute(c));
+        if (hasImportingConstructor)
+        {
+            return; // Has importing constructor, all good
+        }
+
+        // Found a violation: has instance exports, no default constructor, and no importing constructor
+        var firstConstructor = constructors.First();
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor,
+            firstConstructor.Locations.FirstOrDefault() ?? symbol.Locations.FirstOrDefault(),
+            symbol.Name));
+    }
+
+    /// <summary>
+    /// Determines whether the specified type has any instance-level MEF exports.
+    /// </summary>
+    /// <param name="symbol">The type symbol to analyze.</param>
+    /// <returns><see langword="true"/> if the type has instance exports; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for export attributes on the type itself or on its instance members (properties, methods, fields).
+    /// Static members with export attributes are ignored since they don't require type instantiation.
+    /// </remarks>
+    private static bool HasInstanceExports(INamedTypeSymbol symbol)
+    {
+        // Check the type itself for Export attributes
+        if (HasExportAttribute(symbol))
+        {
+            return true;
+        }
+
+        // Check instance members (properties, methods, fields) for Export attributes
+        foreach (ISymbol member in symbol.GetMembers())
+        {
+            // Skip static members and nested types
+            if (member.IsStatic || member is ITypeSymbol)
+            {
+                continue;
+            }
+
+            if (HasExportAttribute(member))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified symbol has any MEF export attributes.
+    /// </summary>
+    /// <param name="symbol">The symbol to check for export attributes.</param>
+    /// <returns><see langword="true"/> if the symbol has export attributes; otherwise, <see langword="false"/>.</returns>
+    private static bool HasExportAttribute(ISymbol symbol)
+    {
+        foreach (AttributeData attribute in symbol.GetAttributes())
+        {
+            if (IsExportAttribute(attribute.AttributeClass))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified constructor has the ImportingConstructor attribute.
+    /// </summary>
+    /// <param name="constructor">The constructor to check.</param>
+    /// <returns><see langword="true"/> if the constructor has the ImportingConstructor attribute; otherwise, <see langword="false"/>.</returns>
+    private static bool HasImportingConstructorAttribute(IMethodSymbol constructor)
+    {
+        foreach (AttributeData attribute in constructor.GetAttributes())
+        {
+            if (IsImportingConstructorAttribute(attribute.AttributeClass))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type is a MEF export attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <returns><see langword="true"/> if the attribute type is an export attribute; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for both MEF v1 and MEF v2 export attributes, including custom attributes that derive from the base export attribute types.
+    /// </remarks>
+    private static bool IsExportAttribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        // Check if it's a direct Export attribute or derived from one
+        return IsAttributeOfType(attributeType, "ExportAttribute", MefV1ExportAttributeNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ExportAttribute", MefV2ExportAttributeNamespace.AsSpan());
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type is a MEF importing constructor attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <returns><see langword="true"/> if the attribute type is an importing constructor attribute; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for both MEF v1 and MEF v2 importing constructor attributes, including custom attributes that derive from the base importing constructor attribute types.
+    /// </remarks>
+    private static bool IsImportingConstructorAttribute(INamedTypeSymbol? attributeType)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        // Check if it's a direct ImportingConstructor attribute or derived from one
+        return IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV1ImportingConstructorNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV2ImportingConstructorNamespace.AsSpan());
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type matches the expected type and namespace, including inheritance hierarchy.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <param name="attributeTypeName">The expected attribute type name.</param>
+    /// <param name="expectedNamespace">The expected namespace components.</param>
+    /// <returns><see langword="true"/> if the attribute type matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsAttributeOfType(INamedTypeSymbol attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
+    {
+        // Check the attribute type itself and its base types
+        var current = attributeType;
+        while (current is not null)
+        {
+            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified namespace matches the expected namespace components.
+    /// </summary>
+    /// <param name="actual">The actual namespace to check.</param>
+    /// <param name="expectedNames">The expected namespace components in reverse order (leaf to root).</param>
+    /// <returns><see langword="true"/> if the namespace matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
+    {
+        if (actual is null or { IsGlobalNamespace: true })
+        {
+            return expectedNames.Length == 0;
+        }
+
+        if (expectedNames.Length == 0)
+        {
+            return false;
+        }
+
+        if (actual.Name != expectedNames[expectedNames.Length - 1])
+        {
+            return false;
+        }
+
+        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames.Slice(0, expectedNames.Length - 1));
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF004ExportWithoutImportingConstructorAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF004ExportWithoutImportingConstructorAnalyzer.cs
@@ -22,7 +22,7 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzer : DiagnosticAnaly
     /// <summary>
     /// The descriptor used for diagnostics created by this rule.
     /// </summary>
-    internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+    internal static readonly DiagnosticDescriptor Descriptor = new(
         id: Id,
         title: Strings.VSMEF004_Title,
         messageFormat: Strings.VSMEF004_MessageFormat,
@@ -30,11 +30,6 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzer : DiagnosticAnaly
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
-
-    private static readonly ImmutableArray<string> MefV1ExportAttributeNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
-    private static readonly ImmutableArray<string> MefV2ExportAttributeNamespace = ImmutableArray.Create("System", "Composition");
-    private static readonly ImmutableArray<string> MefV1ImportingConstructorNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
-    private static readonly ImmutableArray<string> MefV2ImportingConstructorNamespace = ImmutableArray.Create("System", "Composition");
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptor);
@@ -48,225 +43,58 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzer : DiagnosticAnaly
         context.RegisterCompilationStartAction(context =>
         {
             // Only run if MEF assemblies are referenced
-            bool mefV1AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase));
-            bool mefV2AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase));
-            if (mefV1AttributesPresent || mefV2AttributesPresent)
+            if (Utils.ReferencesMefAttributes(context.Compilation))
             {
-                context.RegisterSymbolAction(context => this.AnalyzeSymbol(context), SymbolKind.NamedType);
+                context.RegisterSymbolAction(context => AnalyzeSymbol(context), SymbolKind.NamedType);
             }
         });
-    }
 
-    /// <summary>
-    /// Analyzes a named type symbol to check if it has MEF exports but lacks appropriate constructors.
-    /// </summary>
-    /// <param name="context">The symbol analysis context.</param>
-    private void AnalyzeSymbol(SymbolAnalysisContext context)
-    {
-        INamedTypeSymbol symbol = (INamedTypeSymbol)context.Symbol;
-
-        // Skip interfaces, delegates, enums and value types as they don't have constructors in the sense we care about
-        if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract)
+        static void AnalyzeSymbol(SymbolAnalysisContext context)
         {
-            return;
-        }
+            INamedTypeSymbol symbol = (INamedTypeSymbol)context.Symbol;
 
-        // Check if the type has any Export attributes (instance exports, not static members)
-        bool hasInstanceExports = HasInstanceExports(symbol);
-        if (!hasInstanceExports)
-        {
-            return;
-        }
-
-        // Get all constructors
-        var constructors = symbol.Constructors.Where(c => !c.IsStatic && !c.IsImplicitlyDeclared).ToList();
-
-        // If there are no explicitly declared constructors, the compiler provides a default parameterless constructor
-        if (constructors.Count == 0)
-        {
-            return; // Default constructor is fine
-        }
-
-        // Check if there's a parameterless constructor
-        var parameterlessConstructor = constructors.FirstOrDefault(c => c.Parameters.Length == 0);
-        if (parameterlessConstructor is not null)
-        {
-            return; // Parameterless constructor is fine, MEF can use it
-        }
-
-        // Check if any constructor has [ImportingConstructor] attribute
-        bool hasImportingConstructor = constructors.Any(c => HasImportingConstructorAttribute(c));
-        if (hasImportingConstructor)
-        {
-            return; // Has importing constructor, all good
-        }
-
-        // Found a violation: has instance exports, no default constructor, and no importing constructor
-        var firstConstructor = constructors.First();
-        context.ReportDiagnostic(Diagnostic.Create(
-            Descriptor,
-            firstConstructor.Locations.FirstOrDefault() ?? symbol.Locations.FirstOrDefault(),
-            symbol.Name));
-    }
-
-    /// <summary>
-    /// Determines whether the specified type has any instance-level MEF exports.
-    /// </summary>
-    /// <param name="symbol">The type symbol to analyze.</param>
-    /// <returns><see langword="true"/> if the type has instance exports; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>
-    /// This method checks for export attributes on the type itself or on its instance members (properties, methods, fields).
-    /// Static members with export attributes are ignored since they don't require type instantiation.
-    /// </remarks>
-    private static bool HasInstanceExports(INamedTypeSymbol symbol)
-    {
-        // Check the type itself for Export attributes
-        if (HasExportAttribute(symbol))
-        {
-            return true;
-        }
-
-        // Check instance members (properties, methods, fields) for Export attributes
-        foreach (ISymbol member in symbol.GetMembers())
-        {
-            // Skip static members and nested types
-            if (member.IsStatic || member is ITypeSymbol)
+            // Skip interfaces, delegates, enums and value types as they don't have constructors in the sense we care about
+            if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract)
             {
-                continue;
+                return;
             }
 
-            if (HasExportAttribute(member))
+            // Check if the type has any Export attributes (instance exports, not static members)
+            bool hasInstanceExports = Utils.HasInstanceExports(symbol);
+            if (!hasInstanceExports)
             {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether the specified symbol has any MEF export attributes.
-    /// </summary>
-    /// <param name="symbol">The symbol to check for export attributes.</param>
-    /// <returns><see langword="true"/> if the symbol has export attributes; otherwise, <see langword="false"/>.</returns>
-    private static bool HasExportAttribute(ISymbol symbol)
-    {
-        foreach (AttributeData attribute in symbol.GetAttributes())
-        {
-            if (IsExportAttribute(attribute.AttributeClass))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether the specified constructor has the ImportingConstructor attribute.
-    /// </summary>
-    /// <param name="constructor">The constructor to check.</param>
-    /// <returns><see langword="true"/> if the constructor has the ImportingConstructor attribute; otherwise, <see langword="false"/>.</returns>
-    private static bool HasImportingConstructorAttribute(IMethodSymbol constructor)
-    {
-        foreach (AttributeData attribute in constructor.GetAttributes())
-        {
-            if (IsImportingConstructorAttribute(attribute.AttributeClass))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether the specified attribute type is a MEF export attribute.
-    /// </summary>
-    /// <param name="attributeType">The attribute type to check.</param>
-    /// <returns><see langword="true"/> if the attribute type is an export attribute; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>
-    /// This method checks for both MEF v1 and MEF v2 export attributes, including custom attributes that derive from the base export attribute types.
-    /// </remarks>
-    private static bool IsExportAttribute(INamedTypeSymbol? attributeType)
-    {
-        if (attributeType is null)
-        {
-            return false;
-        }
-
-        // Check if it's a direct Export attribute or derived from one
-        return IsAttributeOfType(attributeType, "ExportAttribute", MefV1ExportAttributeNamespace.AsSpan()) ||
-               IsAttributeOfType(attributeType, "ExportAttribute", MefV2ExportAttributeNamespace.AsSpan());
-    }
-
-    /// <summary>
-    /// Determines whether the specified attribute type is a MEF importing constructor attribute.
-    /// </summary>
-    /// <param name="attributeType">The attribute type to check.</param>
-    /// <returns><see langword="true"/> if the attribute type is an importing constructor attribute; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>
-    /// This method checks for both MEF v1 and MEF v2 importing constructor attributes, including custom attributes that derive from the base importing constructor attribute types.
-    /// </remarks>
-    private static bool IsImportingConstructorAttribute(INamedTypeSymbol? attributeType)
-    {
-        if (attributeType is null)
-        {
-            return false;
-        }
-
-        // Check if it's a direct ImportingConstructor attribute or derived from one
-        return IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV1ImportingConstructorNamespace.AsSpan()) ||
-               IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV2ImportingConstructorNamespace.AsSpan());
-    }
-
-    /// <summary>
-    /// Determines whether the specified attribute type matches the expected type and namespace, including inheritance hierarchy.
-    /// </summary>
-    /// <param name="attributeType">The attribute type to check.</param>
-    /// <param name="attributeTypeName">The expected attribute type name.</param>
-    /// <param name="expectedNamespace">The expected namespace components.</param>
-    /// <returns><see langword="true"/> if the attribute type matches; otherwise, <see langword="false"/>.</returns>
-    private static bool IsAttributeOfType(INamedTypeSymbol attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
-    {
-        // Check the attribute type itself and its base types
-        var current = attributeType;
-        while (current is not null)
-        {
-            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
-            {
-                return true;
+                return;
             }
 
-            current = current.BaseType;
+            // Get all constructors
+            var constructors = symbol.Constructors.Where(c => !c.IsStatic && !c.IsImplicitlyDeclared).ToList();
+
+            // If there are no explicitly declared constructors, the compiler provides a default parameterless constructor
+            if (constructors.Count == 0)
+            {
+                return; // Default constructor is fine
+            }
+
+            // Check if there's a parameterless constructor
+            var parameterlessConstructor = constructors.FirstOrDefault(c => c.Parameters.Length == 0);
+            if (parameterlessConstructor is not null)
+            {
+                return; // Parameterless constructor is fine, MEF can use it
+            }
+
+            // Check if any constructor has [ImportingConstructor] attribute
+            bool hasImportingConstructor = constructors.Any(Utils.HasImportingConstructorAttribute);
+            if (hasImportingConstructor)
+            {
+                return; // Has importing constructor, all good
+            }
+
+            // Found a violation: has instance exports, no default constructor, and no importing constructor
+            var firstConstructor = constructors.First();
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptor,
+                firstConstructor.Locations.FirstOrDefault() ?? symbol.Locations.FirstOrDefault(),
+                symbol.Name));
         }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether the specified namespace matches the expected namespace components.
-    /// </summary>
-    /// <param name="actual">The actual namespace to check.</param>
-    /// <param name="expectedNames">The expected namespace components in reverse order (leaf to root).</param>
-    /// <returns><see langword="true"/> if the namespace matches; otherwise, <see langword="false"/>.</returns>
-    private static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
-    {
-        if (actual is null or { IsGlobalNamespace: true })
-        {
-            return expectedNames.Length == 0;
-        }
-
-        if (expectedNames.Length == 0)
-        {
-            return false;
-        }
-
-        if (actual.Name != expectedNames[expectedNames.Length - 1])
-        {
-            return false;
-        }
-
-        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames.Slice(0, expectedNames.Length - 1));
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF005MultipleImportingConstructorsAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF005MultipleImportingConstructorsAnalyzer.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Creates a diagnostic when a type has multiple constructors annotated with <c>[ImportingConstructor]</c>.
+/// </summary>
+/// <remarks>
+/// This analyzer detects when a class has more than one constructor marked with the <c>[ImportingConstructor]</c> attribute.
+/// MEF requires that only one constructor per type be marked as the importing constructor.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class VSMEF005MultipleImportingConstructorsAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The ID for diagnostics reported by this analyzer.
+    /// </summary>
+    public const string Id = "VSMEF005";
+
+    /// <summary>
+    /// The descriptor used for diagnostics created by this rule.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+        id: Id,
+        title: Strings.VSMEF005_Title,
+        messageFormat: Strings.VSMEF005_MessageFormat,
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly ImmutableArray<string> MefV1ImportingConstructorNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ImportingConstructorNamespace = ImmutableArray.Create("System", "Composition");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            // Only run if MEF assemblies are referenced
+            bool mefV1AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase));
+            bool mefV2AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase));
+            if (mefV1AttributesPresent || mefV2AttributesPresent)
+            {
+                context.RegisterSymbolAction(context => AnalyzeSymbol(context), SymbolKind.NamedType);
+            }
+        });
+    }
+
+    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    {
+        var symbol = (INamedTypeSymbol)context.Symbol;
+
+        // Only analyze classes
+        if (symbol.TypeKind != TypeKind.Class)
+        {
+            return;
+        }
+
+        // Find all constructors with ImportingConstructor attributes
+        var importingConstructors = new List<IMethodSymbol>();
+
+        foreach (var constructor in symbol.Constructors)
+        {
+            if (constructor.IsStatic)
+            {
+                continue;
+            }
+
+            foreach (var attribute in constructor.GetAttributes())
+            {
+                if (IsImportingConstructorAttribute(attribute.AttributeClass))
+                {
+                    importingConstructors.Add(constructor);
+                    break; // Found one ImportingConstructor attribute on this constructor, no need to check for more
+                }
+            }
+        }
+
+        // Report diagnostic if more than one constructor has ImportingConstructor attribute
+        if (importingConstructors.Count > 1)
+        {
+            // Report on each importing constructor
+            foreach (var constructor in importingConstructors)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Descriptor,
+                    constructor.Locations[0],
+                    symbol.Name));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type is an importing constructor attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <returns><see langword="true"/> if the attribute type is an importing constructor attribute; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This method checks for both MEF v1 and MEF v2 importing constructor attributes, including custom attributes that derive from the base importing constructor attribute types.
+    /// </remarks>
+    private static bool IsImportingConstructorAttribute(INamedTypeSymbol? attributeType)
+    {
+        return IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV1ImportingConstructorNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV2ImportingConstructorNamespace.AsSpan());
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type matches the expected type and namespace, including inheritance hierarchy.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <param name="attributeTypeName">The expected attribute type name.</param>
+    /// <param name="expectedNamespace">The expected namespace components.</param>
+    /// <returns><see langword="true"/> if the attribute type matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsAttributeOfType(INamedTypeSymbol? attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        // Check the attribute type itself and its base types
+        var current = attributeType;
+        while (current is not null)
+        {
+            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified namespace matches the expected namespace components.
+    /// </summary>
+    /// <param name="actual">The actual namespace to check.</param>
+    /// <param name="expectedNames">The expected namespace components in reverse order (leaf to root).</param>
+    /// <returns><see langword="true"/> if the namespace matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
+    {
+        if (actual is null or { IsGlobalNamespace: true })
+        {
+            return expectedNames.Length == 0;
+        }
+
+        if (expectedNames.Length == 0)
+        {
+            return false;
+        }
+
+        if (actual.Name != expectedNames[expectedNames.Length - 1])
+        {
+            return false;
+        }
+
+        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames.Slice(0, expectedNames.Length - 1));
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF006ImportNullabilityAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF006ImportNullabilityAnalyzer.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers;
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Creates a diagnostic when an import's null-annotation doesn't match its AllowDefault setting.
+/// </summary>
+/// <remarks>
+/// This analyzer detects when:
+/// 1. An import is nullable but doesn't have AllowDefault = true
+/// 2. An import has AllowDefault = true but isn't nullable
+/// Only operates in nullable contexts.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class VSMEF006ImportNullabilityAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The ID for diagnostics reported by this analyzer.
+    /// </summary>
+    public const string Id = "VSMEF006";
+
+    /// <summary>
+    /// The descriptor for nullable import without AllowDefault.
+    /// </summary>
+    public static readonly DiagnosticDescriptor NullableWithoutAllowDefaultDescriptor = new DiagnosticDescriptor(
+        id: Id,
+        title: Strings.VSMEF006_Title,
+        messageFormat: Strings.VSMEF006_NullableWithoutAllowDefault_MessageFormat,
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// The descriptor for AllowDefault without nullable.
+    /// </summary>
+    public static readonly DiagnosticDescriptor AllowDefaultWithoutNullableDescriptor = new DiagnosticDescriptor(
+        id: Id,
+        title: Strings.VSMEF006_Title,
+        messageFormat: Strings.VSMEF006_AllowDefaultWithoutNullable_MessageFormat,
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly ImmutableArray<string> MefV1ImportNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2ImportNamespace = ImmutableArray.Create("System", "Composition");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        NullableWithoutAllowDefaultDescriptor,
+        AllowDefaultWithoutNullableDescriptor);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            // Only run if MEF assemblies are referenced
+            bool mefV1AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase));
+            bool mefV2AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase));
+            if (mefV1AttributesPresent || mefV2AttributesPresent)
+            {
+                context.RegisterSymbolAction(context => AnalyzeField(context), SymbolKind.Field);
+                context.RegisterSymbolAction(context => AnalyzeProperty(context), SymbolKind.Property);
+                context.RegisterSymbolAction(context => AnalyzeMethod(context), SymbolKind.Method);
+            }
+        });
+    }
+
+    private static void AnalyzeField(SymbolAnalysisContext context)
+    {
+        var field = (IFieldSymbol)context.Symbol;
+        AnalyzeMember(context, field, field.Type, field.GetAttributes());
+    }
+
+    private static void AnalyzeProperty(SymbolAnalysisContext context)
+    {
+        var property = (IPropertySymbol)context.Symbol;
+        AnalyzeMember(context, property, property.Type, property.GetAttributes());
+    }
+
+    private static void AnalyzeMethod(SymbolAnalysisContext context)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+
+        // Check method parameters for [ImportingConstructor] methods or regular constructors
+        if (method.MethodKind == MethodKind.Constructor || HasImportingConstructorAttribute(method))
+        {
+            foreach (var parameter in method.Parameters)
+            {
+                AnalyzeMember(context, parameter, parameter.Type, parameter.GetAttributes());
+            }
+        }
+    }
+
+    private static void AnalyzeMember(SymbolAnalysisContext context, ISymbol member, ITypeSymbol type, ImmutableArray<AttributeData> attributes)
+    {
+        var importAttribute = GetImportAttribute(attributes);
+        if (importAttribute is null)
+        {
+            return;
+        }
+
+        bool isNullable = IsNullableType(type);
+        bool hasAllowDefault = GetAllowDefaultValue(importAttribute);
+
+        if (isNullable && !hasAllowDefault)
+        {
+            // Nullable type but no AllowDefault = true
+            context.ReportDiagnostic(Diagnostic.Create(
+                NullableWithoutAllowDefaultDescriptor,
+                member.Locations[0],
+                member.Name));
+        }
+        else if (!isNullable && hasAllowDefault)
+        {
+            // AllowDefault = true but not nullable
+            context.ReportDiagnostic(Diagnostic.Create(
+                AllowDefaultWithoutNullableDescriptor,
+                member.Locations[0],
+                member.Name));
+        }
+
+        static bool IsNullableType(ITypeSymbol type)
+        {
+            return type.CanBeReferencedByName && type.NullableAnnotation == NullableAnnotation.Annotated;
+        }
+    }
+
+    private static AttributeData? GetImportAttribute(ImmutableArray<AttributeData> attributes)
+    {
+        return attributes.FirstOrDefault(attr => IsImportAttribute(attr.AttributeClass));
+    }
+
+    private static bool IsImportAttribute(INamedTypeSymbol? attributeType)
+    {
+        return IsAttributeOfType(attributeType, "ImportAttribute", MefV1ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportAttribute", MefV2ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportManyAttribute", MefV1ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportManyAttribute", MefV2ImportNamespace.AsSpan());
+    }
+
+    private static bool GetAllowDefaultValue(AttributeData importAttribute)
+    {
+        var allowDefaultArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "AllowDefault");
+        if (allowDefaultArg.Key is not null && allowDefaultArg.Value.Value is bool allowDefault)
+        {
+            return allowDefault;
+        }
+
+        return false; // Default value is false
+    }
+
+    private static bool HasImportingConstructorAttribute(IMethodSymbol method)
+    {
+        return method.GetAttributes().Any(attr => IsImportingConstructorAttribute(attr.AttributeClass));
+    }
+
+    private static bool IsImportingConstructorAttribute(INamedTypeSymbol? attributeType)
+    {
+        return IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV1ImportNamespace.AsSpan()) ||
+               IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV2ImportNamespace.AsSpan());
+    }
+
+    /// <summary>
+    /// Determines whether the specified attribute type matches the expected type and namespace, including inheritance hierarchy.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check.</param>
+    /// <param name="attributeTypeName">The expected attribute type name.</param>
+    /// <param name="expectedNamespace">The expected namespace components.</param>
+    /// <returns><see langword="true"/> if the attribute type matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsAttributeOfType(INamedTypeSymbol? attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
+    {
+        if (attributeType is null)
+        {
+            return false;
+        }
+
+        // Check the attribute type itself and its base types
+        var current = attributeType;
+        while (current is not null)
+        {
+            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified namespace matches the expected namespace components.
+    /// </summary>
+    /// <param name="actual">The actual namespace to check.</param>
+    /// <param name="expectedNames">The expected namespace components in reverse order (leaf to root).</param>
+    /// <returns><see langword="true"/> if the namespace matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
+    {
+        if (actual is null or { IsGlobalNamespace: true })
+        {
+            return expectedNames.Length == 0;
+        }
+
+        if (expectedNames.Length == 0)
+        {
+            return false;
+        }
+
+        if (actual.Name != expectedNames[expectedNames.Length - 1])
+        {
+            return false;
+        }
+
+        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames.Slice(0, expectedNames.Length - 1));
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF006ImportNullabilityAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF006ImportNullabilityAnalyzer.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.VisualStudio.Composition.Analyzers;
 
-using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -29,7 +27,7 @@ public class VSMEF006ImportNullabilityAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// The descriptor for nullable import without AllowDefault.
     /// </summary>
-    public static readonly DiagnosticDescriptor NullableWithoutAllowDefaultDescriptor = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor NullableWithoutAllowDefaultDescriptor = new(
         id: Id,
         title: Strings.VSMEF006_Title,
         messageFormat: Strings.VSMEF006_NullableWithoutAllowDefault_MessageFormat,
@@ -41,7 +39,7 @@ public class VSMEF006ImportNullabilityAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// The descriptor for AllowDefault without nullable.
     /// </summary>
-    public static readonly DiagnosticDescriptor AllowDefaultWithoutNullableDescriptor = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor AllowDefaultWithoutNullableDescriptor = new(
         id: Id,
         title: Strings.VSMEF006_Title,
         messageFormat: Strings.VSMEF006_AllowDefaultWithoutNullable_MessageFormat,
@@ -49,9 +47,6 @@ public class VSMEF006ImportNullabilityAnalyzer : DiagnosticAnalyzer
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
-
-    private static readonly ImmutableArray<string> MefV1ImportNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
-    private static readonly ImmutableArray<string> MefV2ImportNamespace = ImmutableArray.Create("System", "Composition");
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
@@ -67,164 +62,72 @@ public class VSMEF006ImportNullabilityAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(context =>
         {
             // Only run if MEF assemblies are referenced
-            bool mefV1AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.ComponentModel.Composition", StringComparison.OrdinalIgnoreCase));
-            bool mefV2AttributesPresent = context.Compilation.ReferencedAssemblyNames.Any(i => string.Equals(i.Name, "System.Composition.AttributedModel", StringComparison.OrdinalIgnoreCase));
-            if (mefV1AttributesPresent || mefV2AttributesPresent)
+            if (Utils.ReferencesMefAttributes(context.Compilation))
             {
-                context.RegisterSymbolAction(context => AnalyzeField(context), SymbolKind.Field);
-                context.RegisterSymbolAction(context => AnalyzeProperty(context), SymbolKind.Property);
-                context.RegisterSymbolAction(context => AnalyzeMethod(context), SymbolKind.Method);
+                context.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
+                context.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
+                context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
             }
         });
-    }
 
-    private static void AnalyzeField(SymbolAnalysisContext context)
-    {
-        var field = (IFieldSymbol)context.Symbol;
-        AnalyzeMember(context, field, field.Type, field.GetAttributes());
-    }
-
-    private static void AnalyzeProperty(SymbolAnalysisContext context)
-    {
-        var property = (IPropertySymbol)context.Symbol;
-        AnalyzeMember(context, property, property.Type, property.GetAttributes());
-    }
-
-    private static void AnalyzeMethod(SymbolAnalysisContext context)
-    {
-        var method = (IMethodSymbol)context.Symbol;
-
-        // Check method parameters for [ImportingConstructor] methods or regular constructors
-        if (method.MethodKind == MethodKind.Constructor || HasImportingConstructorAttribute(method))
+        static void AnalyzeField(SymbolAnalysisContext context)
         {
-            foreach (var parameter in method.Parameters)
+            var field = (IFieldSymbol)context.Symbol;
+            AnalyzeMember(context, field, field.Type, field.GetAttributes());
+        }
+
+        static void AnalyzeProperty(SymbolAnalysisContext context)
+        {
+            var property = (IPropertySymbol)context.Symbol;
+            AnalyzeMember(context, property, property.Type, property.GetAttributes());
+        }
+
+        static void AnalyzeMethod(SymbolAnalysisContext context)
+        {
+            var method = (IMethodSymbol)context.Symbol;
+
+            // Check method parameters for [ImportingConstructor] methods or regular constructors
+            if (method.MethodKind == MethodKind.Constructor || Utils.HasImportingConstructorAttribute(method))
             {
-                AnalyzeMember(context, parameter, parameter.Type, parameter.GetAttributes());
+                foreach (var parameter in method.Parameters)
+                {
+                    AnalyzeMember(context, parameter, parameter.Type, parameter.GetAttributes());
+                }
             }
         }
-    }
 
-    private static void AnalyzeMember(SymbolAnalysisContext context, ISymbol member, ITypeSymbol type, ImmutableArray<AttributeData> attributes)
-    {
-        var importAttribute = GetImportAttribute(attributes);
-        if (importAttribute is null)
+        static void AnalyzeMember(SymbolAnalysisContext context, ISymbol member, ITypeSymbol type, ImmutableArray<AttributeData> attributes)
         {
-            return;
-        }
-
-        bool isNullable = IsNullableType(type);
-        bool hasAllowDefault = GetAllowDefaultValue(importAttribute);
-
-        if (isNullable && !hasAllowDefault)
-        {
-            // Nullable type but no AllowDefault = true
-            context.ReportDiagnostic(Diagnostic.Create(
-                NullableWithoutAllowDefaultDescriptor,
-                member.Locations[0],
-                member.Name));
-        }
-        else if (!isNullable && hasAllowDefault)
-        {
-            // AllowDefault = true but not nullable
-            context.ReportDiagnostic(Diagnostic.Create(
-                AllowDefaultWithoutNullableDescriptor,
-                member.Locations[0],
-                member.Name));
-        }
-
-        static bool IsNullableType(ITypeSymbol type)
-        {
-            return type.CanBeReferencedByName && type.NullableAnnotation == NullableAnnotation.Annotated;
-        }
-    }
-
-    private static AttributeData? GetImportAttribute(ImmutableArray<AttributeData> attributes)
-    {
-        return attributes.FirstOrDefault(attr => IsImportAttribute(attr.AttributeClass));
-    }
-
-    private static bool IsImportAttribute(INamedTypeSymbol? attributeType)
-    {
-        return IsAttributeOfType(attributeType, "ImportAttribute", MefV1ImportNamespace.AsSpan()) ||
-               IsAttributeOfType(attributeType, "ImportAttribute", MefV2ImportNamespace.AsSpan()) ||
-               IsAttributeOfType(attributeType, "ImportManyAttribute", MefV1ImportNamespace.AsSpan()) ||
-               IsAttributeOfType(attributeType, "ImportManyAttribute", MefV2ImportNamespace.AsSpan());
-    }
-
-    private static bool GetAllowDefaultValue(AttributeData importAttribute)
-    {
-        var allowDefaultArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "AllowDefault");
-        if (allowDefaultArg.Key is not null && allowDefaultArg.Value.Value is bool allowDefault)
-        {
-            return allowDefault;
-        }
-
-        return false; // Default value is false
-    }
-
-    private static bool HasImportingConstructorAttribute(IMethodSymbol method)
-    {
-        return method.GetAttributes().Any(attr => IsImportingConstructorAttribute(attr.AttributeClass));
-    }
-
-    private static bool IsImportingConstructorAttribute(INamedTypeSymbol? attributeType)
-    {
-        return IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV1ImportNamespace.AsSpan()) ||
-               IsAttributeOfType(attributeType, "ImportingConstructorAttribute", MefV2ImportNamespace.AsSpan());
-    }
-
-    /// <summary>
-    /// Determines whether the specified attribute type matches the expected type and namespace, including inheritance hierarchy.
-    /// </summary>
-    /// <param name="attributeType">The attribute type to check.</param>
-    /// <param name="attributeTypeName">The expected attribute type name.</param>
-    /// <param name="expectedNamespace">The expected namespace components.</param>
-    /// <returns><see langword="true"/> if the attribute type matches; otherwise, <see langword="false"/>.</returns>
-    private static bool IsAttributeOfType(INamedTypeSymbol? attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
-    {
-        if (attributeType is null)
-        {
-            return false;
-        }
-
-        // Check the attribute type itself and its base types
-        var current = attributeType;
-        while (current is not null)
-        {
-            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
+            var importAttribute = Utils.GetImportAttribute(attributes);
+            if (importAttribute is null)
             {
-                return true;
+                return;
             }
 
-            current = current.BaseType;
+            bool isNullable = IsNullableType(type);
+            bool hasAllowDefault = Utils.GetAllowDefaultValue(importAttribute);
+
+            if (isNullable && !hasAllowDefault)
+            {
+                // Nullable type but no AllowDefault = true
+                context.ReportDiagnostic(Diagnostic.Create(
+                    NullableWithoutAllowDefaultDescriptor,
+                    member.Locations[0],
+                    member.Name));
+            }
+            else if (!isNullable && hasAllowDefault)
+            {
+                // AllowDefault = true but not nullable
+                context.ReportDiagnostic(Diagnostic.Create(
+                    AllowDefaultWithoutNullableDescriptor,
+                    member.Locations[0],
+                    member.Name));
+            }
+
+            static bool IsNullableType(ITypeSymbol type)
+            {
+                return type.CanBeReferencedByName && type.NullableAnnotation == NullableAnnotation.Annotated;
+            }
         }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether the specified namespace matches the expected namespace components.
-    /// </summary>
-    /// <param name="actual">The actual namespace to check.</param>
-    /// <param name="expectedNames">The expected namespace components in reverse order (leaf to root).</param>
-    /// <returns><see langword="true"/> if the namespace matches; otherwise, <see langword="false"/>.</returns>
-    private static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
-    {
-        if (actual is null or { IsGlobalNamespace: true })
-        {
-            return expectedNames.Length == 0;
-        }
-
-        if (expectedNames.Length == 0)
-        {
-            return false;
-        }
-
-        if (actual.Name != expectedNames[expectedNames.Length - 1])
-        {
-            return false;
-        }
-
-        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames.Slice(0, expectedNames.Length - 1));
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF007DuplicateImportAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF007DuplicateImportAnalyzer.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Creates a diagnostic when a type imports the same contract more than once.
+/// </summary>
+/// <remarks>
+/// This analyzer detects when a type has multiple imports (properties, constructor parameters, or a mix)
+/// that import the same contract. For imports with specific contract names, it only flags duplicates
+/// when the contract names match exactly.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class VSMEF007DuplicateImportAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The ID for diagnostics reported by this analyzer.
+    /// </summary>
+    public const string Id = "VSMEF007";
+
+    /// <summary>
+    /// The descriptor used for diagnostics created by this rule.
+    /// </summary>
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: Id,
+        title: Strings.VSMEF007_Title,
+        messageFormat: Strings.VSMEF007_MessageFormat,
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            // Only scan further if the compilation references the assemblies that define the attributes we'll be looking for.
+            if (Utils.ReferencesMefAttributes(context.Compilation))
+            {
+                context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+            }
+        });
+    }
+
+    private static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+
+        // Skip interfaces, enums, and other non-class types
+        if (namedType.TypeKind is not (TypeKind.Class or TypeKind.Struct))
+        {
+            return;
+        }
+
+        var importContracts = new List<ImportContract>();
+
+        // Collect all imports from properties
+        foreach (var member in namedType.GetMembers())
+        {
+            if (member is IPropertySymbol property)
+            {
+                var importAttribute = Utils.GetImportAttribute(property.GetAttributes());
+                if (importAttribute is not null)
+                {
+                    var contract = GetImportContract(importAttribute, property.Type);
+                    if (contract is not null)
+                    {
+                        importContracts.Add(new ImportContract(contract, property.Name, property.Locations[0]));
+                    }
+                }
+            }
+        }
+
+        // Collect all imports from constructor parameters
+        foreach (var member in namedType.GetMembers())
+        {
+            if (member is IMethodSymbol method && method.MethodKind == MethodKind.Constructor)
+            {
+                // Check if this constructor has [ImportingConstructor] or if it's the only constructor
+                bool isImportingConstructor = Utils.HasImportingConstructorAttribute(method) ||
+                    (namedType.Constructors.Length == 1 && Utils.HasInstanceExports(namedType));
+
+                if (isImportingConstructor)
+                {
+                    foreach (var parameter in method.Parameters)
+                    {
+                        var importAttribute = Utils.GetImportAttribute(parameter.GetAttributes());
+                        if (importAttribute is not null)
+                        {
+                            var contract = GetImportContract(importAttribute, parameter.Type);
+                            if (contract is not null)
+                            {
+                                importContracts.Add(new ImportContract(contract, parameter.Name, parameter.Locations[0]));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Find duplicates
+        var contractGroups = importContracts.GroupBy(ic => ic.Contract).Where(g => g.Count() > 1);
+
+        foreach (var group in contractGroups)
+        {
+            foreach (var import in group)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Descriptor,
+                    import.Location,
+                    namedType.Name,
+                    import.Contract));
+            }
+        }
+    }
+
+    private static string? GetImportContract(AttributeData importAttribute, ITypeSymbol importType)
+    {
+        // Check for explicit contract name or type in constructor arguments
+        if (importAttribute.ConstructorArguments.Length > 0)
+        {
+            var firstArg = importAttribute.ConstructorArguments[0];
+            if (firstArg.Value is string contractName && !string.IsNullOrEmpty(contractName))
+            {
+                return contractName;
+            }
+
+            if (firstArg.Value is INamedTypeSymbol contractType)
+            {
+                return contractType.ToDisplayString();
+            }
+        }
+
+        // Check for contract name in named arguments
+        var contractNameArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "ContractName");
+        if (contractNameArg.Key is not null && contractNameArg.Value.Value is string namedContractName && !string.IsNullOrEmpty(namedContractName))
+        {
+            return namedContractName;
+        }
+
+        // Check for contract type in named arguments
+        var contractTypeArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "ContractType");
+        if (contractTypeArg.Key is not null && contractTypeArg.Value.Value is INamedTypeSymbol namedContractType)
+        {
+            return namedContractType.ToDisplayString();
+        }
+
+        // Default contract is the type name
+        return importType.ToDisplayString();
+    }
+
+    private record ImportContract(string Contract, string MemberName, Location Location);
+}

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -13,13 +13,12 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         public Test()
         {
             this.ReferenceAssemblies = ReferencesHelper.DefaultReferences;
-            this.TestBehaviors |= Microsoft.CodeAnalysis.Testing.TestBehaviors.SkipGeneratedCodeCheck;
+            this.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
 
             this.SolutionTransforms.Add((solution, projectId) =>
             {
                 var parseOptions = (CSharpParseOptions)solution.GetProject(projectId)!.ParseOptions!;
-                solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp8)); // need nullable
-
+                solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp12));
                 return solution;
             });
 

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -18,7 +18,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
             this.SolutionTransforms.Add((solution, projectId) =>
             {
                 var parseOptions = (CSharpParseOptions)solution.GetProject(projectId)!.ParseOptions!;
-                solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp7_3));
+                solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp8)); // need nullable
 
                 return solution;
             });

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -23,18 +23,19 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         return test.RunAsync();
     }
 
-    public static Task VerifyCodeFixAsync(string source, string fixedSource)
-        => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+    public static Task VerifyCodeFixAsync(string source, string fixedSource, int? codeActionIndex = null)
+        => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource, codeActionIndex);
 
-    public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
-        => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+    public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource, int? codeActionIndex = null)
+        => VerifyCodeFixAsync(source, new[] { expected }, fixedSource, codeActionIndex);
 
-    public static Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    public static Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource, int? codeActionIndex)
     {
         var test = new Test
         {
             TestCode = source,
             FixedCode = fixedSource,
+            CodeActionIndex = codeActionIndex,
         };
 
         test.ExpectedDiagnostics.AddRange(expected);

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF004ExportWithoutImportingConstructorAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF004ExportWithoutImportingConstructorAnalyzerTests.cs
@@ -75,6 +75,22 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzerTests
     }
 
     [Fact]
+    public async Task ClassWithExportAndImportingPrimaryConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            [method: ImportingConstructor]
+            class Foo(string parameter)
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ClassWithExportAndMultipleConstructorsOneImporting_NoWarning()
     {
         string test = """
@@ -109,6 +125,22 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzerTests
                 public {|#0:Foo|}(string parameter)
                 {
                 }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndPrimaryDefaultConstructorWithoutImportingConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class {|#0:Foo|}(string parameter)
+            {
             }
             """;
 

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF004ExportWithoutImportingConstructorAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF004ExportWithoutImportingConstructorAnalyzerTests.cs
@@ -371,8 +371,8 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzerTests
             using System.ComponentModel.Composition;
 
             [AttributeUsage(AttributeTargets.Class)]
-            class MyExportAttribute : ExportAttribute 
-            { 
+            class MyExportAttribute : ExportAttribute
+            {
                 public MyExportAttribute() : base() { }
             }
 
@@ -397,8 +397,8 @@ public class VSMEF004ExportWithoutImportingConstructorAnalyzerTests
             using System.Composition;
 
             [AttributeUsage(AttributeTargets.Class)]
-            class MyExportAttribute : ExportAttribute 
-            { 
+            class MyExportAttribute : ExportAttribute
+            {
                 public MyExportAttribute() : base() { }
             }
 

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF004ExportWithoutImportingConstructorAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF004ExportWithoutImportingConstructorAnalyzerTests.cs
@@ -1,0 +1,567 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = CSharpCodeFixVerifier<Microsoft.VisualStudio.Composition.Analyzers.VSMEF004ExportWithoutImportingConstructorAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSMEF004ExportWithoutImportingConstructorAnalyzerTests
+{
+    [Fact]
+    public async Task ClassWithoutExports_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndDefaultConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndImplicitDefaultConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndImportingConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndMultipleConstructorsOneImporting_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo(string parameter)
+                {
+                }
+
+                [ImportingConstructor]
+                public Foo(int parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndNonDefaultConstructorWithoutImportingConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithPropertyExportAndNonDefaultConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Export]
+                public string Bar { get; set; }
+
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithMethodExportAndNonDefaultConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Export]
+                public string GetValue() => "test";
+
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithFieldExportAndNonDefaultConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Export]
+                public string Field = "test";
+
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithStaticMemberExportAndNonDefaultConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Export]
+                public static string StaticField = "test";
+
+                [Export]
+                public static string StaticProperty { get; set; }
+
+                [Export]
+                public static string StaticMethod() => "test";
+
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithMixedStaticAndInstanceExports_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Export]
+                public static string StaticField = "test";
+
+                [Export]
+                public string InstanceProperty { get; set; }
+
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task AbstractClass_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            abstract class Foo
+            {
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Interface_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            interface IFoo
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Enum_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            enum Foo
+            {
+                Value1
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Struct_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            struct Foo
+            {
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MEFv2ExportAttributeWithNonDefaultConstructor_Warning()
+    {
+        string test = """
+            using System.Composition;
+
+            [Export]
+            class Foo
+            {
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task MEFv2ExportAttributeWithImportingConstructor_NoWarning()
+    {
+        string test = """
+            using System.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task CustomExportAttributeDerivedFromMEFv1_Warning()
+    {
+        string test = """
+            using System;
+            using System.ComponentModel.Composition;
+
+            [AttributeUsage(AttributeTargets.Class)]
+            class MyExportAttribute : ExportAttribute 
+            { 
+                public MyExportAttribute() : base() { }
+            }
+
+            [MyExport]
+            class Foo
+            {
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task CustomExportAttributeDerivedFromMEFv2_Warning()
+    {
+        string test = """
+            using System;
+            using System.Composition;
+
+            [AttributeUsage(AttributeTargets.Class)]
+            class MyExportAttribute : ExportAttribute 
+            { 
+                public MyExportAttribute() : base() { }
+            }
+
+            [MyExport]
+            class Foo
+            {
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task CustomImportingConstructorAttributeDerivedFromMEFv1_NoWarning()
+    {
+        string test = """
+            using System;
+            using System.ComponentModel.Composition;
+
+            [AttributeUsage(AttributeTargets.Constructor)]
+            class MyImportingConstructorAttribute : ImportingConstructorAttribute { }
+
+            [Export]
+            class Foo
+            {
+                [MyImportingConstructor]
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task CustomImportingConstructorAttributeDerivedFromMEFv2_NoWarning()
+    {
+        string test = """
+            using System.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithDefaultAndNonDefaultConstructors_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo()
+                {
+                }
+
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithMultipleNonDefaultConstructorsNoneImporting_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public {|#0:Foo|}(string parameter)
+                {
+                }
+
+                public Foo(int parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndPrivateConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                private {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndInternalConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                internal {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithExportAndProtectedConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                protected {|#0:Foo|}(string parameter)
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NestedClassWithExportAndNonDefaultConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Outer
+            {
+                [Export]
+                class Foo
+                {
+                    public {|#0:Foo|}(string parameter)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithoutMEFReferences_NoWarning()
+    {
+        string test = """
+            // No MEF using statements
+            class Foo
+            {
+                public Foo(string parameter)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF005MultipleImportingConstructorsAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF005MultipleImportingConstructorsAnalyzerTests.cs
@@ -1,0 +1,337 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = CSharpCodeFixVerifier<Microsoft.VisualStudio.Composition.Analyzers.VSMEF005MultipleImportingConstructorsAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSMEF005MultipleImportingConstructorsAnalyzerTests
+{
+    [Fact]
+    public async Task ClassWithNoConstructors_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithSingleImportingConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo(string value) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithSingleNonImportingConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo(string value) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithMultipleNonImportingConstructors_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo() { }
+                public Foo(string value) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithMultipleImportingConstructors_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}() { }
+
+                [ImportingConstructor]
+                public {|#1:Foo|}(string value) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithMultipleImportingConstructors_MefV2_Warning()
+    {
+        string test = """
+            using System.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}() { }
+
+                [ImportingConstructor]
+                public {|#1:Foo|}(string value) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithThreeImportingConstructors_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}() { }
+
+                [ImportingConstructor]
+                public {|#1:Foo|}(string value) { }
+
+                [ImportingConstructor]
+                public {|#2:Foo|}(int value) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(2).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithMultipleImportingConstructors_MixedParameterTypes_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            interface IService { }
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}([Import]IService service) { }
+
+                [ImportingConstructor]
+                public {|#1:Foo|}([ImportMany]IService[] services) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithImportingConstructorAndRegularConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo() { }
+
+                [ImportingConstructor]
+                public Foo(string value) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task InheritedClass_WithMultipleImportingConstructors_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}() { }
+
+                [ImportingConstructor]
+                public {|#1:Foo|}(string value) { }
+            }
+
+            [Export]
+            class Bar : Foo
+            {
+                public Bar() : base() { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task CustomImportingConstructorAttribute_MEFv1_Warning()
+    {
+        string test = """
+            using System;
+            using System.ComponentModel.Composition;
+
+            class CustomImportingConstructorAttribute : ImportingConstructorAttribute
+            {
+            }
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}() { }
+
+                [CustomImportingConstructor]
+                public {|#1:Foo|}(string value) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task MixedMEFVersions_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+            using MEFv2 = System.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]  // MEF v1
+                public {|#0:Foo|}() { }
+
+                [MEFv2.ImportingConstructor]  // MEF v2
+                public {|#1:Foo|}(string value) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ClassWithMultipleImportingConstructors_NestedInNamespace_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            namespace MyNamespace
+            {
+                [Export]
+                class Foo
+                {
+                    [ImportingConstructor]
+                    public {|#0:Foo|}() { }
+
+                    [ImportingConstructor]
+                    public {|#1:Foo|}(string value) { }
+                }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task GenericClassWithMultipleImportingConstructors_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo<T>
+            {
+                [ImportingConstructor]
+                public {|#0:Foo|}() { }
+
+                [ImportingConstructor]
+                public {|#1:Foo|}(T value) { }
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Foo"),
+            VerifyCS.Diagnostic().WithLocation(1).WithArguments("Foo"),
+        };
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+}

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF006ImportNullabilityAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF006ImportNullabilityAnalyzerTests.cs
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.Composition.Analyzers;
+using VerifyCS = CSharpCodeFixVerifier<Microsoft.VisualStudio.Composition.Analyzers.VSMEF006ImportNullabilityAnalyzer, Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.VSMEF006ImportNullabilityCodeFixProvider>;
+
+public class VSMEF006ImportNullabilityAnalyzerTests
+{
+    [Fact]
+    public async Task ImportWithoutNullableAnnotations_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string Value { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NullableImportWithAllowDefault_NoWarning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string? Value { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonNullableImportWithoutAllowDefault_NoWarning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string Value { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NullableImportWithoutAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NonNullableImportWithAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string {|#0:Value|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.AllowDefaultWithoutNullableDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NullablePropertyImportWithoutAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NullableConstructorParameterImportWithoutAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import] string? {|#0:value|})
+                {
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ImportManyWithNullableWithoutAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+            using System.Collections.Generic;
+
+            class Foo
+            {
+                [ImportMany]
+                public IEnumerable<string>? {|#0:Values|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Values");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task MefV2NullableImportWithoutAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task MefV2NonNullableImportWithAllowDefault_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string {|#0:Value|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.AllowDefaultWithoutNullableDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NullableImportWithAllowDefaultFalse_Warning()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = false)]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task NullableImportWithoutAllowDefault_CodeFix_AddAllowDefault()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        string fixedTest = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string? Value { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedTest);
+    }
+
+    [Fact]
+    public async Task NullableImportWithoutAllowDefault_CodeFix_MakeNonNullable()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        string fixedTest = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string Value { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedTest, 1); // Second code fix
+    }
+
+    [Fact]
+    public async Task NonNullableImportWithAllowDefault_CodeFix_MakeNullable()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string {|#0:Value|} { get; set; }
+            }
+            """;
+
+        string fixedTest = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string? Value { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.AllowDefaultWithoutNullableDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedTest);
+    }
+
+    [Fact]
+    public async Task NonNullableImportWithAllowDefault_CodeFix_RemoveAllowDefault()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string {|#0:Value|} { get; set; }
+            }
+            """;
+
+        string fixedTest = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string Value { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.AllowDefaultWithoutNullableDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedTest, 1); // Second code fix
+    }
+
+    [Fact]
+    public async Task NullablePropertyImportWithoutAllowDefault_CodeFix_AddAllowDefault()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        string fixedTest = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string? Value { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedTest);
+    }
+
+    [Fact]
+    public async Task ImportWithExistingAllowDefaultFalse_CodeFix_UpdateToTrue()
+    {
+        string test = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = false)]
+                public string? {|#0:Value|} { get; set; }
+            }
+            """;
+
+        string fixedTest = """
+            #nullable enable
+            using System.ComponentModel.Composition;
+
+            class Foo
+            {
+                [Import(AllowDefault = true)]
+                public string? Value { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(VSMEF006ImportNullabilityAnalyzer.NullableWithoutAllowDefaultDescriptor)
+            .WithLocation(0)
+            .WithArguments("Value");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedTest);
+    }
+}

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF007DuplicateImportAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF007DuplicateImportAnalyzerTests.cs
@@ -1,0 +1,409 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.Composition.Analyzers;
+using VerifyCS = CSharpCodeFixVerifier<Microsoft.VisualStudio.Composition.Analyzers.VSMEF007DuplicateImportAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSMEF007DuplicateImportAnalyzerTests
+{
+    [Fact]
+    public async Task ClassWithNoImports_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithSingleImport_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import]
+                public string Value { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithDifferentTypeImports_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import]
+                public string StringValue { get; set; }
+                
+                [Import]
+                public int IntValue { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithDuplicateTypeImports_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import]
+                public string {|#0:Value1|} { get; set; }
+                
+                [Import]
+                public string {|#1:Value2|} { get; set; }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ClassWithDuplicateImportsInConstructor_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import] string {|#0:value1|}, [Import] string {|#1:value2|})
+                {
+                }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ClassWithMixedPropertyAndConstructorDuplicates_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import]
+                public string {|#0:PropertyValue|} { get; set; }
+                
+                [ImportingConstructor]
+                public Foo([Import] string {|#1:constructorValue|})
+                {
+                }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ClassWithDifferentContractNames_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import("Contract1")]
+                public string Value1 { get; set; }
+                
+                [Import("Contract2")]
+                public string Value2 { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ClassWithSameContractNames_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import("SameContract")]
+                public string {|#0:Value1|} { get; set; }
+                
+                [Import("SameContract")]
+                public string {|#1:Value2|} { get; set; }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "SameContract");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "SameContract");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ClassWithMefV2Attributes_Warning()
+    {
+        string test = """
+            using System.Composition;
+
+            [Export]
+            class Foo
+            {
+                [Import]
+                public string {|#0:Value1|} { get; set; }
+                
+                [Import]
+                public string {|#1:Value2|} { get; set; }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ConstructorWithDifferentTypeImports_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import] string stringValue, [Import] int intValue)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ConstructorWithDifferentContractNames_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import("Contract1")] string value1, [Import("Contract2")] string value2)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ConstructorWithSameContractNames_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import("SameContract")] string {|#0:value1|}, [Import("SameContract")] string {|#1:value2|})
+                {
+                }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "SameContract");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "SameContract");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ConstructorWithThreeDuplicateImports_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import] string {|#0:value1|}, [Import] string {|#1:value2|}, [Import] string {|#2:value3|})
+                {
+                }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        var expected2 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(2)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1, expected2);
+    }
+
+    [Fact]
+    public async Task ConstructorWithMixedImportAndNonImportParameters_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import] string {|#0:importedValue1|}, string nonImportedValue, [Import] string {|#1:importedValue2|})
+                {
+                }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task ConstructorWithContractTypeParameter_Warning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([Import(typeof(string))] object {|#0:value1|}, [Import(typeof(string))] object {|#1:value2|})
+                {
+                }
+            }
+            """;
+
+        var expected0 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(0)
+            .WithArguments("Foo", "string");
+
+        var expected1 = VerifyCS.Diagnostic(VSMEF007DuplicateImportAnalyzer.Descriptor)
+            .WithLocation(1)
+            .WithArguments("Foo", "string");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected0, expected1);
+    }
+
+    [Fact]
+    public async Task NonImportingConstructor_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+
+            [Export]
+            class Foo
+            {
+                public Foo(string value1, string value2)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ConstructorWithImportManyAttributes_NoWarning()
+    {
+        string test = """
+            using System.ComponentModel.Composition;
+            using System.Collections.Generic;
+
+            [Export]
+            class Foo
+            {
+                [ImportingConstructor]
+                public Foo([ImportMany] IEnumerable<string> values1, [ImportMany] IEnumerable<int> values2)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
Fixes #257
Fixes #287
Fixes #317

New analyzers for:

- Missing `[ImportingConstructor]`
- Duplicate `[ImportingConstructor]`
- Duplicate `[Import]`
- Mismatched C# nullability and `AllowDefault`

Mostly coded using GitHub Copilot.