### PR TITLE
Support generic type parameters in TypeMismatchAnalyzer

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF003ExportTypeMismatchAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF003ExportTypeMismatchAnalyzer.cs
@@ -155,7 +155,7 @@ public class VSMEF003ExportTypeMismatchAnalyzer : DiagnosticAnalyzer
         // Check if implementing type implements exported interface
         if (exportedType.TypeKind == TypeKind.Interface)
         {
-            return implementingType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, exportedType));
+            return implementingType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i.IsGenericType ? i.ConstructUnboundGenericType() : i, exportedType));
         }
 
         return false;

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF003ExportTypeMismatchAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF003ExportTypeMismatchAnalyzerTests.cs
@@ -41,6 +41,44 @@ public class VSMEF003ExportTypeMismatchAnalyzerTests
     }
 
     [Fact]
+    public async Task ExportingImplementedGenericTypeInterface_ProducesNoDiagnostic()
+    {
+        string test = """
+            using System.Composition;
+
+            interface ITest<T> where T : class
+            {
+            }
+
+            [Export(typeof(ITest<>))]
+            class Test<T> : ITest<T> where T : class
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExportingImplementedMultiGenericTypeInterface_ProducesNoDiagnostic()
+    {
+        string test = """
+            using System.Composition;
+
+            interface ITest<T,V> where T : class where V : class
+            {
+            }
+
+            [Export(typeof(ITest<,>))]
+            class Test<A,B> : ITest<A,B> where A : class where B : class
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ExportingBaseClass_ProducesNoDiagnostic()
     {
         string test = """


### PR DESCRIPTION
Created some tests and a fix for the case of a generic type, as it looks like this should be valid and not throw a warning.