### PR TITLE
Check exported type for unbound types instead.

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF003ExportTypeMismatchAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/VSMEF003ExportTypeMismatchAnalyzer.cs
@@ -155,7 +155,7 @@ public class VSMEF003ExportTypeMismatchAnalyzer : DiagnosticAnalyzer
         // Check if implementing type implements exported interface
         if (exportedType.TypeKind == TypeKind.Interface)
         {
-            return implementingType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i.IsGenericType ? i.ConstructUnboundGenericType() : i, exportedType));
+            return implementingType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(exportedType.IsUnboundGenericType ? i.ConstructUnboundGenericType() : i, exportedType));
         }
 
         return false;

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF003ExportTypeMismatchAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/VSMEF003ExportTypeMismatchAnalyzerTests.cs
@@ -41,6 +41,33 @@ public class VSMEF003ExportTypeMismatchAnalyzerTests
     }
 
     [Fact]
+    public async Task ExportingImplementedMultiTypeInterface_ProducesNoDiagnostic()
+    {
+        string test = """
+            using System.Composition;
+
+            class TestType1
+            {
+            }
+
+            class TestType2
+            {
+            }
+
+            interface ITest<T,V> where T : class where V : class
+            {
+            }
+
+            [Export(typeof(ITest<TestType1,TestType2>))]
+            class Test : ITest<TestType1,TestType2>
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ExportingImplementedGenericTypeInterface_ProducesNoDiagnostic()
     {
         string test = """


### PR DESCRIPTION
Looks like checking for generic types interfered with some other valid implementation of exports. I've added a new test and adjusted the logic a bit to account for this implementation as well.