### PR TITLE
Fix up some broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Lightning fast MEF engine, supporting System.ComponentModel.Composition and Syst
 
 ### Documentation
 
-* [Why VS-MEF?](https://microsoft.github.io/vs-mef/docs/why.md)
-* [Differences between .NET MEF, NuGet MEF and VS MEF](https://microsoft.github.io/vs-mef/docs/mef_library_differences.md)
-* [Hosting](https://microsoft.github.io/vs-mef/docs/hosting.md)
-* [more docs](https://microsoft.github.io/vs-mef/docs/index.md)
+* [Getting started](https://microsoft.github.io/vs-mef/docs/getting-started.html)
+* [Why VS-MEF?](https://microsoft.github.io/vs-mef/docs/why.html)
+* [Differences between .NET MEF, NuGet MEF and VS MEF](https://microsoft.github.io/vs-mef/docs/mef_library_differences.html)
+* [Hosting](https://microsoft.github.io/vs-mef/docs/hosting.html)
 
 [Learn more about this package](src/Microsoft.VisualStudio.Composition/README.md).
 

--- a/src/Microsoft.VisualStudio.Composition/README.md
+++ b/src/Microsoft.VisualStudio.Composition/README.md
@@ -8,7 +8,7 @@
 
 ## Documentation
 
-* [Why VS-MEF?](https://github.com/microsoft/vs-mef/blob/main/doc/why.md)
-* [Differences between .NET MEF, NuGet MEF and VS MEF](https://github.com/microsoft/vs-mef/blob/main/doc/mef_library_differences.md)
-* [Hosting](https://github.com/microsoft/vs-mef/blob/main/doc/hosting.md)
-* [more docs](https://github.com/microsoft/vs-mef/blob/main/doc/index.md)
+* [Getting started](https://microsoft.github.io/vs-mef/docs/getting-started.html)
+* [Why VS-MEF?](https://microsoft.github.io/vs-mef/docs/why.html)
+* [Differences between .NET MEF, NuGet MEF and VS MEF](https://microsoft.github.io/vs-mef/docs/mef_library_differences.html)
+* [Hosting](https://microsoft.github.io/vs-mef/docs/hosting.html)


### PR DESCRIPTION
Two issues are fixed here:

- In _non_-docfx md files, links must be expressed with .html extensions. I missed this in a few places.
- An index.md file was removed, but links to it remained. I've changed these to point to the getting-started doc.