### PR TITLE
Reclassify samples as tests

### DIFF
--- a/tools/Get-SymbolFiles.ps1
+++ b/tools/Get-SymbolFiles.ps1
@@ -18,7 +18,7 @@ Write-Progress -Activity $ActivityName -CurrentOperation "Discovery PDB files"
 $PDBs = Get-ChildItem -rec "$Path/*.pdb"
 
 # Filter PDBs to product OR test related.
-$testregex = "unittest|tests|\.test\."
+$testregex = "unittest|tests|\.test\.|samples"
 
 Write-Progress -Activity $ActivityName -CurrentOperation "De-duplicating symbols"
 $PDBsByHash = @{}


### PR DESCRIPTION
They are not shipping binaries, so we don't sign nor archive their symbols.