### PR TITLE
Concrete metadata view class improvements

### DIFF
--- a/docfx/docs/metadata-views.md
+++ b/docfx/docs/metadata-views.md
@@ -1,0 +1,73 @@
+# Metadata views
+
+VS MEF supports several ways to consume export metadata through a strongly-typed view. The differences between them matter because they affect:
+
+- which exports are filtered out during composition
+- whether `[DefaultValue]` participates in metadata access only, or also in filtering
+- whether metadata types such as `System.Type` and `System.Type[]` preserve VS MEF's lazy assembly-load behavior
+
+## Interface metadata views
+
+An interface metadata view is the baseline model.
+
+[!code-csharp[](../../samples/docs/MetadataViews.cs#InterfaceMetadataView)]
+
+For interface metadata views:
+
+- properties **without** `[DefaultValue]` are **required**
+- properties **with** `[DefaultValue]` are **optional**
+- required properties filter exports by **presence** and **type compatibility**
+- optional properties allow the metadata key to be absent, but if the key is present its value still has to be type-compatible
+
+This is the most predictable model when you want the metadata contract itself to define filtering behavior.
+
+## Legacy metadata view implementation classes
+
+MEF v1 also supports applying <xref:System.ComponentModel.Composition.MetadataViewImplementationAttribute> to an interface and pointing it at a concrete implementation type.
+
+[!code-csharp[](../../samples/docs/MetadataViews.cs#LegacyMetadataViewImplementation)]
+
+The legacy implementation style uses a constructor that accepts the raw metadata dictionary. This remains supported for compatibility.
+
+For these legacy dictionary-backed implementation classes:
+
+- required interface properties still participate in filtering
+- optional interface properties are **not** included in the filter model
+- the implementation class is responsible for reading metadata, applying defaults, and coercing values
+
+Because the implementation is working directly from the raw dictionary, it does **not** automatically inherit the full interface metadata-view behavior.
+
+## `MetadataView`-based implementation classes
+
+VS MEF now includes <xref:Microsoft.VisualStudio.Composition.MetadataView> to make concrete metadata view implementations easier to write while still keeping the interface as the metadata contract.
+
+[!code-csharp[](../../samples/docs/MetadataViews.cs#MetadataViewBaseImplementation)]
+
+For `MetadataView`-derived implementation classes:
+
+- the interface remains the canonical filtering contract
+- required properties filter by presence and type compatibility
+- optional properties participate as optional constraints just like ordinary interface metadata views
+- `[DefaultValue]` is honored through the same metadata-view pipeline used for interfaces
+- metadata values such as `System.Type` and `System.Type[]` preserve VS MEF's lazy materialization behavior because the values are read through the library's metadata wrappers instead of eagerly coerced by user code
+
+This is the recommended approach when you want a concrete metadata view type without reimplementing the filtering and lazy metadata semantics yourself.
+
+> [!IMPORTANT]
+> A type derived from <xref:Microsoft.VisualStudio.Composition.MetadataView> is **not** meant to be used directly as `TMetadata` in `Lazy<T, TMetadata>`. It must be reached through an interface metadata view that is annotated with <xref:System.ComponentModel.Composition.MetadataViewImplementationAttribute>. VS MEF rejects direct use as an unsupported metadata view type, so declared imports fail during composition and direct export queries fail when the query is evaluated.
+
+## Choosing a model
+
+Use:
+
+- a plain **interface metadata view** when an interface is sufficient
+- a **`MetadataView`-derived class** when you want a concrete type but still want interface-style filtering and metadata handling
+- a **dictionary-constructor implementation** only when you need to preserve existing MEF v1 behavior or custom dictionary-based logic
+
+## Behavior summary
+
+| Metadata view model | Required properties filter | Optional properties filter | Defaults handled by VS MEF | Preserves lazy `Type` / `Type[]` behavior |
+| --- | --- | --- | --- | --- |
+| Interface metadata view | Yes | Yes, when present | Yes | Yes |
+| Legacy dictionary-backed implementation | Yes | No | No, implementation decides | Not automatically |
+| `MetadataView`-derived implementation | Yes | Yes, when present | Yes | Yes |

--- a/docfx/docs/metadata-views.md
+++ b/docfx/docs/metadata-views.md
@@ -37,13 +37,13 @@ For these legacy dictionary-backed implementation classes:
 
 Because the implementation is working directly from the raw dictionary, it does **not** automatically inherit the full interface metadata-view behavior.
 
-## `MetadataView`-based implementation classes
+## Interface-backed `MetadataView` implementation classes
 
 VS MEF now includes <xref:Microsoft.VisualStudio.Composition.MetadataView> to make concrete metadata view implementations easier to write while still keeping the interface as the metadata contract.
 
 [!code-csharp[](../../samples/docs/MetadataViews.cs#MetadataViewBaseImplementation)]
 
-For `MetadataView`-derived implementation classes:
+For interface-backed `MetadataView`-derived implementation classes:
 
 - the interface remains the canonical filtering contract
 - required properties filter by presence and type compatibility
@@ -54,14 +54,32 @@ For `MetadataView`-derived implementation classes:
 This is the recommended approach when you want a concrete metadata view type without reimplementing the filtering and lazy metadata semantics yourself.
 
 > [!IMPORTANT]
-> A type derived from <xref:Microsoft.VisualStudio.Composition.MetadataView> is **not** meant to be used directly as `TMetadata` in `Lazy<T, TMetadata>`. It must be reached through an interface metadata view that is annotated with <xref:System.ComponentModel.Composition.MetadataViewImplementationAttribute>. VS MEF rejects direct use as an unsupported metadata view type, so declared imports fail during composition and direct export queries fail when the query is evaluated.
+> When a <xref:Microsoft.VisualStudio.Composition.MetadataView>-derived type is reached through <xref:System.ComponentModel.Composition.MetadataViewImplementationAttribute>, the attributed interface remains the metadata contract.
+
+## Direct `MetadataView` classes
+
+You can also use a <xref:Microsoft.VisualStudio.Composition.MetadataView>-derived class directly as `TMetadata`.
+
+[!code-csharp[](../../samples/docs/MetadataViews.cs#DirectMetadataView)]
+
+For direct `MetadataView` classes:
+
+- the metadata contract is the set of **public instance properties** on the class and its base types
+- required properties are those without `[DefaultValue]`
+- optional properties are those with `[DefaultValue]`
+- optional properties still filter by type compatibility when metadata is present
+- inherited public properties participate in both filtering and default handling
+- if a derived class hides a base property with the same name, the **most-derived property wins**
+- implemented interfaces are ignored for this direct path
+- metadata values such as `System.Type` and `System.Type[]` preserve VS MEF's lazy materialization behavior because the values are read through the library's metadata wrappers instead of eagerly coerced by user code
 
 ## Choosing a model
 
 Use:
 
 - a plain **interface metadata view** when an interface is sufficient
-- a **`MetadataView`-derived class** when you want a concrete type but still want interface-style filtering and metadata handling
+- an **interface-backed `MetadataView`-derived class** when you want a concrete type but want an interface to remain the metadata contract
+- a **direct `MetadataView`-derived class** when the class itself should define the metadata contract through its public instance properties
 - a **dictionary-constructor implementation** only when you need to preserve existing MEF v1 behavior or custom dictionary-based logic
 
 ## Behavior summary
@@ -70,4 +88,5 @@ Use:
 | --- | --- | --- | --- | --- |
 | Interface metadata view | Yes | Yes, when present | Yes | Yes |
 | Legacy dictionary-backed implementation | Yes | No | No, implementation decides | Not automatically |
-| `MetadataView`-derived implementation | Yes | Yes, when present | Yes | Yes |
+| Interface-backed `MetadataView` implementation | Yes | Yes, when present | Yes | Yes |
+| Direct `MetadataView` class | Yes | Yes, when present | Yes | Yes |

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -2,6 +2,7 @@ items:
 - href: getting-started.md
 - href: dynamic_recomposition.md
 - href: hosting.md
+- href: metadata-views.md
 - href: mef_library_differences.md
 - href: vsmefx.md
 - href: why.md

--- a/samples/docs/MetadataViews.cs
+++ b/samples/docs/MetadataViews.cs
@@ -87,3 +87,28 @@ public class HandlerMetadataView : MetadataView, IConcreteHandlerMetadata
 }
 
 #endregion
+
+#region DirectMetadataView
+
+public class DirectHandlerMetadataBase : MetadataView
+{
+    [DefaultValue(false)]
+    public bool SupportsAsync => this.GetMetadata<bool>();
+}
+
+public class DirectHandlerMetadata : DirectHandlerMetadataBase
+{
+    public string Name => this.GetMetadata<string>();
+
+    [DefaultValue(null)]
+    public Type HandlerType => this.GetMetadata<Type>();
+}
+
+[MefV1.Export]
+internal class DirectMetadataImporter
+{
+    [MefV1.ImportMany("Handler")]
+    public IEnumerable<Lazy<object, DirectHandlerMetadata>> Handlers { get; set; } = null!;
+}
+
+#endregion

--- a/samples/docs/MetadataViews.cs
+++ b/samples/docs/MetadataViews.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Samples.MetadataViews;
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.VisualStudio.Composition;
+using MefV1 = System.ComponentModel.Composition;
+
+#region InterfaceMetadataView
+
+public interface IHandlerMetadata
+{
+    string Name { get; }
+
+    [DefaultValue(false)]
+    bool SupportsAsync { get; }
+}
+
+[MefV1.Export("Handler", typeof(object))]
+[MefV1.ExportMetadata(nameof(IHandlerMetadata.Name), "Text")]
+internal class TextHandler
+{
+}
+
+[MefV1.Export]
+internal class InterfaceMetadataImporter
+{
+    [MefV1.ImportMany("Handler")]
+    public IEnumerable<Lazy<object, IHandlerMetadata>> Handlers { get; set; } = null!;
+}
+
+#endregion
+
+#region LegacyMetadataViewImplementation
+
+[MefV1.MetadataViewImplementation(typeof(LegacyHandlerMetadataView))]
+public interface ILegacyHandlerMetadata
+{
+    string Name { get; }
+
+    [DefaultValue(false)]
+    bool SupportsAsync { get; }
+}
+
+public class LegacyHandlerMetadataView : ILegacyHandlerMetadata
+{
+    public LegacyHandlerMetadataView(IDictionary<string, object> metadata)
+    {
+        this.Name = metadata.ContainsKey(nameof(ILegacyHandlerMetadata.Name))
+            ? (string)metadata[nameof(ILegacyHandlerMetadata.Name)]
+            : string.Empty;
+        this.SupportsAsync = metadata.ContainsKey(nameof(ILegacyHandlerMetadata.SupportsAsync))
+            && (bool)metadata[nameof(ILegacyHandlerMetadata.SupportsAsync)];
+    }
+
+    public string Name { get; }
+
+    public bool SupportsAsync { get; }
+}
+
+#endregion
+
+#region MetadataViewBaseImplementation
+
+[MefV1.MetadataViewImplementation(typeof(HandlerMetadataView))]
+public interface IConcreteHandlerMetadata
+{
+    string Name { get; }
+
+    [DefaultValue(false)]
+    bool SupportsAsync { get; }
+
+    [DefaultValue(null)]
+    Type HandlerType { get; }
+}
+
+public class HandlerMetadataView : MetadataView, IConcreteHandlerMetadata
+{
+    public string Name => this.GetMetadata<string>();
+
+    public bool SupportsAsync => this.GetMetadata<bool>();
+
+    public Type HandlerType => this.GetMetadata<Type>();
+}
+
+#endregion

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.Composition
         private static readonly ImmutableHashSet<ComposablePartDefinition> AlwaysBundledParts = ImmutableHashSet.Create(
             ExportProvider.ExportProviderPartDefinition,
             PassthroughMetadataViewProvider.PartDefinition,
+            MetadataViewDirectProvider.PartDefinition,
             MetadataViewClassProvider.PartDefinition,
             MetadataViewClassDefaultCtorProvider.PartDefinition,
             ExportMetadataViewInterfaceEmitProxy.PartDefinition)

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -109,9 +109,16 @@ namespace Microsoft.VisualStudio.Composition
 
                     var parameters = ctor.GetParameters();
                     return parameters.Length == 1
-                        && (parameters[0].ParameterType.IsAssignableFrom(typeof(IDictionary<string, object?>))
-                        || parameters[0].ParameterType.IsAssignableFrom(typeof(IReadOnlyDictionary<string, object?>)));
+                        && IsSupportedDictionaryParameterType(parameters[0].ParameterType);
                 });
+        }
+
+        private static bool IsSupportedDictionaryParameterType(Type parameterType)
+        {
+            return (typeof(IDictionary<string, object?>).IsAssignableFrom(parameterType)
+                || typeof(IReadOnlyDictionary<string, object?>).IsAssignableFrom(parameterType))
+                && (parameterType.IsAssignableFrom(typeof(Dictionary<string, object?>))
+                || parameterType.IsAssignableFrom(typeof(ImmutableDictionary<string, object?>)));
         }
 
         private readonly struct ImplementationActivation
@@ -149,7 +156,14 @@ namespace Microsoft.VisualStudio.Composition
 
             private static object InvokeDictionaryConstructor(IReadOnlyDictionary<string, object?> metadata, ConstructorInfo constructor)
             {
-                object metadataMaybeWrapped = constructor.GetParameters()[0].ParameterType.IsAssignableFrom(metadata.GetType()) ? metadata : ImmutableDictionary.CreateRange(metadata);
+                Type parameterType = constructor.GetParameters()[0].ParameterType;
+                object metadataMaybeWrapped = parameterType.IsInstanceOfType(metadata)
+                    ? metadata
+                    : parameterType.IsAssignableFrom(typeof(Dictionary<string, object?>))
+                    ? metadata.ToDictionary(pair => pair.Key, pair => pair.Value)
+                    : parameterType.IsAssignableFrom(typeof(ImmutableDictionary<string, object?>))
+                    ? ImmutableDictionary.CreateRange(metadata)
+                    : throw Assumes.NotReachable();
                 return constructor.Invoke(new[] { metadataMaybeWrapped });
             }
         }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.Composition
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Globalization;
     using System.Linq;
     using System.Reflection;
     using MefV1 = System.ComponentModel.Composition;
@@ -14,42 +16,142 @@ namespace Microsoft.VisualStudio.Composition
         internal static readonly ComposablePartDefinition PartDefinition =
             Utilities.GetMetadataViewProviderPartDefinition(typeof(MetadataViewImplProxy), 100, Resolver.DefaultInstance);
 
+        internal enum ImplementationKind
+        {
+            None,
+            LegacyDictionary,
+            MetadataViewBase,
+        }
+
         public bool IsMetadataViewSupported(Type metadataType)
         {
-            return HasMetadataViewImplementation(metadataType);
+            return TryGetImplementationActivation(metadataType, throwOnInvalidConfiguration: true) is object;
         }
 
         public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
         {
-            var ctor = FindImplClassConstructor(metadataViewType);
-            Assumes.NotNull(ctor);
-            return ctor.Invoke(new object[] { metadata });
+            var activation = TryGetImplementationActivation(metadataViewType, throwOnInvalidConfiguration: true);
+            Assumes.NotNull(activation);
+            return activation.Value.CreateProxy(metadata, defaultValues, metadataViewType);
         }
 
         internal static bool HasMetadataViewImplementation(Type metadataType)
         {
-            return FindImplClassConstructor(metadataType) != null;
+            return GetImplementationKind(metadataType) != ImplementationKind.None;
         }
 
-        private static ConstructorInfo? FindImplClassConstructor(Type metadataType)
+        internal static ImplementationKind GetImplementationKind(Type metadataType)
+        {
+            return TryGetImplementationActivation(metadataType, throwOnInvalidConfiguration: true)?.Kind ?? ImplementationKind.None;
+        }
+
+        private static ImplementationActivation? TryGetImplementationActivation(Type metadataType, bool throwOnInvalidConfiguration)
         {
             Requires.NotNull(metadataType, nameof(metadataType));
+
             var attr = metadataType.GetTypeInfo().GetFirstAttribute<MefV1.MetadataViewImplementationAttribute>();
-            if (attr != null)
+            if (attr == null)
             {
-                if (metadataType.IsAssignableFrom(attr.ImplementationType))
+                return null;
+            }
+
+            Type? implementationType = attr.ImplementationType;
+            if (implementationType == null || !metadataType.IsAssignableFrom(implementationType))
+            {
+                if (throwOnInvalidConfiguration)
                 {
-                    var ctors = from ctor in attr.ImplementationType?.GetConstructors(BindingFlags.Public | BindingFlags.Instance) ?? Enumerable.Empty<ConstructorInfo>()
-                                let parameters = ctor.GetParameters()
-                                where parameters.Length == 1 && (
-                                    parameters[0].ParameterType.IsAssignableFrom(typeof(IDictionary<string, object?>)) ||
-                                    parameters[0].ParameterType.IsAssignableFrom(typeof(IReadOnlyDictionary<string, object?>)))
-                                select ctor;
-                    return ctors.FirstOrDefault();
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationTypeMustImplementMetadataView, implementationType?.FullName, metadataType.FullName));
                 }
+
+                return null;
+            }
+
+            TypeInfo implementationTypeInfo = implementationType.GetTypeInfo();
+
+            ConstructorInfo? ctor = FindDefaultConstructor(implementationTypeInfo);
+            if (ctor != null && typeof(MetadataView).GetTypeInfo().IsAssignableFrom(implementationTypeInfo))
+            {
+                return new ImplementationActivation(ImplementationKind.MetadataViewBase, ctor);
+            }
+
+            ctor = FindDictionaryConstructor(implementationTypeInfo);
+            if (ctor != null)
+            {
+                return new ImplementationActivation(ImplementationKind.LegacyDictionary, ctor);
+            }
+
+            if (throwOnInvalidConfiguration)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationConstructorUnsupported, implementationType.FullName, metadataType.FullName));
             }
 
             return null;
+        }
+
+        private static ConstructorInfo? FindDefaultConstructor(TypeInfo implementationType)
+        {
+            Requires.NotNull(implementationType, nameof(implementationType));
+
+            return implementationType.DeclaredConstructors.FirstOrDefault(ctor => ctor.IsPublic && !ctor.IsStatic && ctor.GetParameters().Length == 0);
+        }
+
+        private static ConstructorInfo? FindDictionaryConstructor(TypeInfo implementationType)
+        {
+            Requires.NotNull(implementationType, nameof(implementationType));
+
+            return implementationType.DeclaredConstructors.FirstOrDefault(
+                ctor =>
+                {
+                    if (!ctor.IsPublic || ctor.IsStatic)
+                    {
+                        return false;
+                    }
+
+                    var parameters = ctor.GetParameters();
+                    return parameters.Length == 1
+                        && (parameters[0].ParameterType.IsAssignableFrom(typeof(IDictionary<string, object?>))
+                        || parameters[0].ParameterType.IsAssignableFrom(typeof(IReadOnlyDictionary<string, object?>)));
+                });
+        }
+
+        private readonly struct ImplementationActivation
+        {
+            internal ImplementationActivation(ImplementationKind kind, ConstructorInfo constructor)
+            {
+                this.Kind = kind;
+                this.Constructor = constructor;
+            }
+
+            internal ImplementationKind Kind { get; }
+
+            internal ConstructorInfo Constructor { get; }
+
+            internal object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
+            {
+                Requires.NotNull(metadata, nameof(metadata));
+                Requires.NotNull(defaultValues, nameof(defaultValues));
+                Requires.NotNull(metadataViewType, nameof(metadataViewType));
+
+                return this.Kind switch
+                {
+                    ImplementationKind.MetadataViewBase => InitializeMetadataView(metadata, defaultValues, this.Constructor),
+                    ImplementationKind.LegacyDictionary => InvokeDictionaryConstructor(metadata, this.Constructor),
+                    _ => throw Assumes.NotReachable(),
+                };
+            }
+
+            private static object InitializeMetadataView(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, ConstructorInfo constructor)
+            {
+                var metadataView = (MetadataView)constructor.Invoke(Type.EmptyTypes);
+                metadataView.Initialize(metadata, defaultValues);
+                return metadataView;
+            }
+
+            private static object InvokeDictionaryConstructor(IReadOnlyDictionary<string, object?> metadata, ConstructorInfo constructor)
+            {
+                object metadataMaybeWrapped = constructor.GetParameters()[0].ParameterType.IsAssignableFrom(metadata.GetType()) ? metadata : ImmutableDictionary.CreateRange(metadata);
+                return constructor.Invoke(new[] { metadataMaybeWrapped });
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -850,15 +850,18 @@ namespace Microsoft.VisualStudio.Composition
                 if (metadataView.GetTypeInfo().IsClass || (metadataView.GetTypeInfo().IsInterface && !metadataView.Equals(typeof(IDictionary<string, object?>))))
                 {
                     var metadataBuilder = ImmutableDictionary.CreateBuilder<string, object?>();
+                    var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
                     foreach (var property in metadataView.EnumProperties().WherePublicInstance())
                     {
-                        if (!metadataBuilder.ContainsKey(property.Name))
+                        if (!seenPropertyNames.Add(property.Name))
                         {
-                            var defaultValueAttribute = property.GetFirstAttribute<DefaultValueAttribute>();
-                            if (defaultValueAttribute != null)
-                            {
-                                metadataBuilder.Add(property.Name, defaultValueAttribute.Value);
-                            }
+                            continue;
+                        }
+
+                        var defaultValueAttribute = property.GetFirstAttribute<DefaultValueAttribute>();
+                        if (defaultValueAttribute != null)
+                        {
+                            metadataBuilder.Add(property.Name, defaultValueAttribute.Value);
                         }
                     }
 

--- a/src/Microsoft.VisualStudio.Composition/ImportMetadataViewConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportMetadataViewConstraint.cs
@@ -173,7 +173,9 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(resolver, nameof(resolver));
 
             var metadataView = metadataViewRef.Resolve();
-            bool hasMetadataViewImplementation = MetadataViewImplProxy.HasMetadataViewImplementation(metadataView);
+            MetadataViewImplProxy.ImplementationKind metadataViewImplementationKind = MetadataViewImplProxy.GetImplementationKind(metadataView);
+            bool hasMetadataViewImplementation = metadataViewImplementationKind != MetadataViewImplProxy.ImplementationKind.None;
+            bool usesInterfaceMetadataSemantics = metadataViewImplementationKind == MetadataViewImplProxy.ImplementationKind.MetadataViewBase;
             if (metadataView.GetTypeInfo().IsInterface && !metadataView.Equals(typeof(IDictionary<string, object>)) && !metadataView.Equals(typeof(IReadOnlyDictionary<string, object>)))
             {
                 var requiredMetadata = ImmutableDictionary.CreateBuilder<string, MetadatumRequirement>();
@@ -182,8 +184,10 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     bool required = !property.IsAttributeDefined<DefaultValueAttribute>();
 
-                    // Ignore properties that have a default value and have a metadataview implementation.
-                    if (required || !hasMetadataViewImplementation)
+                    // Legacy dictionary-backed metadata view implementations preserve MEFv1's behavior
+                    // of ignoring optional properties during filtering. Newer implementation paths
+                    // can safely use the full interface contract because they reuse interface semantics.
+                    if (required || !hasMetadataViewImplementation || usesInterfaceMetadataSemantics)
                     {
                         requiredMetadata.Add(property.Name, new MetadatumRequirement(TypeRef.Get(ReflectionHelpers.GetMemberType(property), resolver), required));
                     }

--- a/src/Microsoft.VisualStudio.Composition/ImportMetadataViewConstraint.cs
+++ b/src/Microsoft.VisualStudio.Composition/ImportMetadataViewConstraint.cs
@@ -178,25 +178,44 @@ namespace Microsoft.VisualStudio.Composition
             bool usesInterfaceMetadataSemantics = metadataViewImplementationKind == MetadataViewImplProxy.ImplementationKind.MetadataViewBase;
             if (metadataView.GetTypeInfo().IsInterface && !metadataView.Equals(typeof(IDictionary<string, object>)) && !metadataView.Equals(typeof(IReadOnlyDictionary<string, object>)))
             {
-                var requiredMetadata = ImmutableDictionary.CreateBuilder<string, MetadatumRequirement>();
+                return BuildMetadataRequirements(metadataView, resolver, requiredOnly: hasMetadataViewImplementation && !usesInterfaceMetadataSemantics);
+            }
 
-                foreach (var property in metadataView.EnumProperties().WherePublicInstance())
-                {
-                    bool required = !property.IsAttributeDefined<DefaultValueAttribute>();
-
-                    // Legacy dictionary-backed metadata view implementations preserve MEFv1's behavior
-                    // of ignoring optional properties during filtering. Newer implementation paths
-                    // can safely use the full interface contract because they reuse interface semantics.
-                    if (required || !hasMetadataViewImplementation || usesInterfaceMetadataSemantics)
-                    {
-                        requiredMetadata.Add(property.Name, new MetadatumRequirement(TypeRef.Get(ReflectionHelpers.GetMemberType(property), resolver), required));
-                    }
-                }
-
-                return requiredMetadata.ToImmutable();
+            if (MetadataView.IsDirectMetadataViewType(metadataView) && !metadataView.GetTypeInfo().IsAbstract)
+            {
+                return BuildMetadataRequirements(metadataView, resolver, requiredOnly: false);
             }
 
             return ImmutableDictionary<string, MetadatumRequirement>.Empty;
+        }
+
+        private static ImmutableDictionary<string, MetadatumRequirement> BuildMetadataRequirements(Type metadataView, Resolver resolver, bool requiredOnly)
+        {
+            Requires.NotNull(metadataView, nameof(metadataView));
+            Requires.NotNull(resolver, nameof(resolver));
+
+            var requiredMetadata = ImmutableDictionary.CreateBuilder<string, MetadatumRequirement>();
+            var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var property in metadataView.EnumProperties().WherePublicInstance())
+            {
+                if (!seenPropertyNames.Add(property.Name))
+                {
+                    continue;
+                }
+
+                bool required = !property.IsAttributeDefined<DefaultValueAttribute>();
+
+                // Legacy dictionary-backed metadata view implementations preserve MEFv1's behavior
+                // of ignoring optional properties during filtering. Newer implementation paths
+                // can safely use the full interface or class contract because they reuse interface semantics.
+                if (!requiredOnly || required)
+                {
+                    requiredMetadata.Add(property.Name, new MetadatumRequirement(TypeRef.Get(ReflectionHelpers.GetMemberType(property), resolver), required));
+                }
+            }
+
+            return requiredMetadata.ToImmutable();
         }
 
         public struct MetadatumRequirement

--- a/src/Microsoft.VisualStudio.Composition/MetadataView.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataView.cs
@@ -5,7 +5,6 @@ namespace Microsoft.VisualStudio.Composition;
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 
 /// <summary>
@@ -44,16 +43,6 @@ public abstract class MetadataView
 
         this.metadata = metadata;
         this.defaultValues = defaultValues;
-    }
-
-    internal static void ThrowIfDirectMetadataViewType(Type metadataViewType)
-    {
-        Requires.NotNull(metadataViewType, nameof(metadataViewType));
-
-        if (IsDirectMetadataViewType(metadataViewType))
-        {
-            throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewDirectUseUnsupported, metadataViewType.FullName));
-        }
     }
 
     internal static bool IsDirectMetadataViewType(Type metadataViewType)

--- a/src/Microsoft.VisualStudio.Composition/MetadataView.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataView.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Provides helper methods for concrete metadata view implementations that are referenced by
+/// <see cref="System.ComponentModel.Composition.MetadataViewImplementationAttribute"/>.
+/// </summary>
+public abstract class MetadataView
+{
+    private IReadOnlyDictionary<string, object?>? defaultValues;
+    private IReadOnlyDictionary<string, object?>? metadata;
+
+    /// <summary>
+    /// Gets a metadata value using the calling property's name as the metadata key.
+    /// </summary>
+    /// <typeparam name="T">The expected metadata value type.</typeparam>
+    /// <param name="propertyName">The name of the property whose metadata should be read.</param>
+    /// <returns>The metadata value.</returns>
+    protected T GetMetadata<T>([CallerMemberName] string propertyName = "")
+    {
+        Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
+        Verify.Operation(this.metadata is object && this.defaultValues is object, "This metadata view has not been initialized.");
+
+        if (!this.metadata.TryGetValue(propertyName, out object? value))
+        {
+            value = this.defaultValues[propertyName];
+        }
+
+        return (T)value!;
+    }
+
+    internal void Initialize(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues)
+    {
+        Requires.NotNull(metadata, nameof(metadata));
+        Requires.NotNull(defaultValues, nameof(defaultValues));
+        Verify.Operation(this.metadata is null && this.defaultValues is null, "This metadata view has already been initialized.");
+
+        this.metadata = metadata;
+        this.defaultValues = defaultValues;
+    }
+
+    internal static void ThrowIfDirectMetadataViewType(Type metadataViewType)
+    {
+        Requires.NotNull(metadataViewType, nameof(metadataViewType));
+
+        if (IsDirectMetadataViewType(metadataViewType))
+        {
+            throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewDirectUseUnsupported, metadataViewType.FullName));
+        }
+    }
+
+    internal static bool IsDirectMetadataViewType(Type metadataViewType)
+    {
+        Requires.NotNull(metadataViewType, nameof(metadataViewType));
+        return typeof(MetadataView).IsAssignableFrom(metadataViewType);
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -40,7 +40,6 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(metadata, nameof(metadata));
             Requires.NotNull(defaultValues, nameof(defaultValues));
             Requires.NotNull(metadataViewType, nameof(metadataViewType));
-            MetadataView.ThrowIfDirectMetadataViewType(metadataViewType);
 
             TypeInfo typeInfo = metadataViewType.GetTypeInfo();
             ConstructorInfo? ctor = FindConstructor(typeInfo);

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassDefaultCtorProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(metadataType, nameof(metadataType));
             var typeInfo = metadataType.GetTypeInfo();
 
-            return typeInfo.IsClass && !typeInfo.IsAbstract && FindConstructor(typeInfo) != null;
+            return typeInfo.IsClass && !typeInfo.IsAbstract && !MetadataView.IsDirectMetadataViewType(metadataType) && FindConstructor(typeInfo) != null;
         }
 
         public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
@@ -40,6 +40,7 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(metadata, nameof(metadata));
             Requires.NotNull(defaultValues, nameof(defaultValues));
             Requires.NotNull(metadataViewType, nameof(metadataViewType));
+            MetadataView.ThrowIfDirectMetadataViewType(metadataViewType);
 
             TypeInfo typeInfo = metadataViewType.GetTypeInfo();
             ConstructorInfo? ctor = FindConstructor(typeInfo);

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
@@ -29,11 +29,12 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(metadataType, nameof(metadataType));
             var typeInfo = metadataType.GetTypeInfo();
 
-            return typeInfo.IsClass && !typeInfo.IsAbstract && FindConstructor(typeInfo) != null;
+            return typeInfo.IsClass && !typeInfo.IsAbstract && !MetadataView.IsDirectMetadataViewType(metadataType) && FindConstructor(typeInfo) != null;
         }
 
         public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
         {
+            MetadataView.ThrowIfDirectMetadataViewType(metadataViewType);
             ConstructorInfo? ctor = FindConstructor(metadataViewType.GetTypeInfo());
             Requires.Argument(ctor is not null, nameof(metadataViewType), "No public constructor with the required signature found.");
 

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewClassProvider.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.Composition
 
         public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
         {
-            MetadataView.ThrowIfDirectMetadataViewType(metadataViewType);
             ConstructorInfo? ctor = FindConstructor(metadataViewType.GetTypeInfo());
             Requires.Argument(ctor is not null, nameof(metadataViewType), "No public constructor with the required signature found.");
 

--- a/src/Microsoft.VisualStudio.Composition/MetadataViewDirectProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/MetadataViewDirectProvider.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition;
+
+using System.Reflection;
+using Microsoft.VisualStudio.Composition.Reflection;
+
+/// <summary>
+/// Supports metadata views that derive from <see cref="MetadataView"/> and are used directly as TMetadata.
+/// </summary>
+internal class MetadataViewDirectProvider : IMetadataViewProvider
+{
+    internal static readonly ComposablePartDefinition PartDefinition =
+        Utilities.GetMetadataViewProviderPartDefinition(typeof(MetadataViewDirectProvider), 1000500, Resolver.DefaultInstance);
+
+    internal static readonly IMetadataViewProvider Default = new MetadataViewDirectProvider();
+
+    private MetadataViewDirectProvider()
+    {
+    }
+
+    public bool IsMetadataViewSupported(Type metadataType)
+    {
+        Requires.NotNull(metadataType, nameof(metadataType));
+        var typeInfo = metadataType.GetTypeInfo();
+
+        return typeInfo.IsClass && !typeInfo.IsAbstract && MetadataView.IsDirectMetadataViewType(metadataType) && FindConstructor(typeInfo) != null;
+    }
+
+    public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
+    {
+        Requires.NotNull(metadata, nameof(metadata));
+        Requires.NotNull(defaultValues, nameof(defaultValues));
+        Requires.NotNull(metadataViewType, nameof(metadataViewType));
+
+        ConstructorInfo? ctor = FindConstructor(metadataViewType.GetTypeInfo());
+        Requires.Argument(ctor is not null, nameof(metadataViewType), "No public default constructor found.");
+        var metadataView = (MetadataView)ctor.Invoke(Type.EmptyTypes);
+        metadataView.Initialize(metadata, defaultValues);
+        return metadataView;
+    }
+
+    private static ConstructorInfo? FindConstructor(TypeInfo metadataType)
+    {
+        Requires.NotNull(metadataType, nameof(metadataType));
+
+        return metadataType.DeclaredConstructors.FirstOrDefault(ctor => ctor.GetParameters().Length == 0 && ctor.IsPublic);
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -170,7 +170,7 @@
     <value>The metadata view implementation type "{0}" for metadata view "{1}" must declare one of the supported constructors: a public parameterless constructor when deriving from Microsoft.VisualStudio.Composition.MetadataView, or a public .ctor(IDictionary&lt;string, object?&gt;) / .ctor(IReadOnlyDictionary&lt;string, object?&gt;).</value>
   </data>
   <data name="MetadataViewDirectUseUnsupported" xml:space="preserve">
-    <value>The metadata view type "{0}" derives from Microsoft.VisualStudio.Composition.MetadataView and must be consumed through an interface metadata view annotated with MetadataViewImplementationAttribute, not used directly as TMetadata.</value>
+    <value>The metadata view type "{0}" derives from Microsoft.VisualStudio.Composition.MetadataView. To be supported, it must be a non-abstract class with a public parameterless constructor when used directly as TMetadata or as the implementation type for an interface annotated with MetadataViewImplementationAttribute.</value>
   </data>
   <data name="UnableToDeterminePrimarySharingBoundary" xml:space="preserve">
     <value>Unable to determine the primary sharing boundary for MEF part "{0}".</value>

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -163,6 +163,15 @@
     <value>The type {0} is an unsupported type of metadata view.</value>
     <comment>{0} is the metadata view type.</comment>
   </data>
+  <data name="MetadataViewImplementationTypeMustImplementMetadataView" xml:space="preserve">
+    <value>The metadata view implementation type "{0}" must implement the metadata view interface "{1}".</value>
+  </data>
+  <data name="MetadataViewImplementationConstructorUnsupported" xml:space="preserve">
+    <value>The metadata view implementation type "{0}" for metadata view "{1}" must declare one of the supported constructors: a public parameterless constructor when deriving from Microsoft.VisualStudio.Composition.MetadataView, or a public .ctor(IDictionary&lt;string, object?&gt;) / .ctor(IReadOnlyDictionary&lt;string, object?&gt;).</value>
+  </data>
+  <data name="MetadataViewDirectUseUnsupported" xml:space="preserve">
+    <value>The metadata view type "{0}" derives from Microsoft.VisualStudio.Composition.MetadataView and must be consumed through an interface metadata view annotated with MetadataViewImplementationAttribute, not used directly as TMetadata.</value>
+  </data>
   <data name="UnableToDeterminePrimarySharingBoundary" xml:space="preserve">
     <value>Unable to determine the primary sharing boundary for MEF part "{0}".</value>
   </data>

--- a/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation.cs
+++ b/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.AppDomainTests
+{
+    using System;
+    using System.ComponentModel;
+    using System.Composition;
+    using MefV1 = System.ComponentModel.Composition;
+
+    [Export]
+    public class PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation
+    {
+        [Import("AnExportWithMetadataTypeValue")]
+        public Lazy<object, IMetadataViewWithImplementation> ImportWithTMetadata { get; set; } = null!;
+    }
+
+    [MefV1.MetadataViewImplementation(typeof(MetadataViewWithImplementation))]
+    public interface IMetadataViewWithImplementation
+    {
+        Type SomeType { get; }
+
+        Type[] SomeTypes { get; }
+
+        [DefaultValue("default")]
+        string SomeProperty { get; }
+    }
+
+    public class MetadataViewWithImplementation : MetadataView, IMetadataViewWithImplementation
+    {
+        public Type SomeType => this.GetMetadata<Type>();
+
+        public Type[] SomeTypes => this.GetMetadata<Type[]>();
+
+        public string SomeProperty => this.GetMetadata<string>();
+    }
+}

--- a/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation.cs
+++ b/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation.cs
@@ -34,4 +34,24 @@ namespace Microsoft.VisualStudio.Composition.AppDomainTests
 
         public string SomeProperty => this.GetMetadata<string>();
     }
+
+    [Export]
+    public class PartThatLazyImportsExportWithTypeMetadataViaDirectMetadataView
+    {
+        [Import("AnExportWithMetadataTypeValue")]
+        public Lazy<object, DirectMetadataView> ImportWithTMetadata { get; set; } = null!;
+    }
+
+    public class DirectMetadataViewBase : MetadataView
+    {
+        [DefaultValue("default")]
+        public string SomeProperty => this.GetMetadata<string>();
+    }
+
+    public class DirectMetadataView : DirectMetadataViewBase
+    {
+        public Type SomeType => this.GetMetadata<Type>();
+
+        public Type[] SomeTypes => this.GetMetadata<Type[]>();
+    }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -352,6 +352,34 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
+        /// <summary>
+        /// Verifies that metadata view implementation classes can preserve lazy assembly loading
+        /// for Type and Type[] metadata when they reuse interface metadata view semantics.
+        /// </summary>
+        [SkippableFact]
+        public async Task ComposableAssembliesLazyLoadedByLazyMetadataViewImplementation()
+        {
+            SkipOnMono();
+            var catalog = TestUtilities.EmptyCatalog.AddParts(
+                await TestUtilities.V2Discovery.CreatePartsAsync(typeof(PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation), typeof(AnExportWithMetadataTypeValue)));
+            var catalogCache = await this.SaveCatalogAsync(catalog);
+            var configuration = CompositionConfiguration.Create(catalog);
+            var compositionCache = await this.SaveConfigurationAsync(configuration);
+
+            // Use a sub-appdomain so we can monitor which assemblies get loaded by our composition engine.
+            var appDomain = AppDomain.CreateDomain("Composition Test sub-domain", null, AppDomain.CurrentDomain.SetupInformation);
+            try
+            {
+                var driver = (AppDomainTestDriver)appDomain.CreateInstanceAndUnwrap(typeof(AppDomainTestDriver).Assembly.FullName, typeof(AppDomainTestDriver).FullName);
+                driver.Initialize(this.cacheManager.GetType(), compositionCache, catalogCache);
+                driver.TestPartThatImportsExportWithTypeMetadataViaMetadataViewImplementation(typeof(YetAnotherExport).Assembly.Location);
+            }
+            finally
+            {
+                AppDomain.Unload(appDomain);
+            }
+        }
+
         private static void SkipOnMono()
         {
             TestUtilities.SkipOnMono("Assemblies are loaded more eagerly in other AppDomains on Mono");
@@ -479,6 +507,21 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container!.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaTMetadata>();
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                Type type = exportWithLazy.ImportWithTMetadata.Metadata.SomeType;
+                Type[] types = exportWithLazy.ImportWithTMetadata.Metadata.SomeTypes;
+                AssertEx.Equal("YetAnotherExport", type.Name);
+                types.Single(t => t.Name == "String");
+                types.Single(t => t.Name == "YetAnotherExport");
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            internal void TestPartThatImportsExportWithTypeMetadataViaMetadataViewImplementation(string lazyLoadedAssemblyPath)
+            {
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                var exportWithLazy = this.container!.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation>();
                 AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
                 AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));

--- a/test/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -380,6 +380,33 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
+        /// <summary>
+        /// Verifies that direct MetadataView classes can preserve lazy assembly loading
+        /// for Type and Type[] metadata when used directly as TMetadata.
+        /// </summary>
+        [SkippableFact]
+        public async Task ComposableAssembliesLazyLoadedByLazyDirectMetadataView()
+        {
+            SkipOnMono();
+            var catalog = TestUtilities.EmptyCatalog.AddParts(
+                await TestUtilities.V2Discovery.CreatePartsAsync(typeof(PartThatLazyImportsExportWithTypeMetadataViaDirectMetadataView), typeof(AnExportWithMetadataTypeValue)));
+            var catalogCache = await this.SaveCatalogAsync(catalog);
+            var configuration = CompositionConfiguration.Create(catalog);
+            var compositionCache = await this.SaveConfigurationAsync(configuration);
+
+            var appDomain = AppDomain.CreateDomain("Composition Test sub-domain", null, AppDomain.CurrentDomain.SetupInformation);
+            try
+            {
+                var driver = (AppDomainTestDriver)appDomain.CreateInstanceAndUnwrap(typeof(AppDomainTestDriver).Assembly.FullName, typeof(AppDomainTestDriver).FullName);
+                driver.Initialize(this.cacheManager.GetType(), compositionCache, catalogCache);
+                driver.TestPartThatImportsExportWithTypeMetadataViaDirectMetadataView(typeof(YetAnotherExport).Assembly.Location);
+            }
+            finally
+            {
+                AppDomain.Unload(appDomain);
+            }
+        }
+
         private static void SkipOnMono()
         {
             TestUtilities.SkipOnMono("Assemblies are loaded more eagerly in other AppDomains on Mono");
@@ -522,6 +549,21 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 var exportWithLazy = this.container!.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaMetadataViewImplementation>();
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                Type type = exportWithLazy.ImportWithTMetadata.Metadata.SomeType;
+                Type[] types = exportWithLazy.ImportWithTMetadata.Metadata.SomeTypes;
+                AssertEx.Equal("YetAnotherExport", type.Name);
+                types.Single(t => t.Name == "String");
+                types.Single(t => t.Name == "YetAnotherExport");
+                AssertEx.True(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            internal void TestPartThatImportsExportWithTypeMetadataViaDirectMetadataView(string lazyLoadedAssemblyPath)
+            {
+                AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
+                var exportWithLazy = this.container!.GetExportedValue<PartThatLazyImportsExportWithTypeMetadataViaDirectMetadataView>();
                 AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));
                 Assert.Equal("default", exportWithLazy.ImportWithTMetadata.Metadata.SomeProperty);
                 AssertEx.False(GetLoadedAssemblies().Any(a => a.Location.Equals(lazyLoadedAssemblyPath, StringComparison.OrdinalIgnoreCase)));

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -72,32 +72,47 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal(new[] { 3, 4 }, partWithOptionalValue.Metadata.IntValues);
         }
 
-        [MefFact(CompositionEngines.V3EmulatingV1, typeof(ProjectedExportingPartA))]
-        public void MetadataViewDerivedClassCannotBeUsedDirectlyAsMetadataType(IContainer container)
+        [MefFact(CompositionEngines.V3EmulatingV1, typeof(ProjectedExportingPartA), typeof(ProjectedExportingPartAB), typeof(ProjectedExportingPartAWithWrongOptionalType))]
+        public void MetadataViewDerivedClassCanBeUsedDirectlyAsMetadataType(IContainer container)
         {
-            var ex = Assert.Throws<NotSupportedException>(() => container.GetExports<object, ProjectedMetadataView>("ProjectedExport").ToList());
-            Assert.Contains(typeof(ProjectedMetadataView).FullName!, ex.Message);
+            var exports = container.GetExports<object, ProjectedMetadataView>("ProjectedExport").ToList();
+            Assert.Equal(2, exports.Count);
+
+            var partWithOptionalDefault = exports.Single(e => e.Value is ProjectedExportingPartA);
+            Assert.Equal("1", partWithOptionalDefault.Metadata.A);
+            Assert.Equal("default", partWithOptionalDefault.Metadata.B);
+            Assert.Equal(new[] { "alpha", "beta" }, partWithOptionalDefault.Metadata.StringValues);
+            Assert.Equal(new[] { 1, 2 }, partWithOptionalDefault.Metadata.IntValues);
+
+            var partWithOptionalValue = exports.Single(e => e.Value is ProjectedExportingPartAB);
+            Assert.Equal("1", partWithOptionalValue.Metadata.A);
+            Assert.Equal("2", partWithOptionalValue.Metadata.B);
+            Assert.Equal(new[] { "gamma", "delta" }, partWithOptionalValue.Metadata.StringValues);
+            Assert.Equal(new[] { 3, 4 }, partWithOptionalValue.Metadata.IntValues);
         }
 
-        [Fact]
-        public async Task MetadataViewDerivedClassImportIsRejectedDuringConfiguration()
+        [MefFact(CompositionEngines.V3EmulatingV1, typeof(ProjectedExportingPartA), typeof(DirectProjectedMetadataViewImporter))]
+        public void MetadataViewDerivedClassCanBeImportedDirectly(IContainer container)
         {
-            var configuration = await TestUtilities.CreateConfigurationAsync(
-                CompositionEngines.V1,
-                typeof(ProjectedExportingPartA),
-                typeof(DirectProjectedMetadataViewImporter));
-
-            Assert.False(configuration.CompositionErrors.IsEmpty);
-            var rootCauses = configuration.CompositionErrors.Peek();
-            Assert.All(rootCauses, error => Assert.Equal(typeof(DirectProjectedMetadataViewImporter), Assert.Single(error.Parts).Definition.Type));
-            Assert.Contains(rootCauses, error => error.Message.Contains(typeof(ProjectedMetadataView).FullName!, StringComparison.Ordinal));
+            var importer = container.GetExportedValue<DirectProjectedMetadataViewImporter>();
+            Assert.NotNull(importer.ImportingProperty);
+            Assert.Equal("1", importer.ImportingProperty!.Metadata.A);
+            Assert.Equal("default", importer.ImportingProperty.Metadata.B);
+            Assert.Equal(new[] { "alpha", "beta" }, importer.ImportingProperty.Metadata.StringValues);
+            Assert.Equal(new[] { 1, 2 }, importer.ImportingProperty.Metadata.IntValues);
         }
 
-        [MefFact(CompositionEngines.V3EmulatingV1 | CompositionEngines.V3AllowConfigurationWithErrors, typeof(ProjectedExportingPartA), typeof(DirectProjectedMetadataViewImporter), typeof(UnrelatedProjectedExport), InvalidConfiguration = true)]
-        public void MetadataViewDerivedClassImportRejectsPartButRetainsUnrelatedParts(IContainer container)
+        [MefFact(CompositionEngines.V3EmulatingV1, typeof(DirectProjectedExportingPartComplete), typeof(DirectProjectedExportingPartMissingShadowed), typeof(DirectOnlyProjectedMetadataViewImporter))]
+        public void DirectMetadataViewWithoutInterface_UsesInheritedPropertiesAndMostDerivedMembers(IContainer container)
         {
-            Assert.Empty(container.GetExportedValues<DirectProjectedMetadataViewImporter>());
-            Assert.NotNull(container.GetExportedValue<UnrelatedProjectedExport>());
+            var importer = container.GetExportedValue<DirectOnlyProjectedMetadataViewImporter>();
+            Assert.NotNull(importer.ImportingProperty);
+            Assert.IsType<DirectProjectedExportingPartComplete>(importer.ImportingProperty!.Value);
+            Assert.Equal("1", importer.ImportingProperty.Metadata.A);
+            Assert.Equal("base-default", importer.ImportingProperty.Metadata.B);
+            Assert.Equal("shadowed", importer.ImportingProperty.Metadata.Shadowed);
+            Assert.Equal(typeof(ProjectedExportingPartA).Name, importer.ImportingProperty.Metadata.SomeType.Name);
+            Assert.Equal(new[] { 6, 7 }, importer.ImportingProperty.Metadata.IntValues);
         }
 
         [MefV1.Export]
@@ -168,6 +183,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             public string? A => this.GetMetadata<string?>();
 
+            [DefaultValue("default")]
             public string? B => this.GetMetadata<string?>();
 
             public string[] StringValues => this.GetMetadata<string[]>();
@@ -201,16 +217,55 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
         }
 
+        public class DirectOnlyProjectedMetadataViewBase : MetadataView
+        {
+            [DefaultValue("base-default")]
+            public string B => this.GetMetadata<string>();
+
+            [DefaultValue("base-shadow")]
+            public string Shadowed => this.GetMetadata<string>();
+
+            public Type SomeType => this.GetMetadata<Type>();
+        }
+
+        public class DirectOnlyProjectedMetadataView : DirectOnlyProjectedMetadataViewBase
+        {
+            public string A => this.GetMetadata<string>();
+
+            public new string Shadowed => this.GetMetadata<string>();
+
+            public int[] IntValues => this.GetMetadata<int[]>();
+        }
+
+        [MefV1.Export("DirectProjectedExport", typeof(object))]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataView.A), "1")]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataView.Shadowed), "shadowed")]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataViewBase.SomeType), typeof(ProjectedExportingPartA))]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataView.IntValues), new[] { 6, 7 })]
+        public class DirectProjectedExportingPartComplete
+        {
+        }
+
+        [MefV1.Export("DirectProjectedExport", typeof(object))]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataView.A), "2")]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataViewBase.SomeType), typeof(ProjectedExportingPartAB))]
+        [MefV1.ExportMetadata(nameof(DirectOnlyProjectedMetadataView.IntValues), new[] { 8, 9 })]
+        public class DirectProjectedExportingPartMissingShadowed
+        {
+        }
+
         [MefV1.Export]
         public class DirectProjectedMetadataViewImporter
         {
-            [MefV1.Import]
+            [MefV1.Import("ProjectedExport")]
             public Lazy<object, ProjectedMetadataView>? ImportingProperty { get; set; }
         }
 
         [MefV1.Export]
-        public class UnrelatedProjectedExport
+        public class DirectOnlyProjectedMetadataViewImporter
         {
+            [MefV1.Import("DirectProjectedExport")]
+            public Lazy<object, DirectOnlyProjectedMetadataView>? ImportingProperty { get; set; }
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -4,9 +4,12 @@
 namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
+    using System.Reflection;
+    using System.Runtime.ExceptionServices;
     using Xunit;
     using MefV1 = System.ComponentModel.Composition;
 
@@ -113,6 +116,21 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal("shadowed", importer.ImportingProperty.Metadata.Shadowed);
             Assert.Equal(typeof(ProjectedExportingPartA).Name, importer.ImportingProperty.Metadata.SomeType.Name);
             Assert.Equal(new[] { 6, 7 }, importer.ImportingProperty.Metadata.IntValues);
+        }
+
+        [Fact]
+        public void MetadataViewImplementationRejectsObjectConstructor()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => IsMetadataViewSupported(typeof(IObjectCtorMetadataView)));
+            Assert.Contains(nameof(ObjectCtorMetadataView), exception.Message);
+        }
+
+        [Fact]
+        public void MetadataViewImplementationWrapsReadOnlyMetadataForDictionaryConstructor()
+        {
+            var metadata = new ReadOnlyMetadataDictionary(new Dictionary<string, object?> { ["A"] = "1" });
+            var metadataView = (IDictionaryCtorMetadataView)CreateProxy(metadata, typeof(IDictionaryCtorMetadataView));
+            Assert.Equal("1", metadataView.A);
         }
 
         [MefV1.Export]
@@ -266,6 +284,95 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             [MefV1.Import("DirectProjectedExport")]
             public Lazy<object, DirectOnlyProjectedMetadataView>? ImportingProperty { get; set; }
+        }
+
+        [MefV1.MetadataViewImplementation(typeof(ObjectCtorMetadataView))]
+        public interface IObjectCtorMetadataView
+        {
+            string? A { get; }
+        }
+
+        public class ObjectCtorMetadataView : IObjectCtorMetadataView
+        {
+            public ObjectCtorMetadataView(object metadata)
+            {
+                this.A = metadata.ToString();
+            }
+
+            public string? A { get; }
+        }
+
+        [MefV1.MetadataViewImplementation(typeof(DictionaryCtorMetadataView))]
+        public interface IDictionaryCtorMetadataView
+        {
+            string? A { get; }
+        }
+
+        public class DictionaryCtorMetadataView : IDictionaryCtorMetadataView
+        {
+            public DictionaryCtorMetadataView(IDictionary<string, object?> metadata)
+            {
+                this.A = (string?)metadata["A"];
+            }
+
+            public string? A { get; }
+        }
+
+        private static bool IsMetadataViewSupported(Type metadataViewType)
+        {
+            return (bool)InvokeMetadataViewImplProxy("IsMetadataViewSupported", metadataViewType)!;
+        }
+
+        private static object CreateProxy(IReadOnlyDictionary<string, object?> metadata, Type metadataViewType)
+        {
+            return InvokeMetadataViewImplProxy(
+                "CreateProxy",
+                metadata,
+                new ReadOnlyMetadataDictionary(new Dictionary<string, object?>()),
+                metadataViewType)!;
+        }
+
+        private static object? InvokeMetadataViewImplProxy(string methodName, params object[] args)
+        {
+            Type metadataViewImplProxyType = typeof(CompositionConfiguration).Assembly.GetType("Microsoft.VisualStudio.Composition.MetadataViewImplProxy", throwOnError: true)!;
+            object metadataViewImplProxy = Activator.CreateInstance(metadataViewImplProxyType, nonPublic: true)!;
+            MethodInfo method = metadataViewImplProxyType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public)!;
+
+            try
+            {
+                return method.Invoke(metadataViewImplProxy, args);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+        }
+
+        private sealed class ReadOnlyMetadataDictionary : IReadOnlyDictionary<string, object?>
+        {
+            private readonly Dictionary<string, object?> inner;
+
+            internal ReadOnlyMetadataDictionary(Dictionary<string, object?> inner)
+            {
+                this.inner = inner;
+            }
+
+            public IEnumerable<string> Keys => this.inner.Keys;
+
+            public IEnumerable<object?> Values => this.inner.Values;
+
+            public int Count => this.inner.Count;
+
+            public object? this[string key] => this.inner[key];
+
+            public bool ContainsKey(string key) => this.inner.ContainsKey(key);
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => this.inner.GetEnumerator();
+
+            public bool TryGetValue(string key, out object? value) => this.inner.TryGetValue(key, out value);
+
+            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Linq;
     using Xunit;
     using MefV1 = System.ComponentModel.Composition;
 
@@ -49,6 +50,54 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal("1", importingPart.ImportingProperty.Metadata.A);
             Assert.Null(importingPart.ImportingProperty.Metadata.B);
             Assert.Equal(10, importingPart.ImportingProperty.Metadata.PropertyWithMetadataThatDoesNotMatchType);
+        }
+
+        [MefFact(CompositionEngines.V3EmulatingV1, typeof(ProjectedExportingPartA), typeof(ProjectedExportingPartAB), typeof(ProjectedExportingPartAWithWrongOptionalType))]
+        public void MetadataViewImplementationWithMetadataViewBase_DirectQueryAppliesFilterAndDefaults(IContainer container)
+        {
+            var exports = container.GetExports<object, IProjectedMetadataView>("ProjectedExport").ToList();
+            Assert.Equal(2, exports.Count);
+
+            var partWithOptionalDefault = exports.Single(e => e.Value is ProjectedExportingPartA);
+            Assert.IsType<ProjectedMetadataView>(partWithOptionalDefault.Metadata);
+            Assert.Equal("1", partWithOptionalDefault.Metadata.A);
+            Assert.Equal("default", partWithOptionalDefault.Metadata.B);
+            Assert.Equal(new[] { "alpha", "beta" }, partWithOptionalDefault.Metadata.StringValues);
+            Assert.Equal(new[] { 1, 2 }, partWithOptionalDefault.Metadata.IntValues);
+
+            var partWithOptionalValue = exports.Single(e => e.Value is ProjectedExportingPartAB);
+            Assert.Equal("1", partWithOptionalValue.Metadata.A);
+            Assert.Equal("2", partWithOptionalValue.Metadata.B);
+            Assert.Equal(new[] { "gamma", "delta" }, partWithOptionalValue.Metadata.StringValues);
+            Assert.Equal(new[] { 3, 4 }, partWithOptionalValue.Metadata.IntValues);
+        }
+
+        [MefFact(CompositionEngines.V3EmulatingV1, typeof(ProjectedExportingPartA))]
+        public void MetadataViewDerivedClassCannotBeUsedDirectlyAsMetadataType(IContainer container)
+        {
+            var ex = Assert.Throws<NotSupportedException>(() => container.GetExports<object, ProjectedMetadataView>("ProjectedExport").ToList());
+            Assert.Contains(typeof(ProjectedMetadataView).FullName!, ex.Message);
+        }
+
+        [Fact]
+        public async Task MetadataViewDerivedClassImportIsRejectedDuringConfiguration()
+        {
+            var configuration = await TestUtilities.CreateConfigurationAsync(
+                CompositionEngines.V1,
+                typeof(ProjectedExportingPartA),
+                typeof(DirectProjectedMetadataViewImporter));
+
+            Assert.False(configuration.CompositionErrors.IsEmpty);
+            var rootCauses = configuration.CompositionErrors.Peek();
+            Assert.All(rootCauses, error => Assert.Equal(typeof(DirectProjectedMetadataViewImporter), Assert.Single(error.Parts).Definition.Type));
+            Assert.Contains(rootCauses, error => error.Message.Contains(typeof(ProjectedMetadataView).FullName!, StringComparison.Ordinal));
+        }
+
+        [MefFact(CompositionEngines.V3EmulatingV1 | CompositionEngines.V3AllowConfigurationWithErrors, typeof(ProjectedExportingPartA), typeof(DirectProjectedMetadataViewImporter), typeof(UnrelatedProjectedExport), InvalidConfiguration = true)]
+        public void MetadataViewDerivedClassImportRejectsPartButRetainsUnrelatedParts(IContainer container)
+        {
+            Assert.Empty(container.GetExportedValues<DirectProjectedMetadataViewImporter>());
+            Assert.NotNull(container.GetExportedValue<UnrelatedProjectedExport>());
         }
 
         [MefV1.Export]
@@ -100,6 +149,68 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public string? B { get; set; }
 
             public int PropertyWithMetadataThatDoesNotMatchType { get; set; }
+        }
+
+        [MefV1.MetadataViewImplementation(typeof(ProjectedMetadataView))]
+        public interface IProjectedMetadataView
+        {
+            string? A { get; }
+
+            [DefaultValue("default")]
+            string? B { get; }
+
+            string[] StringValues { get; }
+
+            int[] IntValues { get; }
+        }
+
+        public class ProjectedMetadataView : MetadataView, IProjectedMetadataView
+        {
+            public string? A => this.GetMetadata<string?>();
+
+            public string? B => this.GetMetadata<string?>();
+
+            public string[] StringValues => this.GetMetadata<string[]>();
+
+            public int[] IntValues => this.GetMetadata<int[]>();
+        }
+
+        [MefV1.Export("ProjectedExport", typeof(object))]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.A), "1")]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.StringValues), new[] { "alpha", "beta" })]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.IntValues), new[] { 1, 2 })]
+        public class ProjectedExportingPartA
+        {
+        }
+
+        [MefV1.Export("ProjectedExport", typeof(object))]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.A), "1")]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.B), "2")]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.StringValues), new[] { "gamma", "delta" })]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.IntValues), new[] { 3, 4 })]
+        public class ProjectedExportingPartAB
+        {
+        }
+
+        [MefV1.Export("ProjectedExport", typeof(object))]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.A), "1")]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.B), 2)]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.StringValues), new[] { "filtered" })]
+        [MefV1.ExportMetadata(nameof(IProjectedMetadataView.IntValues), new[] { 5 })]
+        public class ProjectedExportingPartAWithWrongOptionalType
+        {
+        }
+
+        [MefV1.Export]
+        public class DirectProjectedMetadataViewImporter
+        {
+            [MefV1.Import]
+            public Lazy<object, ProjectedMetadataView>? ImportingProperty { get; set; }
+        }
+
+        [MefV1.Export]
+        public class UnrelatedProjectedExport
+        {
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "18.3",
+  "version": "18.9",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This change introduces a new `MetadataView` abstract base class from which you can derive your concrete metadata views in order to avoid the runtime cost of dynamic interface implementations being Ref.Emit'd.

You've always been able to construct metadata view _classes_, but:
* Their semantics were slightly different than interfaces. For example, optional properties on a class were not considered significant when _filtering exports_ to those whose metadata matched. 
* They were complicated to write since they had to be implemented by hand, deal with type coercion themselves, reaching into an untyped dictionary by hand, etc.
This new `MetadataView` base class makes authoring metadata view classes super easy:

```cs
public class HandlerMetadataView : MetadataView
{
    public string Name => this.GetMetadata<string>();
    public bool SupportsAsync => this.GetMetadata<bool>();
    public Type HandlerType => this.GetMetadata<Type>();
}
```

This view class can be used directly as `TMetadata` in an importing `Lazy<T, TMetadata>`.

The class can optionally implement a metadata view interface that has `[MetadataViewImplementation]` applied to it that points to this class, in which case the class will be automatically picked up wherever an importer uses the interface.