### PR TITLE
Analyzer fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,14 +29,14 @@
     <PackageVersion Include="Nerdbank.MSBuildExtension" Version="0.1.17-beta" />
     <PackageVersion Include="Nerdbank.NetStandardBridge" Version="1.1.46" />
     <PackageVersion Include="OpenSoftware.DgmlBuilder" Version="2.1.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.1" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="10.0.1" />
     <PackageVersion Include="System.Composition" Version="10.0.1" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -1,48 +1,51 @@
 {
-	"metadata": [
-		{
-			"src": [
-				{
-					"src": "../src/Microsoft.VisualStudio.Composition",
-					"files": [
-						"**/*.csproj"
-					]
-				}
-			],
-			"dest": "api"
-		}
-	],
-	"build": {
-		"content": [
-			{
-				"files": [
-					"**/*.{md,yml}"
-				],
-				"exclude": [
-					"_site/**"
-				]
-			}
-		],
-		"resource": [
-			{
-				"files": [
-					"images/**"
-				]
-			}
-		],
-		"xref": [
-			"https://learn.microsoft.com/en-us/dotnet/.xrefmap.json"
-		],
-		"output": "_site",
-		"template": [
-			"default",
-			"modern"
-		],
-		"globalMetadata": {
-			"_appName": "Microsoft.VisualStudio.Composition",
-			"_appTitle": "Microsoft.VisualStudio.Composition",
-			"_enableSearch": true,
-			"pdf": false
-		}
-	}
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "../src/Microsoft.VisualStudio.Composition",
+          "files": [
+            "**/*.csproj"
+          ]
+        }
+      ],
+      "dest": "api",
+      "properties": {
+        "IsDocFx": "true"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "exclude": [
+          "_site/**"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "images/**"
+        ]
+      }
+    ],
+    "xref": [
+      "https://learn.microsoft.com/en-us/dotnet/.xrefmap.json"
+    ],
+    "output": "_site",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appName": "Microsoft.VisualStudio.Composition",
+      "_appTitle": "Microsoft.VisualStudio.Composition",
+      "_enableSearch": true,
+      "pdf": false
+    }
+  }
 }

--- a/samples/Samples.csproj
+++ b/samples/Samples.csproj
@@ -6,10 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRootPath)src\Microsoft.VisualStudio.Composition\Microsoft.VisualStudio.Composition.csproj" />
-    <ProjectReference Include="$(RepoRootPath)src\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>AnalyzerAssembly</OutputItemType>
-    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$(RepoRootPath)src\AnalyzerUser.targets" />

--- a/src/AnalyzerUser.targets
+++ b/src/AnalyzerUser.targets
@@ -3,16 +3,18 @@
     <AnalyzerProjectReference Include="$(RepoRootPath)src\Microsoft.VisualStudio.Composition.Analyzers\Microsoft.VisualStudio.Composition.Analyzers.csproj" />
     <AnalyzerProjectReference Include="$(RepoRootPath)src\Microsoft.VisualStudio.Composition.Analyzers.CSharp\Microsoft.VisualStudio.Composition.Analyzers.CSharp.csproj" Condition="'$(MSBuildProjectExtension)'=='.csproj'" />
     <AnalyzerProjectReference Include="$(RepoRootPath)src\Microsoft.VisualStudio.Composition.Analyzers.VB\Microsoft.VisualStudio.Composition.Analyzers.VB.csproj" Condition="'$(MSBuildProjectExtension)'=='.vbproj'" />
+    <AnalyzerProjectReference Include="$(RepoRootPath)src\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.csproj" />
 
     <ProjectReference Include="@(AnalyzerProjectReference)">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>AnalyzerAssembly</OutputItemType>
+      <OutputItemType>Analyzer</OutputItemType>
     </ProjectReference>
   </ItemGroup>
 
-  <Target Name="ConsumeVsMefAnalyzersDirectly" AfterTargets="ResolveProjectReferences">
+  <Target Name="SuppressAnalyzersAsReferenceAssemblies" AfterTargets="ResolveProjectReferences">
+    <!-- Workaround for https://github.com/NuGet/Home/issues/10312 -->
     <ItemGroup>
-      <Analyzer Include="%(AnalyzerAssembly.Identity)" />
+      <_ResolvedProjectReferencePaths Remove="@(_ResolvedProjectReferencePaths)" Condition="'%(FileName)' == 'Microsoft.VisualStudio.Composition.Analyzers.CodeFixes'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/Strings.resx
@@ -17,7 +17,7 @@
     <comment>{Locked="MetadataView"} The attribute name should not be localized.</comment>
   </data>
   <data name="VSMEF015_MessageFormat" xml:space="preserve">
-    <value>The metadata view interface "{0}" is declared in this compilation but will not be source-generated. Annotate it with [MetadataView] and declare it partial.</value>
+    <value>The metadata view interface "{0}" is declared in this compilation but will not be source-generated. Annotate it with [MetadataView] (from Microsoft.VisualStudio.Composition) and declare it partial.</value>
     <comment>{Locked="[MetadataView]"} The attribute name in brackets should not be localized.</comment>
   </data>
   <data name="VSMEF016_Title" xml:space="preserve">
@@ -25,7 +25,7 @@
     <comment>{Locked="MetadataView"} The attribute name should not be localized.</comment>
   </data>
   <data name="VSMEF016_MessageFormat" xml:space="preserve">
-    <value>The metadata view interface "{0}" is declared in referenced assembly "{1}" and does not have [MetadataViewImplementation]. Recompile that assembly with [MetadataView] applied to the interface.</value>
+    <value>The metadata view interface "{0}" is declared in referenced assembly "{1}" and does not have [MetadataViewImplementation]. Recompile that assembly with [MetadataView] (from Microsoft.VisualStudio.Composition) applied to the interface.</value>
     <comment>{Locked="[MetadataViewImplementation]"} {Locked="[MetadataView]"} The attribute names in brackets should not be localized.</comment>
   </data>
   <data name="VSMEF017_Title" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.Composition.AppHost/Microsoft.VisualStudio.Composition.AppHost.csproj
+++ b/src/Microsoft.VisualStudio.Composition.AppHost/Microsoft.VisualStudio.Composition.AppHost.csproj
@@ -23,4 +23,5 @@
     <PackageReference Include="Nerdbank.MSBuildExtension" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="Microsoft.VisualStudio.Composition.AppHost.targets" />
+  <Import Project="$(RepoRootPath)src\AnalyzerUser.targets" />
 </Project>

--- a/src/Microsoft.VisualStudio.Composition.VSMefx/Microsoft.VisualStudio.Composition.VSMefx.csproj
+++ b/src/Microsoft.VisualStudio.Composition.VSMefx/Microsoft.VisualStudio.Composition.VSMefx.csproj
@@ -22,4 +22,5 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Composition\Microsoft.VisualStudio.Composition.csproj" />
   </ItemGroup>
 
+  <Import Project="$(RepoRootPath)src\AnalyzerUser.targets" />
 </Project>

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Threading.Tasks.Dataflow" Condition="'$(TargetFrameworkIdentifier)'!='.NETCoreApp'" />
   </ItemGroup>
 
-  <Target Name="RemovePackOnlyProjectReferenceOutputs" AfterTargets="ResolveProjectReferences">
+  <Target Name="RemovePackOnlyProjectReferenceOutputs" AfterTargets="ResolveProjectReferences" Condition="'$(IsDocFx)'!='true'">
     <!-- Workaround for https://github.com/NuGet/Home/issues/10312 -->
     <ItemGroup>
       <_ResolvedProjectReferencePaths Remove="@(_ResolvedProjectReferencePaths)" Condition="'%(_ResolvedProjectReferencePaths.PackOnlyReference)' == 'true'" />

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -8,7 +8,7 @@
     <!-- This reference is just so the analyzers package is brought in by our NuGet package. -->
     <ProjectReference Include="..\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes\Microsoft.VisualStudio.Composition.Analyzers.CodeFixes.csproj">
       <PrivateAssets>none</PrivateAssets>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <PackOnlyReference>true</PackOnlyReference>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -21,5 +21,13 @@
     <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFrameworkIdentifier)'!='.NETCoreApp'" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Condition="'$(TargetFrameworkIdentifier)'!='.NETCoreApp'" />
   </ItemGroup>
+
+  <Target Name="RemovePackOnlyProjectReferenceOutputs" AfterTargets="ResolveProjectReferences">
+    <!-- Workaround for https://github.com/NuGet/Home/issues/10312 -->
+    <ItemGroup>
+      <_ResolvedProjectReferencePaths Remove="@(_ResolvedProjectReferencePaths)" Condition="'%(_ResolvedProjectReferencePaths.PackOnlyReference)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="..\OptProf.targets" Condition="'$(TargetFramework)'=='net472'" />
 </Project>

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Microsoft.VisualStudio.Composition.Analyzers.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Microsoft.VisualStudio.Composition.Analyzers.Tests.csproj
@@ -5,7 +5,7 @@
          and most importantly our analyzer test dependencies bring their own copy of vs-mef, leading to a 'last one wins' file overwrite
          issue if we were to share a directory with vs-mef tests that makes testing unstable. -->
     <BaseOutputPath>$(MSBuildThisFileDirectory)..\..\bin\Tests\Microsoft.VisualStudio.Composition.Analyzers.Tests</BaseOutputPath>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/test/Microsoft.VisualStudio.Composition.AppDomainTests/Microsoft.VisualStudio.Composition.AppDomainTests.csproj
+++ b/test/Microsoft.VisualStudio.Composition.AppDomainTests/Microsoft.VisualStudio.Composition.AppDomainTests.csproj
@@ -6,4 +6,5 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Composition.AppDomainTests2\Microsoft.VisualStudio.Composition.AppDomainTests2.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.Composition\Microsoft.VisualStudio.Composition.csproj" />
   </ItemGroup>
+  <Import Project="$(RepoRootPath)src\AnalyzerUser.targets" />
 </Project>

--- a/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaTMetadata.cs
+++ b/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatLazyImportsExportWithTypeMetadataViaTMetadata.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable VSMEF015 // Metadata view interface should be source-generated
+
 namespace Microsoft.VisualStudio.Composition.AppDomainTests
 {
     using System;
-    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Composition;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
     [Export]
     public class PartThatLazyImportsExportWithTypeMetadataViaTMetadata

--- a/test/VS.Mefx.Tests/TestFiles/BasicScripts/ExtendedOperations/ChainOne.cs
+++ b/test/VS.Mefx.Tests/TestFiles/BasicScripts/ExtendedOperations/ChainOne.cs
@@ -10,6 +10,6 @@ namespace ExtendedOperations
     public class ChainOne
     {
         [Import]
-        public AddIn? Adder { get; set; }
+        public AddIn Adder { get; set; } = null!;
     }
 }

--- a/test/VS.Mefx.Tests/TestFiles/BasicScripts/ExtendedOperations/Modulo.cs
+++ b/test/VS.Mefx.Tests/TestFiles/BasicScripts/ExtendedOperations/Modulo.cs
@@ -16,6 +16,6 @@ namespace ExtendedOperations
         }
 
         [Import]
-        public ChainOne? AddInput { get; set; }
+        public ChainOne AddInput { get; set; } = null!;
     }
 }

--- a/test/VS.Mefx.Tests/TestFiles/BasicScripts/MefCalculator/AddIn.cs
+++ b/test/VS.Mefx.Tests/TestFiles/BasicScripts/MefCalculator/AddIn.cs
@@ -9,6 +9,6 @@ namespace MefCalculator
     public class AddIn
     {
         [Import("ChainOne")]
-        public string? FieldOne { get; set; }
+        public string FieldOne { get; set; } = null!;
     }
 }

--- a/test/VS.Mefx.Tests/TestFiles/BasicScripts/MefCalculator/ImportTest.cs
+++ b/test/VS.Mefx.Tests/TestFiles/BasicScripts/MefCalculator/ImportTest.cs
@@ -10,10 +10,10 @@ namespace MefCalculator
     public class ImportTest
     {
         [Import("MissingField")]
-        private string? FailingField { get; set; }
+        private string FailingField { get; set; } = null!;
 
         [ImportMany]
-        public IEnumerable<IOperation>? Operations { get; set; }
+        public IEnumerable<IOperation> Operations { get; set; } = null!;
 
         [Import]
         public int? IntInput { get; set; }

--- a/test/VS.Mefx.Tests/TestFiles/MatchingScripts/User/Importer.cs
+++ b/test/VS.Mefx.Tests/TestFiles/MatchingScripts/User/Importer.cs
@@ -10,12 +10,14 @@ namespace User
     [Export]
     public class Importer
     {
+#pragma warning disable VSMEF007 // https://github.com/microsoft/vs-mef/issues/725
         [Import]
         [ImportMetadataConstraint("Year", 2016)]
-        private Lazy<Car>? NewerCar { get; set; }
+        private Lazy<Car> NewerCar { get; set; } = null!;
 
         [Import]
         [ImportMetadataConstraint("Type", "Used")]
-        private Car? UsedCar { get; set; }
+        private Car UsedCar { get; set; } = null!;
+#pragma warning restore VSMEF007 // https://github.com/microsoft/vs-mef/issues/725
     }
 }

--- a/test/VS.Mefx.Tests/VS.Mefx.Tests.csproj
+++ b/test/VS.Mefx.Tests/VS.Mefx.Tests.csproj
@@ -26,4 +26,5 @@
     </Content>
   </ItemGroup>
 
+  <Import Project="$(RepoRootPath)src\AnalyzerUser.targets" />
 </Project>


### PR DESCRIPTION
- **Beef up diagnostic messages**
- **Add back analyzers package dependency**
  This was a real pain. NuGet won't let us have a package dependency without an assembly reference. MSBuild RAR complains about conflicting assembly dependency versions when analyzers get mixed into the compilation of the main library, so I had to drop the compiler reference via an msbuild hack. That got docfx all bent out of shape so I had to hack it to keep the compiler reference when docfx is building. Finally, in the process of all this, the analyzers were applied to more test projects (which is a good thing) so I had to resolve or suppress more diagnostics.
