### PR TITLE
Propagate obsolete metadata view annotations

### DIFF
--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/MetadataViewSourceGenerator.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/MetadataViewSourceGenerator.cs
@@ -65,6 +65,7 @@ public sealed class MetadataViewSourceGenerator : IIncrementalGenerator
             GeneratedTypeConstraints: GetConstraintClauses(metadataViewInterface, cancellationToken),
             GeneratedTypeAttributeQualifiedName: GetQualifiedGeneratedTypeNameForAttribute(interfaceNamespace, containingTypes, generatedTypeName, metadataViewInterface.TypeParameters.Length),
             HintName: generatedTypeName + ".g.cs",
+            ObsoleteAttributeSource: GetObsoleteAttributeSource(metadataViewInterface),
             Properties: GetMetadataProperties(metadataViewInterface)
                 .Select(property => new MetadataPropertySpec(property.Name, property.Type.ToDisplayString(TypeNameFormat), GetDefaultValueAttributeSource(property, cancellationToken)))
                 .ToImmutableArray());
@@ -98,6 +99,11 @@ public sealed class MetadataViewSourceGenerator : IIncrementalGenerator
         writer.WriteLine("{");
         writer.WriteLine("}");
         writer.WriteLine();
+        if (metadataView.ObsoleteAttributeSource is not null)
+        {
+            writer.WriteLine(metadataView.ObsoleteAttributeSource);
+        }
+
         writer.WriteLine($"[{Types.GeneratedCodeAttribute.QualifiedName}(\"{typeof(MetadataViewSourceGenerator).FullName}\", \"{generatorVersion}\")]");
         writer.WriteLine($"internal sealed class {metadataView.GeneratedTypeName}{metadataView.GeneratedTypeTypeParameters} : {Types.MetadataView.QualifiedName}, {metadataView.InterfaceMetadataName}{metadataView.GeneratedTypeConstraints}");
         writer.WriteLine("{");
@@ -256,16 +262,30 @@ public sealed class MetadataViewSourceGenerator : IIncrementalGenerator
     {
         AttributeData? defaultValueAttribute = property.GetAttributes()
             .FirstOrDefault(attribute => attribute.AttributeClass?.ToDisplayString() == Types.DefaultValueAttribute.FullName);
-        if (defaultValueAttribute is not null)
+        return GetAttributeSource(defaultValueAttribute, Types.DefaultValueAttribute.QualifiedName);
+    }
+
+    private static string? GetObsoleteAttributeSource(INamedTypeSymbol metadataViewInterface)
+    {
+        AttributeData? obsoleteAttribute = metadataViewInterface.GetAttributes()
+            .FirstOrDefault(attribute => attribute.AttributeClass?.ToDisplayString() == Types.ObsoleteAttribute.FullName);
+        return GetAttributeSource(obsoleteAttribute, Types.ObsoleteAttribute.QualifiedName);
+    }
+
+    private static string? GetAttributeSource(AttributeData? attribute, string attributeQualifiedName)
+    {
+        if (attribute is null)
         {
-            string arguments = string.Join(
-                ", ",
-                defaultValueAttribute.ConstructorArguments.Select(GetAttributeArgumentSource)
-                    .Concat(defaultValueAttribute.NamedArguments.Select(static arg => arg.Key + " = " + GetAttributeArgumentSource(arg.Value))));
-            return $"[{Types.DefaultValueAttribute.QualifiedName}({arguments})]";
+            return null;
         }
 
-        return null;
+        string arguments = string.Join(
+            ", ",
+            attribute.ConstructorArguments.Select(GetAttributeArgumentSource)
+                .Concat(attribute.NamedArguments.Select(static arg => arg.Key + " = " + GetAttributeArgumentSource(arg.Value))));
+        return arguments.Length > 0
+            ? $"[{attributeQualifiedName}({arguments})]"
+            : $"[{attributeQualifiedName}]";
     }
 
     private static string GetAttributeArgumentSource(TypedConstant argument)
@@ -357,6 +377,7 @@ public sealed class MetadataViewSourceGenerator : IIncrementalGenerator
         string GeneratedTypeConstraints,
         string GeneratedTypeAttributeQualifiedName,
         string HintName,
+        string? ObsoleteAttributeSource,
         ImmutableArray<MetadataPropertySpec> Properties);
 
     private readonly record struct MetadataPropertySpec(string Name, string TypeName, string? DefaultValueAttributeSource);

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/Types.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/Types.cs
@@ -74,6 +74,13 @@ internal static class Types
         internal const string QualifiedName = $"global::{FullName}";
     }
 
+    internal static class ObsoleteAttribute
+    {
+        internal const string Name = "ObsoleteAttribute";
+        internal const string FullName = $"System.{Name}";
+        internal const string QualifiedName = $"global::{FullName}";
+    }
+
     internal static class DefaultValueAttribute
     {
         internal const string Name = "DefaultValueAttribute";

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/MetadataViewSourceGeneratorTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/MetadataViewSourceGeneratorTests.cs
@@ -219,6 +219,31 @@ public class MetadataViewSourceGeneratorTests
         Assert.Equal((int)DayOfWeek.Friday, defaultValueAttribute.ConstructorArguments[0].Value);
     }
 
+    [Fact]
+    public void Generator_AnnotatesGeneratedTypeWhenMetadataViewInterfaceIsObsolete()
+    {
+        string source = """
+            using System;
+            using Microsoft.VisualStudio.Composition;
+
+            [Obsolete("Use INextMetadataView instead", DiagnosticId = "VSMEFTEST001")]
+            [MetadataView]
+            public partial interface IObsoleteMetadataView
+            {
+                string A { get; }
+            }
+            """;
+
+        Compilation outputCompilation = RunGenerator(source).OutputCompilation;
+        INamedTypeSymbol metadataViewInterface = outputCompilation.GetTypeByMetadataName("IObsoleteMetadataView")!;
+        AttributeData implementationAttribute = metadataViewInterface.GetAttributes().Single(a => a.AttributeClass?.Name == "MetadataViewImplementationAttribute");
+        INamedTypeSymbol generatedType = (INamedTypeSymbol)implementationAttribute.ConstructorArguments[0].Value!;
+
+        AttributeData obsoleteAttribute = generatedType.GetAttributes().Single(a => a.AttributeClass?.Name == nameof(ObsoleteAttribute));
+        Assert.Equal("Use INextMetadataView instead", (string?)obsoleteAttribute.ConstructorArguments[0].Value);
+        Assert.Equal("VSMEFTEST001", obsoleteAttribute.NamedArguments.Single(arg => arg.Key == nameof(ObsoleteAttribute.DiagnosticId)).Value.Value);
+    }
+
     private static void AssertGeneratedMetadataViewType(INamedTypeSymbol generatedType)
     {
         INamedTypeSymbol definition = generatedType.OriginalDefinition;


### PR DESCRIPTION
When a `[MetadataView]` interface is also marked `[Obsolete]`, the source generator was still emitting a generated implementation class that directly referenced the obsolete interface without being obsolete itself. That produced an avoidable warning from generated code and broke the new regression case.

This change teaches the generator to copy `ObsoleteAttribute` from the metadata-view interface onto the generated class, preserving both constructor and named arguments. I also factored the attribute-emission path so the existing default-value handling and the new obsolete handling share the same argument rendering logic.

A regression test now covers an obsolete metadata-view interface and verifies that the generated implementation carries the matching obsolete annotation.