### PR TITLE
Add CS0649 suppressor for MEF imported fields

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,15 @@
 - Tests use xunit v3 with Microsoft.Testing.Platform (MTP v2). Traditional VSTest `--filter` syntax does NOT work.
 - Some tests are known to be unstable. When running tests, you should skip the unstable ones by using `-- --filter-not-trait "FailsInCloudTest=true"`.
 
+## Analyzer documentation
+
+- When adding or renumbering an analyzer or diagnostic suppressor, update the analyzer package catalog in `src/Microsoft.VisualStudio.Composition.Analyzers/README.md`.
+- Add or update the DocFX analyzer docs in `docfx/analyzers/`:
+  - add a per-ID page such as `docfx/analyzers/VSMEF018.md`
+  - update `docfx/analyzers/index.md`
+  - update `docfx/analyzers/toc.yml`
+- Before assigning a new `VSMEF###` identifier, check the existing analyzer and suppressor docs so the new ID does not collide with an existing one.
+
 ### Running Tests
 
 **Run all tests**:

--- a/docfx/analyzers/VSMEF018.md
+++ b/docfx/analyzers/VSMEF018.md
@@ -1,0 +1,29 @@
+# VSMEF018 Suppress CS0649 for MEF imported fields on exported parts
+
+`VSMEF018` suppresses `CS0649` for imported fields on exported MEF parts.
+
+## Why this matters
+
+MEF assigns imported fields during composition, not in the constructor or initializer that the C# compiler analyzes. That can make valid imports look like permanently unassigned fields and produce `CS0649` incorrectly.
+
+## When it applies
+
+The suppressor applies to fields on exported parts when the field is decorated with either flavor of `Import`-style attribute that this library recognizes.
+
+MEFv2 does not support field imports, so in practice field suppression only applies to MEFv1 field imports.
+
+## Example
+
+```cs
+using System;
+using System.ComponentModel.Composition;
+
+[Export]
+public class SomeService
+{
+    [Import(AllowDefault = true)]
+    private Lazy<IDependency>? dependency;
+}
+
+public interface IDependency { }
+```

--- a/docfx/analyzers/index.md
+++ b/docfx/analyzers/index.md
@@ -23,3 +23,4 @@ ID | Title
 [VSMEF015](VSMEF015.md) | Metadata view interface should be source-generated
 [VSMEF016](VSMEF016.md) | Referenced metadata view interface should be source-generated
 [VSMEF017](VSMEF017.md) | Invalid [MetadataView] usage
+[VSMEF018](VSMEF018.md) | Suppress CS0649 for MEF imported fields on exported parts

--- a/docfx/analyzers/toc.yml
+++ b/docfx/analyzers/toc.yml
@@ -17,3 +17,4 @@ items:
 - href: VSMEF015.md
 - href: VSMEF016.md
 - href: VSMEF017.md
+- href: VSMEF018.md

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/CS0649ImportingMemberSuppressor.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/CS0649ImportingMemberSuppressor.cs
@@ -43,13 +43,12 @@ public class CS0649ImportingMemberSuppressor : DiagnosticSuppressor
                 continue;
             }
 
-            ISymbol? affectedSymbol = ImportingMemberSuppressorUtilities.GetAffectedMemberSymbol(context, diagnostic);
-            if (affectedSymbol is not IFieldSymbol and not IPropertySymbol)
+            if (ImportingMemberSuppressorUtilities.GetAffectedMemberSymbol(context, diagnostic) is not IFieldSymbol affectedField)
             {
                 continue;
             }
 
-            INamedTypeSymbol? containingType = affectedSymbol.ContainingType;
+            INamedTypeSymbol? containingType = affectedField.ContainingType;
             if (containingType is null ||
                 !ImportingMemberSuppressorUtilities.HasInstanceExports(containingType) ||
                 ImportingMemberSuppressorUtilities.HasPartNotDiscoverableAttribute(containingType))
@@ -57,7 +56,7 @@ public class CS0649ImportingMemberSuppressor : DiagnosticSuppressor
                 continue;
             }
 
-            if (ImportingMemberSuppressorUtilities.GetImportAttribute(affectedSymbol.GetAttributes()) is null)
+            if (ImportingMemberSuppressorUtilities.GetImportAttribute(affectedField.GetAttributes()) is null)
             {
                 continue;
             }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/CS0649ImportingMemberSuppressor.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/CS0649ImportingMemberSuppressor.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers;
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Suppresses CS0649 for MEF importing members on exported parts,
+/// since composition assigns them at runtime instead of in source.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CS0649ImportingMemberSuppressor : DiagnosticSuppressor
+{
+    /// <summary>
+    /// The suppressor ID.
+    /// </summary>
+    public const string Id = "VSMEF018";
+
+    private const string SuppressedDiagnosticId = "CS0649";
+
+    /// <summary>
+    /// The descriptor for this suppressor.
+    /// </summary>
+    internal static readonly SuppressionDescriptor Descriptor = new(
+        id: Id,
+        suppressedDiagnosticId: SuppressedDiagnosticId,
+        justification: "Importing members on exported MEF parts are assigned at runtime by composition, so imported fields may appear unassigned in source.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions =>
+        ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc/>
+    public override void ReportSuppressions(SuppressionAnalysisContext context)
+    {
+        foreach (Diagnostic diagnostic in context.ReportedDiagnostics)
+        {
+            if (diagnostic.Id != SuppressedDiagnosticId)
+            {
+                continue;
+            }
+
+            ISymbol? affectedSymbol = ImportingMemberSuppressorUtilities.GetAffectedMemberSymbol(context, diagnostic);
+            if (affectedSymbol is not IFieldSymbol and not IPropertySymbol)
+            {
+                continue;
+            }
+
+            INamedTypeSymbol? containingType = affectedSymbol.ContainingType;
+            if (containingType is null ||
+                !ImportingMemberSuppressorUtilities.HasInstanceExports(containingType) ||
+                ImportingMemberSuppressorUtilities.HasPartNotDiscoverableAttribute(containingType))
+            {
+                continue;
+            }
+
+            if (ImportingMemberSuppressorUtilities.GetImportAttribute(affectedSymbol.GetAttributes()) is null)
+            {
+                continue;
+            }
+
+            context.ReportSuppression(Suppression.Create(Descriptor, diagnostic));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/CS8618ImportingMemberSuppressor.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/CS8618ImportingMemberSuppressor.cs
@@ -3,11 +3,15 @@
 
 namespace Microsoft.VisualStudio.Composition.Analyzers;
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
 /// <summary>
 /// Suppresses CS8618 for MEF importing fields and properties on exported parts,
 /// since MEF initializes such members after construction.
 /// </summary>
-[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class CS8618ImportingMemberSuppressor : DiagnosticSuppressor
 {
     /// <summary>
@@ -23,7 +27,7 @@ public class CS8618ImportingMemberSuppressor : DiagnosticSuppressor
     internal static readonly SuppressionDescriptor Descriptor = new(
         id: Id,
         suppressedDiagnosticId: SuppressedDiagnosticId,
-        justification: Strings.VSMEF014_Justification);
+        justification: "Importing members on exported MEF parts are initialized after construction unless AllowDefault = true is specified.");
 
     /// <inheritdoc/>
     public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions =>
@@ -39,7 +43,7 @@ public class CS8618ImportingMemberSuppressor : DiagnosticSuppressor
                 continue;
             }
 
-            ISymbol? affectedSymbol = this.GetAffectedMemberSymbol(context, diagnostic);
+            ISymbol? affectedSymbol = ImportingMemberSuppressorUtilities.GetAffectedMemberSymbol(context, diagnostic);
             if (affectedSymbol is not IFieldSymbol and not IPropertySymbol)
             {
                 continue;
@@ -52,59 +56,19 @@ public class CS8618ImportingMemberSuppressor : DiagnosticSuppressor
 
             INamedTypeSymbol? containingType = affectedSymbol.ContainingType;
             if (containingType is null ||
-                !Utils.HasInstanceExports(containingType) ||
-                Utils.HasPartNotDiscoverableAttribute(containingType))
+                !ImportingMemberSuppressorUtilities.HasInstanceExports(containingType) ||
+                ImportingMemberSuppressorUtilities.HasPartNotDiscoverableAttribute(containingType))
             {
                 continue;
             }
 
-            AttributeData? importAttribute = Utils.GetImportAttribute(affectedSymbol.GetAttributes());
-            if (importAttribute is null || Utils.GetAllowDefaultValue(importAttribute))
+            AttributeData? importAttribute = ImportingMemberSuppressorUtilities.GetImportAttribute(affectedSymbol.GetAttributes());
+            if (importAttribute is null || ImportingMemberSuppressorUtilities.GetAllowDefaultValue(importAttribute))
             {
                 continue;
             }
 
             context.ReportSuppression(Suppression.Create(Descriptor, diagnostic));
         }
-    }
-
-    private ISymbol? GetAffectedMemberSymbol(SuppressionAnalysisContext context, Diagnostic diagnostic)
-    {
-        foreach (Location location in diagnostic.AdditionalLocations)
-        {
-            ISymbol? symbol = GetDeclaredSymbol(context, location);
-            if (symbol is IFieldSymbol or IPropertySymbol)
-            {
-                return symbol;
-            }
-        }
-
-        return GetDeclaredSymbol(context, diagnostic.Location);
-    }
-
-    private static ISymbol? GetDeclaredSymbol(SuppressionAnalysisContext context, Location location)
-    {
-        SyntaxTree? syntaxTree = location.SourceTree;
-        if (syntaxTree is null)
-        {
-            return null;
-        }
-
-        SemanticModel semanticModel = context.GetSemanticModel(syntaxTree);
-        SyntaxNode root = syntaxTree.GetRoot(context.CancellationToken);
-        SyntaxNode? node = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
-
-        while (node is not null)
-        {
-            ISymbol? symbol = semanticModel.GetDeclaredSymbol(node, context.CancellationToken);
-            if (symbol is not null)
-            {
-                return symbol;
-            }
-
-            node = node.Parent;
-        }
-
-        return null;
     }
 }

--- a/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/ImportingMemberSuppressorUtilities.cs
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers.CSharp/ImportingMemberSuppressorUtilities.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Analyzers;
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+internal static class ImportingMemberSuppressorUtilities
+{
+    private static readonly ImmutableArray<string> MefV1AttributeNamespace = ImmutableArray.Create("System", "ComponentModel", "Composition");
+    private static readonly ImmutableArray<string> MefV2AttributeNamespace = ImmutableArray.Create("System", "Composition");
+
+    internal static bool HasInstanceExports(INamedTypeSymbol symbol)
+    {
+        if (HasExportAttribute(symbol) || HasInheritedExportAttribute(symbol))
+        {
+            return true;
+        }
+
+        foreach (ISymbol member in symbol.GetMembers())
+        {
+            if (member.IsStatic || member is ITypeSymbol)
+            {
+                continue;
+            }
+
+            if (HasExportAttribute(member))
+            {
+                return true;
+            }
+        }
+
+        for (INamedTypeSymbol? baseType = symbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (HasInheritedExportAttribute(baseType))
+            {
+                return true;
+            }
+        }
+
+        return symbol.AllInterfaces.Any(HasInheritedExportAttribute);
+    }
+
+    internal static bool HasPartNotDiscoverableAttribute(INamedTypeSymbol symbol)
+    {
+        return symbol.GetAttributes().Any(attribute => IsPartNotDiscoverableAttribute(attribute.AttributeClass));
+    }
+
+    internal static AttributeData? GetImportAttribute(ImmutableArray<AttributeData> attributes)
+    {
+        return attributes.FirstOrDefault(attr => IsImportAttribute(attr.AttributeClass));
+    }
+
+    internal static bool GetAllowDefaultValue(AttributeData importAttribute)
+    {
+        KeyValuePair<string, TypedConstant> allowDefaultArg = importAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "AllowDefault");
+        return allowDefaultArg.Key is not null && allowDefaultArg.Value.Value is bool allowDefault && allowDefault;
+    }
+
+    internal static ISymbol? GetAffectedMemberSymbol(SuppressionAnalysisContext context, Diagnostic diagnostic)
+    {
+        foreach (Location location in diagnostic.AdditionalLocations)
+        {
+            ISymbol? symbol = GetDeclaredSymbol(context, location);
+            if (symbol is IFieldSymbol or IPropertySymbol)
+            {
+                return symbol;
+            }
+        }
+
+        return GetDeclaredSymbol(context, diagnostic.Location);
+    }
+
+    private static bool HasExportAttribute(ISymbol symbol)
+    {
+        return symbol.GetAttributes().Any(attribute => IsExportAttribute(attribute.AttributeClass));
+    }
+
+    private static bool HasInheritedExportAttribute(ISymbol symbol)
+    {
+        return symbol.GetAttributes().Any(attribute => IsInheritedExportAttribute(attribute.AttributeClass));
+    }
+
+    private static bool IsExportAttribute(INamedTypeSymbol? attributeType)
+    {
+        return attributeType is not null &&
+            (IsAttributeOfType(attributeType, "ExportAttribute", MefV1AttributeNamespace.AsSpan()) ||
+             IsAttributeOfType(attributeType, "ExportAttribute", MefV2AttributeNamespace.AsSpan()));
+    }
+
+    private static bool IsInheritedExportAttribute(INamedTypeSymbol? attributeType)
+    {
+        return attributeType is not null &&
+            IsAttributeOfType(attributeType, "InheritedExportAttribute", MefV1AttributeNamespace.AsSpan());
+    }
+
+    private static bool IsPartNotDiscoverableAttribute(INamedTypeSymbol? attributeType)
+    {
+        return attributeType is not null &&
+            (IsAttributeOfType(attributeType, "PartNotDiscoverableAttribute", MefV1AttributeNamespace.AsSpan()) ||
+             IsAttributeOfType(attributeType, "PartNotDiscoverableAttribute", MefV2AttributeNamespace.AsSpan()));
+    }
+
+    private static bool IsImportAttribute(INamedTypeSymbol? attributeType)
+    {
+        return attributeType is not null &&
+            (IsAttributeOfType(attributeType, "ImportAttribute", MefV1AttributeNamespace.AsSpan()) ||
+             IsAttributeOfType(attributeType, "ImportAttribute", MefV2AttributeNamespace.AsSpan()) ||
+             IsAttributeOfType(attributeType, "ImportManyAttribute", MefV1AttributeNamespace.AsSpan()) ||
+             IsAttributeOfType(attributeType, "ImportManyAttribute", MefV2AttributeNamespace.AsSpan()));
+    }
+
+    private static bool IsAttributeOfType(INamedTypeSymbol attributeType, string attributeTypeName, ReadOnlySpan<string> expectedNamespace)
+    {
+        for (INamedTypeSymbol? current = attributeType; current is not null; current = current.BaseType)
+        {
+            if (current.Name == attributeTypeName && IsNamespaceMatch(current.ContainingNamespace, expectedNamespace))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsNamespaceMatch(INamespaceSymbol? actual, ReadOnlySpan<string> expectedNames)
+    {
+        if (actual is null or { IsGlobalNamespace: true })
+        {
+            return expectedNames.Length == 0;
+        }
+
+        if (expectedNames.Length == 0 || actual.Name != expectedNames[expectedNames.Length - 1])
+        {
+            return false;
+        }
+
+        return IsNamespaceMatch(actual.ContainingNamespace, expectedNames[..^1]);
+    }
+
+    private static ISymbol? GetDeclaredSymbol(SuppressionAnalysisContext context, Location location)
+    {
+        SyntaxTree? syntaxTree = location.SourceTree;
+        if (syntaxTree is null)
+        {
+            return null;
+        }
+
+        SemanticModel semanticModel = context.GetSemanticModel(syntaxTree);
+        SyntaxNode root = syntaxTree.GetRoot(context.CancellationToken);
+        SyntaxNode? node = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+
+        while (node is not null)
+        {
+            ISymbol? symbol = semanticModel.GetDeclaredSymbol(node, context.CancellationToken);
+            if (symbol is not null)
+            {
+                return symbol;
+            }
+
+            node = node.Parent;
+        }
+
+        return null;
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition.Analyzers/README.md
+++ b/src/Microsoft.VisualStudio.Composition.Analyzers/README.md
@@ -26,3 +26,4 @@ Suppressor ID | Suppressed Diagnostic | Description
 --|--|--
 VSMEF013 | IDE0044 | Suppresses "Make field readonly" for fields decorated with MEF `[Import]` or `[ImportMany]` attributes, since such fields are assigned at runtime via reflection.
 VSMEF014 | CS8618 | Suppresses "Non-nullable member must contain a non-null value when exiting constructor" for MEF importing members that are initialized after construction unless `AllowDefault = true` is specified.
+VSMEF018 | CS0649 | Suppresses "Field is never assigned to, and will always have its default value" for MEF imported fields on exported parts, since composition assigns them at runtime.

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/CS0649ImportingMemberSuppressorTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/CS0649ImportingMemberSuppressorTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+using Microsoft.VisualStudio.Composition.Analyzers;
+
+public class CS0649ImportingMemberSuppressorTests
+{
+    [Fact]
+    public async Task ExportedTypeWithAllowDefaultImportField_SuppressesCS0649()
+    {
+        string test = """
+            #nullable enable
+            #pragma warning disable CS1591
+            using System;
+            using System.ComponentModel.Composition;
+
+            [Export]
+            public class SomeService
+            {
+                [Import(AllowDefault = true)]
+                private Lazy<IService>? {|#0:someOtherService|};
+
+                public Lazy<IService>? Value => this.someOtherService;
+            }
+
+            public interface IService { }
+            """;
+
+        await new Test
+        {
+            TestCode = test,
+            ExpectedDiagnostics = { Cs0649Diagnostic(0, isSuppressed: true) },
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task NonImportField_DoesNotSuppressCS0649()
+    {
+        string test = """
+            #nullable enable
+            #pragma warning disable CS1591
+
+            public class SomeService
+            {
+                private object? {|#0:someOtherService|};
+
+                public object? Value => this.someOtherService;
+            }
+            """;
+
+        await new Test
+        {
+            TestCode = test,
+            ExpectedDiagnostics = { Cs0649Diagnostic(0) },
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task VisualBasicImportField_DoesNotProduceEquivalentCompilerWarning()
+    {
+        string test = """
+            Imports System
+            Imports System.ComponentModel.Composition
+
+            <Export>
+            Public Class SomeService
+                <Import(AllowDefault:=True)>
+                Private someOtherService As Lazy(Of IService)
+
+                Public ReadOnly Property Value As Lazy(Of IService)
+                    Get
+                        Return Me.someOtherService
+                    End Get
+                End Property
+            End Class
+
+            Public Interface IService
+            End Interface
+            """;
+
+        await new VisualBasicTest
+        {
+            TestCode = test,
+        }.RunAsync();
+    }
+
+    private static DiagnosticResult Cs0649Diagnostic(int location, bool isSuppressed = false)
+    {
+        DiagnosticResult result = new DiagnosticResult("CS0649", DiagnosticSeverity.Warning)
+            .WithLocation(location)
+            .WithArguments("SomeService.someOtherService", "null");
+        return isSuppressed ? result.WithIsSuppressed(true) : result;
+    }
+
+#pragma warning disable RS1001 // Missing DiagnosticAnalyzerAttribute - intentionally omitted for test-only class
+    private sealed class NoopAnalyzer : DiagnosticAnalyzer
+#pragma warning restore RS1001
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        }
+    }
+
+    private sealed class Test : CSharpCodeFixTest<NoopAnalyzer, EmptyCodeFixProvider, DefaultVerifier>
+    {
+        public Test()
+        {
+            this.ReferenceAssemblies = ReferencesHelper.DefaultReferences;
+            this.CompilerDiagnostics = CompilerDiagnostics.All;
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
+        {
+            yield return new NoopAnalyzer();
+            yield return new CS0649ImportingMemberSuppressor();
+        }
+    }
+
+    private sealed class VisualBasicTest : VisualBasicCodeFixTest<NoopAnalyzer, EmptyCodeFixProvider, DefaultVerifier>
+    {
+        public VisualBasicTest()
+        {
+            this.ReferenceAssemblies = ReferencesHelper.DefaultReferences;
+            this.CompilerDiagnostics = CompilerDiagnostics.All;
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
+        {
+            yield return new NoopAnalyzer();
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpMultiAnalyzerVerifier+Test.cs
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/Helpers/CSharpMultiAnalyzerVerifier+Test.cs
@@ -58,6 +58,7 @@ public static partial class CSharpMultiAnalyzerVerifier
                 new VSMEF012DisallowMefAttributeVersionAnalyzer(),
                 new IDE0044ImportFieldSuppressor(),
                 new CS8618ImportingMemberSuppressor(),
+                new CS0649ImportingMemberSuppressor(),
             ];
         }
 


### PR DESCRIPTION
## Why

MEF assigns imported fields during composition, so valid imported fields can trigger CS0649 even though they are populated at runtime. This change adds the missing suppressor and documents it alongside the existing analyzer catalog.

## What changed

- add `VSMEF018` to suppress `CS0649` on imported fields of exported MEF parts
- keep the compiler-diagnostic suppressors C#-only by moving `CS0649` and `CS8618` suppressors into the C# analyzer assembly
- add focused compiler-level tests for the new suppressor and a VB test showing there is no equivalent VB compiler warning in the same scenario
- register the new suppressor in the multi-analyzer test harness
- document the new suppressor in `docfx/analyzers/` and the analyzer package README
- record the analyzer doc update locations in `.github/copilot-instructions.md` so future analyzer additions update the docs consistently

## Notes for reviewers

The VB probe changed the shape of the implementation a bit: instead of keeping a C#-only suppressor in the shared analyzer assembly with an `RS1004` suppression, the compiler-specific suppressors now live in the C# analyzer assembly. A small shared helper in that assembly keeps the import/export detection logic consistent between `CS0649` and `CS8618`.