### PR TITLE
Reduce composition cache allocations

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/SerializationContextBase.cs
@@ -58,6 +58,12 @@ namespace Microsoft.VisualStudio.Composition
 
         private static readonly object BoxedTrue = true;
         private static readonly object BoxedFalse = false;
+        private static readonly object BoxedCreationPolicyAny = CreationPolicy.Any;
+        private static readonly object BoxedCreationPolicyShared = CreationPolicy.Shared;
+        private static readonly object BoxedCreationPolicyNonShared = CreationPolicy.NonShared;
+        private static readonly object BoxedInt32Zero = 0;
+        private static readonly object BoxedInt32One = 1;
+        private static readonly object BoxedInt32NegativeOne = -1;
 
         internal SerializationContextBase(BinaryReader reader, Resolver resolver)
         {
@@ -751,6 +757,39 @@ namespace Microsoft.VisualStudio.Composition
                     throw new NotSupportedException();
                 }
 
+                if (elementType == typeof(object))
+                {
+                    var array = new object?[(int)count];
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i] = itemReader();
+                    }
+
+                    return array;
+                }
+
+                if (elementType == typeof(string))
+                {
+                    var array = new string?[(int)count];
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i] = (string?)itemReader();
+                    }
+
+                    return array;
+                }
+
+                if (elementType == typeof(Type))
+                {
+                    var array = new Type?[(int)count];
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i] = (Type?)itemReader();
+                    }
+
+                    return array;
+                }
+
                 var list = Array.CreateInstance(elementType, (int)count);
                 for (int i = 0; i < list.Length; i++)
                 {
@@ -824,23 +863,27 @@ namespace Microsoft.VisualStudio.Composition
                 // access of any of its contents, we'll do a just-in-time deserialization,
                 // and perhaps only of the requested values.
                 uint count = this.ReadCompressedUInt();
-                var metadata = ImmutableDictionary<string, object?>.Empty;
-
-                if (count > 0)
+                if (count == 0)
                 {
-                    var builder = this.metadataBuilder; // reuse builder to save on GC pressure
-                    for (int i = 0; i < count; i++)
-                    {
-                        string? key = this.ReadString();
-                        object? value = this.ReadObject();
-                        builder.Add(key, value);
-                    }
-
-                    metadata = builder.ToImmutable();
-                    builder.Clear(); // clean up for the next user.
+                    return ImmutableDictionary<string, object?>.Empty;
                 }
 
-                return new LazyMetadataWrapper(metadata, LazyMetadataWrapper.Direction.ToOriginalValue, this.Resolver);
+                bool requiresValueSubstitution = false;
+                var builder = this.metadataBuilder; // reuse builder to save on GC pressure
+                for (int i = 0; i < count; i++)
+                {
+                    string? key = this.ReadString();
+                    object? value = this.ReadObject();
+                    requiresValueSubstitution |= value is LazyMetadataWrapper.ISubstitutedValue;
+                    builder.Add(key, value);
+                }
+
+                ImmutableDictionary<string, object?> metadata = builder.ToImmutable();
+                builder.Clear(); // clean up for the next user.
+
+                return requiresValueSubstitution
+                    ? new LazyMetadataWrapper(metadata, LazyMetadataWrapper.Direction.ToOriginalValue, this.Resolver)
+                    : metadata;
             }
         }
 
@@ -1093,7 +1136,14 @@ namespace Microsoft.VisualStudio.Composition
                     case ObjectType.UInt64:
                         return this.reader.ReadUInt64();
                     case ObjectType.Int32:
-                        return this.reader.ReadInt32();
+                        int int32Value = this.reader.ReadInt32();
+                        return int32Value switch
+                        {
+                            0 => BoxedInt32Zero,
+                            1 => BoxedInt32One,
+                            -1 => BoxedInt32NegativeOne,
+                            _ => int32Value,
+                        };
                     case ObjectType.UInt32:
                         return this.reader.ReadUInt32();
                     case ObjectType.Int16:
@@ -1115,7 +1165,13 @@ namespace Microsoft.VisualStudio.Composition
                     case ObjectType.Guid:
                         return this.ReadGuid();
                     case ObjectType.CreationPolicy:
-                        return (CreationPolicy)this.reader.ReadByte();
+                        return this.reader.ReadByte() switch
+                        {
+                            (byte)CreationPolicy.Any => BoxedCreationPolicyAny,
+                            (byte)CreationPolicy.Shared => BoxedCreationPolicyShared,
+                            (byte)CreationPolicy.NonShared => BoxedCreationPolicyNonShared,
+                            byte value => (CreationPolicy)value,
+                        };
                     case ObjectType.Type:
                         return this.ReadTypeRef().Resolve();
                     case ObjectType.TypeRef:

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -52,15 +52,7 @@ namespace Microsoft.VisualStudio.Composition
             this.Resolver = resolver;
 
             this.partsByType = this.parts.ToDictionary(p => p.TypeRef, this.parts.Count);
-
-            var exports =
-                from part in this.parts
-                from export in part.Exports
-                group export by export.ContractName into exportsByContract
-                select exportsByContract;
-            this.exportsByContractName = exports.ToDictionary(
-                e => e.Key,
-                e => (IReadOnlyCollection<RuntimeExport>)e.ToImmutableArray());
+            this.exportsByContractName = CreateExportsByContractName(this.parts);
         }
 
         public IReadOnlyCollection<RuntimePart> Parts
@@ -74,6 +66,33 @@ namespace Microsoft.VisualStudio.Composition
         }
 
         internal Resolver Resolver { get; }
+
+        private static IReadOnlyDictionary<string, IReadOnlyCollection<RuntimeExport>> CreateExportsByContractName(ImmutableHashSet<RuntimePart> parts)
+        {
+            var exportsByContractName = new Dictionary<string, List<RuntimeExport>>(StringComparer.Ordinal);
+            foreach (RuntimePart part in parts)
+            {
+                for (int i = 0; i < part.Exports.Count; i++)
+                {
+                    RuntimeExport export = part.Exports[i];
+                    if (!exportsByContractName.TryGetValue(export.ContractName, out List<RuntimeExport>? exports))
+                    {
+                        exports = new List<RuntimeExport>(capacity: 1);
+                        exportsByContractName.Add(export.ContractName, exports);
+                    }
+
+                    exports.Add(export);
+                }
+            }
+
+            var immutableExportsByContractName = new Dictionary<string, IReadOnlyCollection<RuntimeExport>>(exportsByContractName.Count, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, List<RuntimeExport>> entry in exportsByContractName)
+            {
+                immutableExportsByContractName.Add(entry.Key, entry.Value.ToImmutableArray());
+            }
+
+            return immutableExportsByContractName;
+        }
 
         public static RuntimeComposition CreateRuntimeComposition(CompositionConfiguration configuration)
         {

--- a/test/Microsoft.VisualStudio.Composition.Tests/ImportMetadataConstraintTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ImportMetadataConstraintTests.cs
@@ -5,10 +5,13 @@ namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Composition;
+    using System.IO;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Composition.Reflection;
     using Xunit;
 
     public class ImportMetadataConstraintTests
@@ -43,6 +46,53 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal(3, part.UnconstrainedMany.Count);
         }
 
+        [Fact]
+        public async Task TypeArrayConstraintIsPreservedAfterCatalogDeserializationAsync()
+        {
+            TypeRef partType = TypeRef.Get(typeof(ImportWithTypeArrayConstraint), TestUtilities.Resolver);
+            TypeRef objectType = TypeRef.Get(typeof(object), TestUtilities.Resolver);
+            var sourceConstraint = new ExportMetadataValueImportConstraint("Types", new Type[] { typeof(string), typeof(int) });
+            var importDefinition = new ImportDefinition(
+                "Contract",
+                ImportCardinality.ExactlyOne,
+                ImmutableDictionary<string, object?>.Empty,
+                ImmutableHashSet.Create<IImportSatisfiabilityConstraint>(sourceConstraint));
+            var importBinding = new ImportDefinitionBinding(
+                importDefinition,
+                partType,
+                new PropertyRef(typeof(ImportWithTypeArrayConstraint).GetProperty(nameof(ImportWithTypeArrayConstraint.Value))!, TestUtilities.Resolver),
+                objectType,
+                objectType);
+            var part = new ComposablePartDefinition(
+                partType,
+                ImmutableDictionary<string, object?>.Empty,
+                ImmutableList<ExportDefinition>.Empty,
+                ImmutableDictionary<MemberRef, IReadOnlyCollection<ExportDefinition>>.Empty,
+                ImmutableList.Create(importBinding),
+                sharingBoundary: null,
+                ImmutableList<MethodRef>.Empty,
+                importingConstructorRef: null,
+                importingConstructorImports: null,
+                CreationPolicy.Any);
+            ComposableCatalog catalog = ComposableCatalog.Create(TestUtilities.Resolver).AddPart(part);
+            var cache = new CachedCatalog();
+            using var stream = new MemoryStream();
+            await cache.SaveAsync(catalog, stream);
+
+            stream.Position = 0;
+            ComposableCatalog deserializedCatalog = await cache.LoadAsync(stream, TestUtilities.Resolver);
+            ExportMetadataValueImportConstraint deserializedConstraint = deserializedCatalog.Parts
+                .Single()
+                .ImportingMembers
+                .Single()
+                .ImportDefinition
+                .ExportConstraints
+                .OfType<ExportMetadataValueImportConstraint>()
+                .Single();
+
+            Assert.Equal(new Type[] { typeof(string), typeof(int) }, Assert.IsType<Type[]>(deserializedConstraint.Value));
+        }
+
         [Export]
         public class ImportOneWithContraintPart
         {
@@ -57,6 +107,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             [ImportMany("Common")]
             public ICollection<object> UnconstrainedMany { get; set; } = null!;
+        }
+
+        private class ImportWithTypeArrayConstraint
+        {
+            public object Value { get; set; } = null!;
         }
 
         [Export("Common", typeof(object))]

--- a/test/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/RuntimeCompositionTests.cs
@@ -4,8 +4,11 @@
 namespace Microsoft.VisualStudio.Composition.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.IO;
     using System.Linq;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
     using Xunit;
 
@@ -38,6 +41,195 @@ namespace Microsoft.VisualStudio.Composition.Tests
             var validComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
 
             Assert.Throws<ArgumentException>(() => RuntimeComposition.CreateRuntimeComposition(validComposition.Parts, ImmutableDictionary<TypeRef, RuntimeComposition.RuntimeExport>.Empty, Resolver.DefaultInstance));
+        }
+
+        /// <summary>
+        /// Verifies that export indexing preserves each contract's exports and their order.
+        /// </summary>
+        [Fact]
+        public void GetExportsGroupsExportsByContractName()
+        {
+            const string SharedContract = "Shared";
+            const string UniqueContract = "Unique";
+            RuntimeComposition.RuntimePart[] parts =
+            {
+                CreatePart(typeof(string), SharedContract, UniqueContract),
+                CreatePart(typeof(int), SharedContract),
+            };
+
+            RuntimeComposition composition = CreateComposition(parts);
+
+            RuntimeComposition.RuntimeExport[] expectedSharedExports = composition.Parts
+                .SelectMany(part => part.Exports)
+                .Where(export => export.ContractName == SharedContract)
+                .ToArray();
+            RuntimeComposition.RuntimeExport[] expectedUniqueExports = composition.Parts
+                .SelectMany(part => part.Exports)
+                .Where(export => export.ContractName == UniqueContract)
+                .ToArray();
+            Assert.Equal(expectedSharedExports, composition.GetExports(SharedContract));
+            Assert.Equal(expectedUniqueExports, composition.GetExports(UniqueContract));
+            Assert.Empty(composition.GetExports("Missing"));
+        }
+
+        /// <summary>
+        /// Verifies that deserialized empty metadata uses the shared empty dictionary.
+        /// </summary>
+        [Fact]
+        public async Task EmptyMetadataIsSharedAfterDeserializationAsync()
+        {
+            RuntimeComposition composition = CreateComposition(
+                CreatePart(typeof(string), "Contract1"),
+                CreatePart(typeof(int), "Contract2"));
+
+            RuntimeComposition deserializedComposition = await RoundTripAsync(composition);
+
+            IReadOnlyDictionary<string, object?>[] metadataDictionaries = deserializedComposition.Parts
+                .SelectMany(part => part.Exports)
+                .Select(export => export.Metadata)
+                .Concat(deserializedComposition.MetadataViewsAndProviders.Values.Select(export => export.Metadata))
+                .ToArray();
+            Assert.NotEmpty(metadataDictionaries);
+            Assert.All(metadataDictionaries, Assert.Empty);
+            Assert.All(metadataDictionaries.Skip(1), metadata => Assert.Same(metadataDictionaries[0], metadata));
+        }
+
+        /// <summary>
+        /// Verifies that metadata without substituted values is returned directly.
+        /// </summary>
+        [Fact]
+        public async Task MetadataWithoutSubstitutedValuesIsImmutableDictionaryAsync()
+        {
+            ImmutableDictionary<string, object?> metadata = ImmutableDictionary<string, object?>.Empty
+                .Add("String", "value")
+                .Add("Integer", 42);
+            RuntimeComposition composition = CreateComposition(CreatePart(typeof(string), "Contract", metadata));
+
+            RuntimeComposition deserializedComposition = await RoundTripAsync(composition);
+            IReadOnlyDictionary<string, object?> deserializedMetadata = deserializedComposition.GetExports("Contract").Single().Metadata;
+
+            Assert.IsAssignableFrom<ImmutableDictionary<string, object?>>(deserializedMetadata);
+            Assert.Equal("value", deserializedMetadata["String"]);
+            Assert.Equal(42, deserializedMetadata["Integer"]);
+        }
+
+        /// <summary>
+        /// Verifies that metadata containing substituted values retains conversion behavior.
+        /// </summary>
+        [Fact]
+        public async Task MetadataWithSubstitutedValuesIsResolvedAsync()
+        {
+            ImmutableDictionary<string, object?> metadata = ImmutableDictionary<string, object?>.Empty.Add("Type", typeof(IDisposable));
+            RuntimeComposition composition = CreateComposition(CreatePart(typeof(string), "Contract", metadata));
+
+            RuntimeComposition deserializedComposition = await RoundTripAsync(composition);
+            IReadOnlyDictionary<string, object?> deserializedMetadata = deserializedComposition.GetExports("Contract").Single().Metadata;
+
+            Assert.False(deserializedMetadata is ImmutableDictionary<string, object?>);
+            Assert.Equal(typeof(IDisposable), deserializedMetadata["Type"]);
+        }
+
+        /// <summary>
+        /// Verifies that common metadata array types are preserved during deserialization.
+        /// </summary>
+        [Fact]
+        public async Task CommonMetadataArrayTypesArePreservedAfterDeserializationAsync()
+        {
+            ImmutableDictionary<string, object?> metadata = ImmutableDictionary<string, object?>.Empty
+                .Add("ObjectArray", new object?[] { "value", 1, null })
+                .Add("StringArray", new string?[] { "value", null })
+                .Add("TypeArray", new Type[] { typeof(string), typeof(int) });
+            RuntimeComposition composition = CreateComposition(CreatePart(typeof(string), "Contract", metadata));
+
+            RuntimeComposition deserializedComposition = await RoundTripAsync(composition);
+            IReadOnlyDictionary<string, object?> deserializedMetadata = deserializedComposition.GetExports("Contract").Single().Metadata;
+
+            Assert.Equal(new object?[] { "value", 1, null }, Assert.IsType<object[]>(deserializedMetadata["ObjectArray"]));
+            Assert.Equal(new string?[] { "value", null }, Assert.IsType<string[]>(deserializedMetadata["StringArray"]));
+            Assert.Equal(new Type[] { typeof(string), typeof(int) }, Assert.IsType<Type[]>(deserializedMetadata["TypeArray"]));
+        }
+
+        /// <summary>
+        /// Verifies that frequently occurring metadata values reuse cached boxed instances.
+        /// </summary>
+        [Fact]
+        public async Task CommonMetadataValuesReuseBoxedInstancesAfterDeserializationAsync()
+        {
+            ImmutableDictionary<string, object?> metadata = ImmutableDictionary<string, object?>.Empty
+                .Add("Any1", CreationPolicy.Any)
+                .Add("Any2", CreationPolicy.Any)
+                .Add("Shared1", CreationPolicy.Shared)
+                .Add("Shared2", CreationPolicy.Shared)
+                .Add("NonShared1", CreationPolicy.NonShared)
+                .Add("NonShared2", CreationPolicy.NonShared)
+                .Add("NegativeOne1", -1)
+                .Add("NegativeOne2", -1)
+                .Add("Zero1", 0)
+                .Add("Zero2", 0)
+                .Add("One1", 1)
+                .Add("One2", 1)
+                .Add("Two1", 2)
+                .Add("Two2", 2);
+            RuntimeComposition composition = CreateComposition(CreatePart(typeof(string), "Contract", metadata));
+
+            RuntimeComposition deserializedComposition = await RoundTripAsync(composition);
+            IReadOnlyDictionary<string, object?> deserializedMetadata = deserializedComposition.GetExports("Contract").Single().Metadata;
+
+            Assert.Same(deserializedMetadata["Any1"], deserializedMetadata["Any2"]);
+            Assert.Same(deserializedMetadata["Shared1"], deserializedMetadata["Shared2"]);
+            Assert.Same(deserializedMetadata["NonShared1"], deserializedMetadata["NonShared2"]);
+            Assert.Same(deserializedMetadata["NegativeOne1"], deserializedMetadata["NegativeOne2"]);
+            Assert.Same(deserializedMetadata["Zero1"], deserializedMetadata["Zero2"]);
+            Assert.Same(deserializedMetadata["One1"], deserializedMetadata["One2"]);
+            Assert.NotSame(deserializedMetadata["Two1"], deserializedMetadata["Two2"]);
+        }
+
+        private static RuntimeComposition.RuntimePart CreatePart(Type type, params string[] contractNames)
+        {
+            return CreatePart(type, contractNames, ImmutableDictionary<string, object?>.Empty);
+        }
+
+        private static RuntimeComposition.RuntimePart CreatePart(Type type, string contractName, IReadOnlyDictionary<string, object?> metadata)
+        {
+            return CreatePart(type, new[] { contractName }, metadata);
+        }
+
+        private static RuntimeComposition.RuntimePart CreatePart(Type type, IReadOnlyList<string> contractNames, IReadOnlyDictionary<string, object?> metadata)
+        {
+            TypeRef typeRef = TypeRef.Get(type, TestUtilities.Resolver);
+            RuntimeComposition.RuntimeExport[] exports = contractNames
+                .Select(contractName => new RuntimeComposition.RuntimeExport(contractName, typeRef, memberRef: null, metadata))
+                .ToArray();
+            return new RuntimeComposition.RuntimePart(
+                typeRef,
+                importingConstructor: null,
+                importingConstructorArguments: Array.Empty<RuntimeComposition.RuntimeImport>(),
+                importingMembers: Array.Empty<RuntimeComposition.RuntimeImport>(),
+                exports,
+                onImportsSatisfiedMethods: Array.Empty<MethodRef>(),
+                sharingBoundary: null);
+        }
+
+        private static RuntimeComposition CreateComposition(params RuntimeComposition.RuntimePart[] parts)
+        {
+            TypeRef providerTypeRef = TypeRef.Get(typeof(RuntimeCompositionTests), TestUtilities.Resolver);
+            var providerExport = new RuntimeComposition.RuntimeExport(
+                "MetadataProvider",
+                providerTypeRef,
+                memberRef: null,
+                ImmutableDictionary<string, object?>.Empty);
+            ImmutableDictionary<TypeRef, RuntimeComposition.RuntimeExport> metadataViewsAndProviders =
+                ImmutableDictionary<TypeRef, RuntimeComposition.RuntimeExport>.Empty.Add(providerTypeRef, providerExport);
+            return RuntimeComposition.CreateRuntimeComposition(parts, metadataViewsAndProviders, TestUtilities.Resolver);
+        }
+
+        private static async Task<RuntimeComposition> RoundTripAsync(RuntimeComposition composition)
+        {
+            var cache = new CachedComposition();
+            using var stream = new MemoryStream();
+            await cache.SaveAsync(composition, stream);
+            stream.Position = 0;
+            return await cache.LoadRuntimeCompositionAsync(stream, TestUtilities.Resolver);
         }
     }
 }


### PR DESCRIPTION
Reduces allocations while loading composition caches by avoiding lazy metadata wrappers when values require no substitution, reusing common boxed values, creating typed arrays directly, and building the contract export index without LINQ grouping or interface enumerators. Metadata substitution and export ordering remain unchanged.

The VS validation Speedometer run measured `Startup.SingleFile` / `0100.Start VS` with no PIT regressions. `CLR_BytesAllocated_Total_devenv` improved by 1,255,856 bytes (0.87%).

Trace comparisons show `LazyMetadataWrapper` allocations from `SerializationContextBase.ReadMetadata` decreased in every measured iteration:

| Iteration | Baseline | This PR | Reduction |
|---|---:|---:|---:|
| PerfMetrics-1 | 1,514,192 B | 0 B | 1,514,192 B |
| PerfMetrics-2 | 1,394,208 B | 109,512 B | 1,284,696 B |
| PerfMetrics-3 | 1,181,776 B | 107,200 B | 1,074,576 B |
| PerfMetrics-4 | 2,403,120 B | 0 B | 2,403,120 B |
| PerfMetrics-5 | 1,503,048 B | 222,392 B | 1,280,656 B |
| Average | 1,599,269 B | 87,821 B | 1,511,448 B |

[PIT results](https://aka.ms/vsengpit?targetBranch=main&targetBuild=12104.16.Build_0bdbc590.260804.105019.765944&runGroup=Speedometer&baselineRunGroup=Speedometer&baselineBranch=main&baselineBuild=12103.328&category=10&since=2026-07-28T07:00:00.000Z&to=2026-08-05T06:59:59.999Z&testMethodFilter=Startup.SingleFile&selectedCounters=Startup.SingleFile%3E0100.Start%20VS%3ECLR_BytesAllocated_Total_devenv)

The existing `Deserialize` benchmark from #760 exercises the complete cache-load path over its synthetic 312-part catalog on .NET Framework 4.8.1:

| | Mean | Allocated |
|---|---:|---:|
| Baseline (`92f6643d`) | 1.859 ms | 580.62 KB |
| This PR | 1.791 ms | 528.04 KB |
| Delta | -3.7% | -9.1% |