### PR TITLE
Reduce metadata view activation overhead

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Globalization;
@@ -13,6 +14,10 @@ namespace Microsoft.VisualStudio.Composition
 
     internal class MetadataViewImplProxy : IMetadataViewProvider
     {
+        private static readonly ConcurrentDictionary<Type, ImplementationActivation> ImplementationActivations = new ConcurrentDictionary<Type, ImplementationActivation>();
+        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation> ExplicitImplementationActivations = new ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation>();
+        private static readonly MethodInfo CreateMetadataViewMethod = typeof(MetadataViewImplProxy).GetMethod(nameof(CreateMetadataView), BindingFlags.NonPublic | BindingFlags.Static)!;
+
         internal static readonly ComposablePartDefinition PartDefinition =
             Utilities.GetMetadataViewProviderPartDefinition(typeof(MetadataViewImplProxy), 100, Resolver.DefaultInstance);
 
@@ -25,15 +30,14 @@ namespace Microsoft.VisualStudio.Composition
 
         public bool IsMetadataViewSupported(Type metadataType)
         {
-            Type? implementationType = GetMetadataViewImplementationType(metadataType);
-            return implementationType is object && TryGetImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration: true) is object;
+            return TryGetImplementationActivation(metadataType, throwOnInvalidConfiguration: true) is object;
         }
 
         public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
         {
-            Type? implementationType = GetMetadataViewImplementationType(metadataViewType);
-            Assumes.NotNull(implementationType);
-            return CreateProxy(metadata, defaultValues, metadataViewType, implementationType);
+            var activation = TryGetImplementationActivation(metadataViewType, throwOnInvalidConfiguration: true);
+            Assumes.NotNull(activation);
+            return activation.Value.CreateProxy(metadata, defaultValues, metadataViewType);
         }
 
         internal static bool IsMetadataViewImplementationSupported(Type metadataType, Type implementationType, bool throwOnInvalidConfiguration = true)
@@ -62,8 +66,24 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(metadataType, nameof(metadataType));
 
+            if (ImplementationActivations.TryGetValue(metadataType, out ImplementationActivation cachedActivation))
+            {
+                return cachedActivation;
+            }
+
             Type? implementationType = GetMetadataViewImplementationType(metadataType);
-            return implementationType is object ? TryGetImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration) : null;
+            if (implementationType is null)
+            {
+                return null;
+            }
+
+            ImplementationActivation? activation = TryGetImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
+            if (activation.HasValue)
+            {
+                return ImplementationActivations.GetOrAdd(metadataType, activation.Value);
+            }
+
+            return null;
         }
 
         private static Type? GetMetadataViewImplementationType(Type metadataType)
@@ -79,6 +99,23 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(metadataType, nameof(metadataType));
             Requires.NotNull(implementationType, nameof(implementationType));
 
+            var key = (MetadataType: metadataType, ImplementationType: implementationType);
+            if (ExplicitImplementationActivations.TryGetValue(key, out ImplementationActivation cachedActivation))
+            {
+                return cachedActivation;
+            }
+
+            ImplementationActivation? activation = CreateImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
+            if (activation.HasValue)
+            {
+                return ExplicitImplementationActivations.GetOrAdd(key, activation.Value);
+            }
+
+            return null;
+        }
+
+        private static ImplementationActivation? CreateImplementationActivation(Type metadataType, Type implementationType, bool throwOnInvalidConfiguration)
+        {
             if (!metadataType.IsAssignableFrom(implementationType))
             {
                 if (throwOnInvalidConfiguration)
@@ -109,6 +146,18 @@ namespace Microsoft.VisualStudio.Composition
             }
 
             return null;
+        }
+
+        private static MetadataViewFactory CreateMetadataViewFactory(Type implementationType)
+        {
+            MethodInfo factoryMethod = CreateMetadataViewMethod.MakeGenericMethod(implementationType);
+            return (MetadataViewFactory)factoryMethod.CreateDelegate(typeof(MetadataViewFactory));
+        }
+
+        private static MetadataView CreateMetadataView<T>()
+            where T : MetadataView, new()
+        {
+            return new T();
         }
 
         private static ConstructorInfo? FindDefaultConstructor(TypeInfo implementationType)
@@ -144,17 +193,23 @@ namespace Microsoft.VisualStudio.Composition
                 || parameterType.IsAssignableFrom(typeof(ImmutableDictionary<string, object?>)));
         }
 
+        private delegate MetadataView MetadataViewFactory();
+
         private readonly struct ImplementationActivation
         {
+            private readonly ConstructorInfo? constructor;
+            private readonly Type? constructorParameterType;
+            private readonly MetadataViewFactory? metadataViewFactory;
+
             internal ImplementationActivation(ImplementationKind kind, ConstructorInfo constructor)
             {
                 this.Kind = kind;
-                this.Constructor = constructor;
+                this.constructor = kind == ImplementationKind.LegacyDictionary ? constructor : null;
+                this.constructorParameterType = kind == ImplementationKind.LegacyDictionary ? constructor.GetParameters()[0].ParameterType : null;
+                this.metadataViewFactory = kind == ImplementationKind.MetadataViewBase ? CreateMetadataViewFactory(constructor.DeclaringType!) : null;
             }
 
             internal ImplementationKind Kind { get; }
-
-            internal ConstructorInfo Constructor { get; }
 
             internal object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
             {
@@ -164,22 +219,21 @@ namespace Microsoft.VisualStudio.Composition
 
                 return this.Kind switch
                 {
-                    ImplementationKind.MetadataViewBase => InitializeMetadataView(metadata, defaultValues, this.Constructor),
-                    ImplementationKind.LegacyDictionary => InvokeDictionaryConstructor(metadata, this.Constructor),
+                    ImplementationKind.MetadataViewBase => InitializeMetadataView(metadata, defaultValues, this.metadataViewFactory!),
+                    ImplementationKind.LegacyDictionary => InvokeDictionaryConstructor(metadata, this.constructor!, this.constructorParameterType!),
                     _ => throw Assumes.NotReachable(),
                 };
             }
 
-            private static object InitializeMetadataView(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, ConstructorInfo constructor)
+            private static object InitializeMetadataView(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, MetadataViewFactory metadataViewFactory)
             {
-                var metadataView = (MetadataView)constructor.Invoke(Type.EmptyTypes);
+                MetadataView metadataView = metadataViewFactory();
                 metadataView.Initialize(metadata, defaultValues);
                 return metadataView;
             }
 
-            private static object InvokeDictionaryConstructor(IReadOnlyDictionary<string, object?> metadata, ConstructorInfo constructor)
+            private static object InvokeDictionaryConstructor(IReadOnlyDictionary<string, object?> metadata, ConstructorInfo constructor, Type parameterType)
             {
-                Type parameterType = constructor.GetParameters()[0].ParameterType;
                 object metadataMaybeWrapped = parameterType.IsInstanceOfType(metadata)
                     ? metadata
                     : parameterType.IsAssignableFrom(typeof(Dictionary<string, object?>))

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.Composition
 
     internal class MetadataViewImplProxy : IMetadataViewProvider
     {
-        private static readonly ConcurrentDictionary<Type, ImplementationActivation> ImplementationActivations = new ConcurrentDictionary<Type, ImplementationActivation>();
-        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation> ExplicitImplementationActivations = new ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation>();
+        private static readonly ConcurrentDictionary<Type, ImplementationActivationCacheEntry> ImplementationActivations = new();
+        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation> ExplicitImplementationActivations = new();
         private static readonly MethodInfo CreateMetadataViewMethod = typeof(MetadataViewImplProxy).GetMethod(nameof(CreateMetadataView), BindingFlags.NonPublic | BindingFlags.Static)!;
 
         internal static readonly ComposablePartDefinition PartDefinition =
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType)
         {
-            var activation = TryGetImplementationActivation(metadataViewType, throwOnInvalidConfiguration: true);
+            ImplementationActivation? activation = TryGetImplementationActivation(metadataViewType, throwOnInvalidConfiguration: true);
             Assumes.NotNull(activation);
             return activation.Value.CreateProxy(metadata, defaultValues, metadataViewType);
         }
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.Composition
 
         internal static object CreateProxy(IReadOnlyDictionary<string, object?> metadata, IReadOnlyDictionary<string, object?> defaultValues, Type metadataViewType, Type implementationType)
         {
-            var activation = TryGetImplementationActivation(metadataViewType, implementationType, throwOnInvalidConfiguration: true);
+            ImplementationActivation? activation = TryGetImplementationActivation(metadataViewType, implementationType, throwOnInvalidConfiguration: true);
             Assumes.NotNull(activation);
             return activation.Value.CreateProxy(metadata, defaultValues, metadataViewType);
         }
@@ -66,21 +66,23 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(metadataType, nameof(metadataType));
 
-            if (ImplementationActivations.TryGetValue(metadataType, out ImplementationActivation cachedActivation))
+            if (ImplementationActivations.TryGetValue(metadataType, out ImplementationActivationCacheEntry cachedActivation))
             {
-                return cachedActivation;
+                return cachedActivation.Activation;
             }
 
             Type? implementationType = GetMetadataViewImplementationType(metadataType);
             if (implementationType is null)
             {
-                return null;
+                ImplementationActivationCacheEntry cacheEntry = default;
+                return ImplementationActivations.GetOrAdd(metadataType, cacheEntry).Activation;
             }
 
             ImplementationActivation? activation = TryGetImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
             if (activation.HasValue)
             {
-                return ImplementationActivations.GetOrAdd(metadataType, activation.Value);
+                ImplementationActivationCacheEntry cacheEntry = new(activation.Value);
+                return ImplementationActivations.GetOrAdd(metadataType, cacheEntry).Activation;
             }
 
             return null;
@@ -131,13 +133,13 @@ namespace Microsoft.VisualStudio.Composition
             ConstructorInfo? ctor = FindDefaultConstructor(implementationTypeInfo);
             if (ctor != null && typeof(MetadataView).GetTypeInfo().IsAssignableFrom(implementationTypeInfo))
             {
-                return new ImplementationActivation(ImplementationKind.MetadataViewBase, ctor);
+                return new ImplementationActivation(CreateMetadataViewFactory(implementationType));
             }
 
             ctor = FindDictionaryConstructor(implementationTypeInfo);
             if (ctor != null)
             {
-                return new ImplementationActivation(ImplementationKind.LegacyDictionary, ctor);
+                return new ImplementationActivation(ctor);
             }
 
             if (throwOnInvalidConfiguration)
@@ -195,18 +197,33 @@ namespace Microsoft.VisualStudio.Composition
 
         private delegate MetadataView MetadataViewFactory();
 
+        private readonly struct ImplementationActivationCacheEntry
+        {
+            internal ImplementationActivationCacheEntry(ImplementationActivation activation)
+            {
+                this.Activation = activation;
+            }
+
+            internal ImplementationActivation? Activation { get; }
+        }
+
         private readonly struct ImplementationActivation
         {
-            private readonly ConstructorInfo? constructor;
-            private readonly Type? constructorParameterType;
+            private readonly (ConstructorInfo Constructor, Type ParameterType)? dictionaryConstructor;
             private readonly MetadataViewFactory? metadataViewFactory;
 
-            internal ImplementationActivation(ImplementationKind kind, ConstructorInfo constructor)
+            internal ImplementationActivation(ConstructorInfo constructor)
             {
-                this.Kind = kind;
-                this.constructor = kind == ImplementationKind.LegacyDictionary ? constructor : null;
-                this.constructorParameterType = kind == ImplementationKind.LegacyDictionary ? constructor.GetParameters()[0].ParameterType : null;
-                this.metadataViewFactory = kind == ImplementationKind.MetadataViewBase ? CreateMetadataViewFactory(constructor.DeclaringType!) : null;
+                this.Kind = ImplementationKind.LegacyDictionary;
+                this.dictionaryConstructor = (constructor, constructor.GetParameters()[0].ParameterType);
+                this.metadataViewFactory = null;
+            }
+
+            internal ImplementationActivation(MetadataViewFactory metadataViewFactory)
+            {
+                this.Kind = ImplementationKind.MetadataViewBase;
+                this.dictionaryConstructor = null;
+                this.metadataViewFactory = metadataViewFactory;
             }
 
             internal ImplementationKind Kind { get; }
@@ -217,10 +234,10 @@ namespace Microsoft.VisualStudio.Composition
                 Requires.NotNull(defaultValues, nameof(defaultValues));
                 Requires.NotNull(metadataViewType, nameof(metadataViewType));
 
-                return this.Kind switch
+                return (this.metadataViewFactory, this.dictionaryConstructor) switch
                 {
-                    ImplementationKind.MetadataViewBase => InitializeMetadataView(metadata, defaultValues, this.metadataViewFactory!),
-                    ImplementationKind.LegacyDictionary => InvokeDictionaryConstructor(metadata, this.constructor!, this.constructorParameterType!),
+                    (MetadataViewFactory factory, null) => InitializeMetadataView(metadata, defaultValues, factory),
+                    (null, (ConstructorInfo constructor, Type parameterType)) => InvokeDictionaryConstructor(metadata, constructor, parameterType),
                     _ => throw Assumes.NotReachable(),
                 };
             }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -147,6 +147,17 @@ namespace Microsoft.VisualStudio.Composition
             }
 
             TypeInfo implementationTypeInfo = implementationType.GetTypeInfo();
+            if (implementationTypeInfo.IsAbstract)
+            {
+                if (throwOnInvalidConfiguration)
+                {
+                    throw CreateInvalidConfigurationException(
+                        string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationTypeAbstract, implementationType.FullName, metadataType.FullName),
+                        InvalidConfigurationKind.AbstractImplementationType);
+                }
+
+                return null;
+            }
 
             ConstructorInfo? ctor = FindDefaultConstructor(implementationTypeInfo);
             if (ctor != null && typeof(MetadataView).GetTypeInfo().IsAssignableFrom(implementationTypeInfo))
@@ -232,6 +243,7 @@ namespace Microsoft.VisualStudio.Composition
         private enum InvalidConfigurationKind
         {
             NoMetadataViewImplementation,
+            AbstractImplementationType,
             NoSupportedConstructor,
         }
 

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -14,8 +14,10 @@ namespace Microsoft.VisualStudio.Composition
 
     internal class MetadataViewImplProxy : IMetadataViewProvider
     {
+        private const string InvalidConfigurationKindDataKey = "Microsoft.VisualStudio.Composition.MetadataViewImplProxy.InvalidConfigurationKind";
+
         private static readonly ConcurrentDictionary<Type, ImplementationActivationCacheEntry> ImplementationActivations = new();
-        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation> ExplicitImplementationActivations = new();
+        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivationCacheEntry> ExplicitImplementationActivations = new();
         private static readonly MethodInfo CreateMetadataViewMethod = typeof(MetadataViewImplProxy).GetMethod(nameof(CreateMetadataView), BindingFlags.NonPublic | BindingFlags.Static)!;
 
         internal static readonly ComposablePartDefinition PartDefinition =
@@ -102,18 +104,34 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(implementationType, nameof(implementationType));
 
             var key = (MetadataType: metadataType, ImplementationType: implementationType);
-            if (ExplicitImplementationActivations.TryGetValue(key, out ImplementationActivation cachedActivation))
+            if (ExplicitImplementationActivations.TryGetValue(key, out ImplementationActivationCacheEntry cachedActivation))
             {
-                return cachedActivation;
+                if (!cachedActivation.Activation.HasValue && throwOnInvalidConfiguration)
+                {
+                    return CreateImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
+                }
+
+                return cachedActivation.Activation;
             }
 
-            ImplementationActivation? activation = CreateImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
-            if (activation.HasValue)
+            try
             {
-                return ExplicitImplementationActivations.GetOrAdd(key, activation.Value);
+                ImplementationActivation? activation = CreateImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
+                ImplementationActivationCacheEntry cacheEntry = new(activation);
+                return ExplicitImplementationActivations.GetOrAdd(key, cacheEntry).Activation;
             }
+            catch (InvalidOperationException ex) when (IsMetadataViewImplementationConfigurationException(ex))
+            {
+                ImplementationActivationCacheEntry cacheEntry = default;
+                ExplicitImplementationActivations.GetOrAdd(key, cacheEntry);
 
-            return null;
+                if (throwOnInvalidConfiguration)
+                {
+                    throw;
+                }
+
+                return null;
+            }
         }
 
         private static ImplementationActivation? CreateImplementationActivation(Type metadataType, Type implementationType, bool throwOnInvalidConfiguration)
@@ -122,7 +140,9 @@ namespace Microsoft.VisualStudio.Composition
             {
                 if (throwOnInvalidConfiguration)
                 {
-                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationTypeMustImplementMetadataView, implementationType.FullName, metadataType.FullName));
+                    throw CreateInvalidConfigurationException(
+                        string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationTypeMustImplementMetadataView, implementationType.FullName, metadataType.FullName),
+                        InvalidConfigurationKind.NoMetadataViewImplementation);
                 }
 
                 return null;
@@ -144,10 +164,24 @@ namespace Microsoft.VisualStudio.Composition
 
             if (throwOnInvalidConfiguration)
             {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationConstructorUnsupported, implementationType.FullName, metadataType.FullName));
+                throw CreateInvalidConfigurationException(
+                    string.Format(CultureInfo.CurrentCulture, Strings.MetadataViewImplementationConstructorUnsupported, implementationType.FullName, metadataType.FullName),
+                    InvalidConfigurationKind.NoSupportedConstructor);
             }
 
             return null;
+        }
+
+        private static InvalidOperationException CreateInvalidConfigurationException(string message, InvalidConfigurationKind kind)
+        {
+            var exception = new InvalidOperationException(message);
+            exception.Data[InvalidConfigurationKindDataKey] = kind;
+            return exception;
+        }
+
+        private static bool IsMetadataViewImplementationConfigurationException(InvalidOperationException exception)
+        {
+            return exception.Data[InvalidConfigurationKindDataKey] is InvalidConfigurationKind;
         }
 
         private static MetadataViewFactory CreateMetadataViewFactory(Type implementationType)
@@ -197,9 +231,15 @@ namespace Microsoft.VisualStudio.Composition
 
         private delegate MetadataView MetadataViewFactory();
 
+        private enum InvalidConfigurationKind
+        {
+            NoMetadataViewImplementation,
+            NoSupportedConstructor,
+        }
+
         private readonly struct ImplementationActivationCacheEntry
         {
-            internal ImplementationActivationCacheEntry(ImplementationActivation activation)
+            internal ImplementationActivationCacheEntry(ImplementationActivation? activation)
             {
                 this.Activation = activation;
             }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/MetadataViewImplProxy.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.Composition
     {
         private const string InvalidConfigurationKindDataKey = "Microsoft.VisualStudio.Composition.MetadataViewImplProxy.InvalidConfigurationKind";
 
-        private static readonly ConcurrentDictionary<Type, ImplementationActivationCacheEntry> ImplementationActivations = new();
-        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivationCacheEntry> ExplicitImplementationActivations = new();
+        private static readonly ConcurrentDictionary<Type, ImplementationActivation?> ImplementationActivations = new();
+        private static readonly ConcurrentDictionary<(Type MetadataType, Type ImplementationType), ImplementationActivation?> ExplicitImplementationActivations = new();
         private static readonly MethodInfo CreateMetadataViewMethod = typeof(MetadataViewImplProxy).GetMethod(nameof(CreateMetadataView), BindingFlags.NonPublic | BindingFlags.Static)!;
 
         internal static readonly ComposablePartDefinition PartDefinition =
@@ -68,23 +68,22 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(metadataType, nameof(metadataType));
 
-            if (ImplementationActivations.TryGetValue(metadataType, out ImplementationActivationCacheEntry cachedActivation))
+            if (ImplementationActivations.TryGetValue(metadataType, out ImplementationActivation? cachedActivation))
             {
-                return cachedActivation.Activation;
+                return cachedActivation;
             }
 
             Type? implementationType = GetMetadataViewImplementationType(metadataType);
             if (implementationType is null)
             {
-                ImplementationActivationCacheEntry cacheEntry = default;
-                return ImplementationActivations.GetOrAdd(metadataType, cacheEntry).Activation;
+                ImplementationActivation? noActivation = null;
+                return ImplementationActivations.GetOrAdd(metadataType, noActivation);
             }
 
             ImplementationActivation? activation = TryGetImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
             if (activation.HasValue)
             {
-                ImplementationActivationCacheEntry cacheEntry = new(activation.Value);
-                return ImplementationActivations.GetOrAdd(metadataType, cacheEntry).Activation;
+                return ImplementationActivations.GetOrAdd(metadataType, activation);
             }
 
             return null;
@@ -104,26 +103,25 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(implementationType, nameof(implementationType));
 
             var key = (MetadataType: metadataType, ImplementationType: implementationType);
-            if (ExplicitImplementationActivations.TryGetValue(key, out ImplementationActivationCacheEntry cachedActivation))
+            if (ExplicitImplementationActivations.TryGetValue(key, out ImplementationActivation? cachedActivation))
             {
-                if (!cachedActivation.Activation.HasValue && throwOnInvalidConfiguration)
+                if (!cachedActivation.HasValue && throwOnInvalidConfiguration)
                 {
                     return CreateImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
                 }
 
-                return cachedActivation.Activation;
+                return cachedActivation;
             }
 
             try
             {
                 ImplementationActivation? activation = CreateImplementationActivation(metadataType, implementationType, throwOnInvalidConfiguration);
-                ImplementationActivationCacheEntry cacheEntry = new(activation);
-                return ExplicitImplementationActivations.GetOrAdd(key, cacheEntry).Activation;
+                return ExplicitImplementationActivations.GetOrAdd(key, activation);
             }
             catch (InvalidOperationException ex) when (IsMetadataViewImplementationConfigurationException(ex))
             {
-                ImplementationActivationCacheEntry cacheEntry = default;
-                ExplicitImplementationActivations.GetOrAdd(key, cacheEntry);
+                ImplementationActivation? noActivation = null;
+                ExplicitImplementationActivations.GetOrAdd(key, noActivation);
 
                 if (throwOnInvalidConfiguration)
                 {
@@ -235,16 +233,6 @@ namespace Microsoft.VisualStudio.Composition
         {
             NoMetadataViewImplementation,
             NoSupportedConstructor,
-        }
-
-        private readonly struct ImplementationActivationCacheEntry
-        {
-            internal ImplementationActivationCacheEntry(ImplementationActivation? activation)
-            {
-                this.Activation = activation;
-            }
-
-            internal ImplementationActivation? Activation { get; }
         }
 
         private readonly struct ImplementationActivation

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -168,6 +168,9 @@
   </data>
   <data name="MetadataViewImplementationConstructorUnsupported" xml:space="preserve">
     <value>The metadata view implementation type "{0}" for metadata view "{1}" must declare one of the supported constructors: a public parameterless constructor when deriving from Microsoft.VisualStudio.Composition.MetadataView, or a public .ctor(IDictionary&lt;string, object?&gt;) / .ctor(IReadOnlyDictionary&lt;string, object?&gt;).</value>
+  </data>
+  <data name="MetadataViewImplementationTypeAbstract" xml:space="preserve">
+    <value>The metadata view implementation type "{0}" for metadata view "{1}" is abstract. Specify a non-abstract implementation type.</value>
   </data>
   <data name="MetadataViewDirectUseUnsupported" xml:space="preserve">
     <value>The metadata view type "{0}" derives from Microsoft.VisualStudio.Composition.MetadataView. To be supported, it must be a non-abstract class with a public parameterless constructor when used directly as TMetadata or as the implementation type for an interface annotated with MetadataViewImplementationAttribute.</value>

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -141,12 +141,23 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
-        public void MetadataViewImplementationActivationFactoryIsCached()
+        public void MetadataViewImplementationAbsenceIsCached()
         {
-            object firstFactory = GetMetadataViewImplementationFactory(typeof(ExportMetadataTests.INamedMetadata));
-            object secondFactory = GetMetadataViewImplementationFactory(typeof(ExportMetadataTests.INamedMetadata));
+            var metadataType = new AttributeCountingTypeDelegator(typeof(string));
 
-            Assert.Same(firstFactory, secondFactory);
+            Assert.False(IsMetadataViewSupported(metadataType));
+            Assert.False(IsMetadataViewSupported(metadataType));
+            Assert.Equal(1, metadataType.GetCustomAttributesCallCount);
+        }
+
+        [Fact]
+        public void MetadataViewImplementationActivationIsCached()
+        {
+            var metadataType = new AttributeCountingTypeDelegator(typeof(IMetadataView));
+
+            Assert.True(IsMetadataViewSupported(metadataType));
+            Assert.True(IsMetadataViewSupported(metadataType));
+            Assert.Equal(1, metadataType.GetCustomAttributesCallCount);
         }
 
         [Fact]
@@ -384,20 +395,6 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 metadataViewType)!;
         }
 
-        private static object GetMetadataViewImplementationFactory(Type metadataViewType)
-        {
-            Type metadataViewImplProxyType = typeof(CompositionConfiguration).Assembly.GetType("Microsoft.VisualStudio.Composition.MetadataViewImplProxy", throwOnError: true)!;
-            MethodInfo getActivationMethod = metadataViewImplProxyType.GetMethod(
-                "TryGetImplementationActivation",
-                BindingFlags.Static | BindingFlags.NonPublic,
-                binder: null,
-                new[] { typeof(Type), typeof(bool) },
-                modifiers: null)!;
-            object activation = getActivationMethod.Invoke(null, new object[] { metadataViewType, true })!;
-            FieldInfo factoryField = activation.GetType().GetField("metadataViewFactory", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            return factoryField.GetValue(activation)!;
-        }
-
         private static object? InvokeMetadataViewImplProxy(string methodName, params object[] args)
         {
             Type metadataViewImplProxyType = typeof(CompositionConfiguration).Assembly.GetType("Microsoft.VisualStudio.Composition.MetadataViewImplProxy", throwOnError: true)!;
@@ -412,6 +409,22 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                 throw;
+            }
+        }
+
+        private sealed class AttributeCountingTypeDelegator : TypeDelegator
+        {
+            internal AttributeCountingTypeDelegator(Type delegatingType)
+                : base(delegatingType)
+            {
+            }
+
+            internal int GetCustomAttributesCallCount { get; private set; }
+
+            public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+            {
+                this.GetCustomAttributesCallCount++;
+                return base.GetCustomAttributes(attributeType, inherit);
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -140,6 +140,22 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal("default", metadataView.B);
         }
 
+        [Fact]
+        public void MetadataViewImplementationActivationFactoryIsCached()
+        {
+            object firstFactory = GetMetadataViewImplementationFactory(typeof(ExportMetadataTests.INamedMetadata));
+            object secondFactory = GetMetadataViewImplementationFactory(typeof(ExportMetadataTests.INamedMetadata));
+
+            Assert.Same(firstFactory, secondFactory);
+        }
+
+        [Fact]
+        public void MetadataViewImplementationWrapsConstructorException()
+        {
+            TargetInvocationException exception = Assert.Throws<TargetInvocationException>(() => CreateProxy(new Dictionary<string, object?>(), typeof(IThrowingMetadataView)));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
         [MefV1.Export]
         public class ImportingPartWithoutMismatchingMetadata
         {
@@ -325,6 +341,19 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public string? A { get; }
         }
 
+        [MefV1.MetadataViewImplementation(typeof(ThrowingMetadataView))]
+        public interface IThrowingMetadataView
+        {
+        }
+
+        public class ThrowingMetadataView : MetadataView, IThrowingMetadataView
+        {
+            public ThrowingMetadataView()
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
         public interface IInterfaceDefaultValueMetadataView
         {
             [DefaultValue("default")]
@@ -353,6 +382,20 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 metadata,
                 new ReadOnlyMetadataDictionary(new Dictionary<string, object?>()),
                 metadataViewType)!;
+        }
+
+        private static object GetMetadataViewImplementationFactory(Type metadataViewType)
+        {
+            Type metadataViewImplProxyType = typeof(CompositionConfiguration).Assembly.GetType("Microsoft.VisualStudio.Composition.MetadataViewImplProxy", throwOnError: true)!;
+            MethodInfo getActivationMethod = metadataViewImplProxyType.GetMethod(
+                "TryGetImplementationActivation",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                binder: null,
+                new[] { typeof(Type), typeof(bool) },
+                modifiers: null)!;
+            object activation = getActivationMethod.Invoke(null, new object[] { metadataViewType, true })!;
+            FieldInfo factoryField = activation.GetType().GetField("metadataViewFactory", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return factoryField.GetValue(activation)!;
         }
 
         private static object? InvokeMetadataViewImplProxy(string methodName, params object[] args)

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -126,6 +126,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public void MetadataViewImplementationRejectsAbstractType()
+        {
+            AssertAbstractMetadataViewImplementationRejected(typeof(IAbstractMetadataView), typeof(AbstractMetadataView));
+        }
+
+        [Fact]
+        public void MetadataViewImplementationRejectsAbstractDictionaryType()
+        {
+            AssertAbstractMetadataViewImplementationRejected(typeof(IAbstractDictionaryMetadataView), typeof(AbstractDictionaryMetadataView));
+        }
+
+        [Fact]
         public void MetadataViewImplementationDoesNotCatchUnrelatedInvalidOperationException()
         {
             var expectedException = new InvalidOperationException();
@@ -347,6 +359,30 @@ namespace Microsoft.VisualStudio.Composition.Tests
             public string? A { get; }
         }
 
+        [MefV1.MetadataViewImplementation(typeof(AbstractMetadataView))]
+        public interface IAbstractMetadataView
+        {
+        }
+
+        public abstract class AbstractMetadataView : MetadataView, IAbstractMetadataView
+        {
+            public AbstractMetadataView()
+            {
+            }
+        }
+
+        [MefV1.MetadataViewImplementation(typeof(AbstractDictionaryMetadataView))]
+        public interface IAbstractDictionaryMetadataView
+        {
+        }
+
+        public abstract class AbstractDictionaryMetadataView : IAbstractDictionaryMetadataView
+        {
+            public AbstractDictionaryMetadataView(IDictionary<string, object?> metadata)
+            {
+            }
+        }
+
         [MefV1.MetadataViewImplementation(typeof(DictionaryCtorMetadataView))]
         public interface IDictionaryCtorMetadataView
         {
@@ -404,6 +440,14 @@ namespace Microsoft.VisualStudio.Composition.Tests
         private static bool IsMetadataViewSupported(Type metadataViewType)
         {
             return (bool)InvokeMetadataViewImplProxy("IsMetadataViewSupported", metadataViewType)!;
+        }
+
+        private static void AssertAbstractMetadataViewImplementationRejected(Type metadataViewType, Type implementationType)
+        {
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => IsMetadataViewSupported(metadataViewType));
+            Assert.Contains("abstract", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(implementationType.Name, exception.Message);
+            Assert.Contains(metadataViewType.Name, exception.Message);
         }
 
         private static object CreateProxy(IReadOnlyDictionary<string, object?> metadata, Type metadataViewType)

--- a/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/MetadataViewImplementationTests.cs
@@ -126,6 +126,17 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public void MetadataViewImplementationDoesNotCatchUnrelatedInvalidOperationException()
+        {
+            var expectedException = new InvalidOperationException();
+            var metadataType = new AssignabilityThrowingTypeDelegator(typeof(IUnrelatedExceptionMetadataView), expectedException);
+
+            InvalidOperationException actualException = Assert.Throws<InvalidOperationException>(() => IsMetadataViewSupported(metadataType));
+
+            Assert.Same(expectedException, actualException);
+        }
+
+        [Fact]
         public void MetadataViewImplementationWrapsReadOnlyMetadataForDictionaryConstructor()
         {
             var metadata = new ReadOnlyMetadataDictionary(new Dictionary<string, object?> { ["A"] = "1" });
@@ -365,6 +376,15 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
+        [MefV1.MetadataViewImplementation(typeof(UnrelatedExceptionMetadataView))]
+        public interface IUnrelatedExceptionMetadataView
+        {
+        }
+
+        public class UnrelatedExceptionMetadataView : MetadataView, IUnrelatedExceptionMetadataView
+        {
+        }
+
         public interface IInterfaceDefaultValueMetadataView
         {
             [DefaultValue("default")]
@@ -425,6 +445,22 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 this.GetCustomAttributesCallCount++;
                 return base.GetCustomAttributes(attributeType, inherit);
+            }
+        }
+
+        private sealed class AssignabilityThrowingTypeDelegator : TypeDelegator
+        {
+            private readonly InvalidOperationException exception;
+
+            internal AssignabilityThrowingTypeDelegator(Type delegatingType, InvalidOperationException exception)
+                : base(delegatingType)
+            {
+                this.exception = exception;
+            }
+
+            public override bool IsAssignableFrom(Type? c)
+            {
+                throw this.exception;
             }
         }
 


### PR DESCRIPTION
Source-generated metadata views repeatedly discovered and invoked their constructors through reflection each time an export's metadata was accessed.

Cache validated activation plans by metadata and implementation type. Bind a typed construction delegate once for MetadataView implementations while preserving reflective dictionary-constructor support and existing exception behavior.