### PR TITLE
Target analyzers at .NET 8 SDK

### DIFF
--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,19 +1,21 @@
 <Project>
+  <!-- These versions are chosen to support the .NET 8 SDK. -->
   <PropertyGroup>
-    <CodeAnalysisVersionForAnalyzers>4.14.0</CodeAnalysisVersionForAnalyzers>
+    <CodeAnalysisVersionForAnalyzers>4.11.0</CodeAnalysisVersionForAnalyzers>
   </PropertyGroup>
   <ItemGroup>
-    <!-- These versions are chosen to support VS 2022 Update 14. -->
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
-    <PackageVersion Update="System.Memory" Version="4.6.3" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="9.0.0" />
-    <PackageVersion Update="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="4.7.2" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Update="System.Memory" Version="4.5.5" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This carefully controls dependencies so the analyzers will run on the .NET 8 SDK.It also ensures that all such dependency versions are specified in a dedicated file so that renovate won't try to update those versions.