### PR TITLE
Avoid false test hang failures

### DIFF
--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/xunit.runner.json
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}

--- a/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/xunit.runner.json
+++ b/test/Microsoft.VisualStudio.Composition.Analyzers.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false
-}

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -91,7 +91,7 @@ if ($isMTP) {
         --filter "TestCategory!=FailsInCloudTest" `
         --collect "Code Coverage;Format=cobertura" `
         --settings "$PSScriptRoot/test.runsettings" `
-        --blame-hang-timeout 60s `
+        --blame-hang-timeout 120s `
         --blame-crash `
         -bl:"$testBinLog" `
         --diag "$testDiagLog;TraceLevel=info" `


### PR DESCRIPTION
## Summary
- extend the legacy VSTest inactivity threshold from 60 to 120 seconds
- match the existing Microsoft Testing Platform hang-dump threshold
- retain parallel analyzer-test execution with no normal-run regression

## Root cause
The captured `testhost` dump was a 60-second hang snapshot, not a crash: it showed 93% CPU utilization, five active worker threads, and the two reported Roslyn verifier tests actively compiling. The VSTest blame collector terminated the active host before it could report a completed test.

## Validation
- ran the complete Release cloud-equivalent test command
- analyzer suite: 391 passing tests in 8 seconds