### PR TITLE
Avoid loading cached catalog assemblies for composition errors

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(import, nameof(import));
 
-            var memberName = import.ImportingParameterRef is object ? $"ctor(parameter #{import.ImportingParameterRef.ParameterIndex})" :
+            var memberName = import.ImportingParameterRef is object ? $"ctor(parameter #{import.ImportingParameterRef.ParameterIndex + 1})" :
                              import.ImportingMemberRef is object ? import.ImportingMemberRef.Name :
                              "(unknown)";
             return string.Format(

--- a/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
+++ b/src/Microsoft.VisualStudio.Composition/ComposedPart.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.Composition
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
@@ -71,7 +70,7 @@ namespace Microsoft.VisualStudio.Composition
             if (this.Definition.ExportDefinitions.Any(ed => CompositionConfiguration.ExportDefinitionPracticallyEqual.Default.Equals(ExportProvider.ExportProviderExportDefinition, ed.Value)) &&
                 !this.Definition.Equals(ExportProvider.ExportProviderPartDefinition))
             {
-                yield return new ComposedPartDiagnostic(this, Strings.ExportOfExportProviderNotAllowed, this.Definition.Type.FullName);
+                yield return new ComposedPartDiagnostic(this, Strings.ExportOfExportProviderNotAllowed, this.Definition.TypeRef.FullName);
             }
 
             var importsWithGenericTypeParameters = this.Definition.Imports
@@ -145,7 +144,7 @@ namespace Microsoft.VisualStudio.Composition
                     }
                 }
 
-                if (pair.Key.ImportDefinition.Cardinality == ImportCardinality.ZeroOrMore && pair.Key.ImportingParameterRef != null && !IsAllowedImportManyParameterType(pair.Key.ImportingParameterRef.Resolve().ParameterType))
+                if (pair.Key.ImportDefinition.Cardinality == ImportCardinality.ZeroOrMore && pair.Key.ImportingParameterRef != null && !IsAllowedImportManyParameterType(pair.Key.ImportingSiteTypeRef))
                 {
                     yield return new ComposedPartDiagnostic(this, Strings.ImportingCtorHasUnsupportedParameterTypeForImportMany);
                 }
@@ -234,13 +233,13 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(import, nameof(import));
 
-            var memberName = import.ImportingParameter is object ? ("ctor(" + import.ImportingParameter.Name + ")") :
+            var memberName = import.ImportingParameterRef is object ? $"ctor(parameter #{import.ImportingParameterRef.ParameterIndex})" :
                              import.ImportingMemberRef is object ? import.ImportingMemberRef.Name :
                              "(unknown)";
             return string.Format(
                 CultureInfo.CurrentCulture,
                 "{0}.{1}",
-                import.ComposablePartType.FullName,
+                import.ComposablePartTypeRef.FullName,
                 memberName);
         }
 
@@ -253,13 +252,13 @@ namespace Microsoft.VisualStudio.Composition
                 return string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.TypeNameWithAssemblyLocation,
-                    export.PartDefinition.Type.FullName,
+                    export.PartDefinition.TypeRef.FullName,
                     export.ExportingMemberRef.Name,
-                    export.PartDefinition.Type.GetTypeInfo().Assembly.FullName);
+                    export.PartDefinition.TypeRef.AssemblyName.FullName);
             }
             else
             {
-                return export.PartDefinition.Type.FullName;
+                return export.PartDefinition.TypeRef.FullName;
             }
         }
 
@@ -272,7 +271,7 @@ namespace Microsoft.VisualStudio.Composition
                 : string.Empty;
         }
 
-        private static bool IsAllowedImportManyParameterType(Type importSiteType)
+        private static bool IsAllowedImportManyParameterType(TypeRef importSiteType)
         {
             Requires.NotNull(importSiteType, nameof(importSiteType));
             if (importSiteType.IsArray)
@@ -280,7 +279,7 @@ namespace Microsoft.VisualStudio.Composition
                 return true;
             }
 
-            if (importSiteType.GetTypeInfo().IsGenericType && importSiteType.GetTypeInfo().GetGenericTypeDefinition().IsEquivalentTo(typeof(IEnumerable<>)))
+            if (importSiteType.IsGenericType && importSiteType.FullName == typeof(IEnumerable<>).FullName)
             {
                 return true;
             }

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -420,7 +420,7 @@ namespace Microsoft.VisualStudio.Composition
                             string.Format(
                                 CultureInfo.CurrentCulture,
                                 Strings.UnableToDeterminePrimarySharingBoundary,
-                                ReflectionHelpers.GetTypeName(partBuilder.PartDefinition.Type, false, true, null, null)));
+                                partBuilder.PartDefinition.TypeRef.FullName));
                     }
                 }
             }

--- a/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatImportsExportedMember.cs
+++ b/test/Microsoft.VisualStudio.Composition.AppDomainTests/PartThatImportsExportedMember.cs
@@ -15,4 +15,20 @@ namespace Microsoft.VisualStudio.Composition.AppDomainTests
         [Import]
         public MemberTypeToExport ImportingProperty { get; set; } = null!;
     }
+
+    /// <summary>
+    /// A part with an importing constructor used to verify lazy assembly loading while reporting composition errors.
+    /// </summary>
+    [Export]
+    public class PartThatImportsExportedMemberThroughConstructor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartThatImportsExportedMemberThroughConstructor"/> class.
+        /// </summary>
+        /// <param name="import">The imported value.</param>
+        [ImportingConstructor]
+        public PartThatImportsExportedMemberThroughConstructor(MemberTypeToExport import)
+        {
+        }
+    }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/AssembliesLazyLoadedTests.cs
@@ -185,6 +185,31 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         /// <summary>
+        /// Verifies that reporting composition errors does not load the assemblies that define the affected parts.
+        /// </summary>
+        [SkippableFact]
+        public async Task ComposableAssembliesLazyLoadedWhenCompositionHasErrors()
+        {
+            SkipOnMono();
+            var catalog = TestUtilities.EmptyCatalog.AddParts(
+                await TestUtilities.V2Discovery.CreatePartsAsync(typeof(PartThatImportsExportedMemberThroughConstructor)));
+            var catalogCache = await this.SaveCatalogAsync(catalog);
+
+            // Use a sub-appdomain so we can monitor which assemblies get loaded by our composition engine.
+            var appDomain = AppDomain.CreateDomain("Composition Test sub-domain", null, AppDomain.CurrentDomain.SetupInformation);
+            try
+            {
+                var driver = (AppDomainTestDriver)appDomain.CreateInstanceAndUnwrap(typeof(AppDomainTestDriver).Assembly.FullName, typeof(AppDomainTestDriver).FullName);
+                driver.ComposeExpectingErrors(catalogCache);
+                driver.AssertAssembliesNotLoaded(typeof(PartThatImportsExportedMemberThroughConstructor).Assembly.Location);
+            }
+            finally
+            {
+                AppDomain.Unload(appDomain);
+            }
+        }
+
+        /// <summary>
         /// Verifies that the assemblies that MEF parts belong to are only loaded when
         /// their metadata is actually retrieved.
         /// </summary>
@@ -476,6 +501,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
                 var containerFactory = cacheManager.LoadExportProviderFactoryAsync(ms, TestUtilities.Resolver).GetAwaiter().GetResult();
                 this.container = containerFactory.CreateExportProvider();
+            }
+
+            internal void ComposeExpectingErrors(Stream cachedCatalog)
+            {
+                Requires.NotNull(cachedCatalog, nameof(cachedCatalog));
+
+                Stream cachedCatalogLocal = CopyStream(cachedCatalog);
+                var catalogManager = new CachedCatalog();
+                this.catalog = catalogManager.LoadAsync(cachedCatalogLocal, TestUtilities.Resolver).Result;
+
+                var configuration = CompositionConfiguration.Create(this.catalog);
+                AssertEx.False(configuration.CompositionErrors.IsEmpty);
             }
 
             internal void TestGetInputAssembliesDoesNotLoadLazyExport(string lazyLoadedAssemblyPath)


### PR DESCRIPTION
Cached catalogs remained lazy-loaded on successful composition, but reporting an invalid graph still resolved part and member types, loading assemblies that had not changed.

This change keeps composition validation and diagnostic formatting on cached `TypeRef`, `MemberRef`, and `ParameterRef` metadata. It also performs ImportMany parameter validation without reflection and adds an AppDomain regression covering an invalid cached catalog with an importing constructor.

Fixes #76