### PR TITLE
Support asynchronous MEF part disposal

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="18.7.23" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Only" Version="18.7.23" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.13.22" />
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.34" />
     <PackageVersion Include="Nerdbank.MSBuildExtension" Version="0.1.17-beta" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="18.7.23" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.13.22" />
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.34" />
     <PackageVersion Include="Nerdbank.MSBuildExtension" Version="0.1.17-beta" />

--- a/docfx/docs/hosting.md
+++ b/docfx/docs/hosting.md
@@ -72,6 +72,35 @@ var exportProvider = exportProviderFactory.CreateExportProvider();
 var program = exportProvider.GetExportedValue<Program>();
 ```
 
+## Disposing an ExportProvider
+
+Prefer asynchronous disposal when the host supports it:
+
+```csharp
+ExportProvider exportProvider = exportProviderFactory.CreateExportProvider();
+try
+{
+    // Acquire and use exports.
+}
+finally
+{
+    await exportProvider.DisposeAsync();
+}
+```
+
+Synchronous disposal also cleans up parts that implement only <xref:System.IAsyncDisposable>.
+Without additional configuration, <xref:Microsoft.VisualStudio.Composition.ExportProvider.Dispose> blocks until each asynchronous cleanup operation completes.
+Hosts that use `Microsoft.VisualStudio.Threading` should provide their <xref:Microsoft.VisualStudio.Threading.JoinableTaskFactory> when creating the export provider factory so synchronous disposal can block without deadlocking the main thread:
+
+```csharp
+IExportProviderFactory exportProviderFactory = config.CreateExportProviderFactory(joinableTaskFactory);
+using ExportProvider exportProvider = exportProviderFactory.CreateExportProvider();
+```
+
+The `JoinableTaskFactory` overload is also available from <xref:Microsoft.VisualStudio.Composition.RuntimeComposition.CreateExportProviderFactory*> and <xref:Microsoft.VisualStudio.Composition.CachedComposition.LoadExportProviderFactoryAsync*>.
+The configured factory applies to the root export provider, sharing boundaries, and parts created by `ExportFactory<T>`.
+See [Disposing MEF parts](parts.md#disposing-mef-parts) for the corresponding part-author guidance.
+
 ## Migrating from .NET MEF or NuGet MEF
 
 ### Where is <xref:System.ComponentModel.Composition.Hosting.DirectoryCatalog>?

--- a/docfx/docs/parts.md
+++ b/docfx/docs/parts.md
@@ -1,0 +1,17 @@
+# Authoring MEF parts
+
+## Disposing MEF parts
+
+.NET MEF and NuGet MEF recognize parts that implement <xref:System.IDisposable>.
+Support for <xref:System.IAsyncDisposable> parts is unique to VS MEF.
+Implement <xref:System.IAsyncDisposable> when cleanup requires asynchronous work instead of starting unobserved work from <xref:System.IDisposable.Dispose*>.
+
+VS MEF disposes an instantiated part when its owning lifetime ends.
+The owning lifetime is usually the <xref:Microsoft.VisualStudio.Composition.ExportProvider>, but a non-shared part created by an `ExportFactory<T>` is owned by the export lifetime returned from `CreateExport`.
+Dispose that export lifetime promptly when the part is no longer needed.
+
+When a lifetime is disposed asynchronously, VS MEF calls <xref:System.IAsyncDisposable.DisposeAsync*> and awaits it.
+If a part implements both <xref:System.IDisposable> and <xref:System.IAsyncDisposable>, asynchronous disposal calls only `DisposeAsync`.
+Synchronous lifetime disposal also cleans up parts that implement only <xref:System.IAsyncDisposable> by blocking until `DisposeAsync` completes.
+
+See [Disposing an ExportProvider](hosting.md#disposing-an-exportprovider) for host configuration and disposal guidance.

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -3,6 +3,7 @@ items:
 - href: dynamic_recomposition.md
 - href: hosting.md
 - href: metadata-views.md
+- href: parts.md
 - href: mef_library_differences.md
 - href: vsmefx.md
 - href: why.md

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -7,6 +7,7 @@ _layout: landing
 * [Why VS-MEF?](docs/why.md)
 * [Differences between .NET MEF, NuGet MEF and VS MEF](docs/mef_library_differences.md)
 * [Hosting](docs/hosting.md)
+* [Authoring MEF parts](docs/parts.md)
 * [Dynamic recomposition](docs/dynamic_recomposition.md)
 * [Diagnostic Analyzers](analyzers/index.md)
 * [vsmefx tool](docs/vsmefx.md)

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -13,6 +13,8 @@ namespace Microsoft.VisualStudio.Composition
     using System.Runtime.CompilerServices;
     using System.Xml.Linq;
     using Microsoft.VisualStudio.Composition.Reflection;
+    using Microsoft.VisualStudio.Threading;
+    using IAsyncDisposable = System.IAsyncDisposable;
 
     public class CompositionConfiguration
     {
@@ -245,7 +247,21 @@ namespace Microsoft.VisualStudio.Composition
         public IExportProviderFactory CreateExportProviderFactory()
         {
             var composition = RuntimeComposition.CreateRuntimeComposition(this);
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return composition.CreateExportProviderFactory();
+#pragma warning restore VSTHRD012
+        }
+
+        /// <summary>
+        /// Creates a factory that synchronously disposes asynchronous parts using the specified joinable task factory.
+        /// </summary>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
+        /// <returns>A factory that creates export providers for this composition.</returns>
+        public IExportProviderFactory CreateExportProviderFactory(JoinableTaskFactory joinableTaskFactory)
+        {
+            Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
+            var composition = RuntimeComposition.CreateRuntimeComposition(this);
+            return composition.CreateExportProviderFactory(joinableTaskFactory);
         }
 
         public string? GetEffectiveSharingBoundary(ComposablePartDefinition partDefinition)

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -16,6 +16,8 @@ namespace Microsoft.VisualStudio.Composition
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
+    using Microsoft.VisualStudio.Threading;
+    using IAsyncDisposable = System.IAsyncDisposable;
 
     public class CachedComposition : ICompositionCacheManager, IRuntimeCompositionCacheManager
     {
@@ -72,7 +74,24 @@ namespace Microsoft.VisualStudio.Composition
         public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, CancellationToken cancellationToken = default(CancellationToken))
         {
             var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return runtimeComposition.CreateExportProviderFactory();
+#pragma warning restore VSTHRD012
+        }
+
+        /// <summary>
+        /// Loads an export provider factory that synchronously disposes asynchronous parts using the specified joinable task factory.
+        /// </summary>
+        /// <param name="cacheStream">The stream to read the cached composition from.</param>
+        /// <param name="resolver">The resolver to use when loading the composition.</param>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>A task whose result is the loaded export provider factory.</returns>
+        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, JoinableTaskFactory joinableTaskFactory, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
+            var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
+            return runtimeComposition.CreateExportProviderFactory(joinableTaskFactory);
         }
 
         private class SerializationContext : SerializationContextBase

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A task whose result is the loaded export provider factory.</returns>
-        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, JoinableTaskFactory joinableTaskFactory, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, JoinableTaskFactory joinableTaskFactory, CancellationToken cancellationToken)
         {
             Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
             var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Composition
         /// </summary>
         /// <param name="inner">The instance to forward queries to.</param>
         protected DelegatingExportProvider(ExportProvider inner)
-            : base(inner.Resolver)
+            : base(inner.Resolver, joinableTaskFactory: null)
         {
             Requires.NotNull(inner, nameof(inner));
             this.inner = inner;

--- a/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.Composition
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using Microsoft.VisualStudio.Composition.Reflection;
 
     /// <summary>
@@ -23,7 +24,9 @@ namespace Microsoft.VisualStudio.Composition
         /// </summary>
         /// <param name="inner">The instance to forward queries to.</param>
         protected DelegatingExportProvider(ExportProvider inner)
-            : base(Requires.NotNull(inner, nameof(inner)).Resolver, joinableTaskFactory: null)
+#pragma warning disable VSTHRD012 // The parent constructor propagates its joinable task factory.
+            : base(Requires.NotNull(inner, nameof(inner)), ImmutableHashSet<string>.Empty)
+#pragma warning restore VSTHRD012
         {
             this.inner = inner;
         }

--- a/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/DelegatingExportProvider.cs
@@ -23,9 +23,8 @@ namespace Microsoft.VisualStudio.Composition
         /// </summary>
         /// <param name="inner">The instance to forward queries to.</param>
         protected DelegatingExportProvider(ExportProvider inner)
-            : base(inner.Resolver, joinableTaskFactory: null)
+            : base(Requires.NotNull(inner, nameof(inner)).Resolver, joinableTaskFactory: null)
         {
-            Requires.NotNull(inner, nameof(inner));
             this.inner = inner;
         }
 

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -513,7 +513,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>A task that completes when disposal finishes.</returns>
         protected virtual async ValueTask DisposeAsyncCore()
         {
-            List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
+            IReadOnlyList<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
             await DisposeSnapshotAsync(disposableSnapshot, this.disposalStartedSynchronously).ConfigureAwait(false);
         }
 
@@ -621,7 +621,7 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot, bool disposeSynchronously)
+        private static async ValueTask DisposeSnapshotAsync(IReadOnlyList<IDisposable> disposableSnapshot, bool disposeSynchronously)
         {
             List<Exception>? exceptions = null;
             foreach (IDisposable item in disposableSnapshot)
@@ -650,7 +650,7 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private List<IDisposable> TakeDisposableSnapshot()
+        private IReadOnlyList<IDisposable> TakeDisposableSnapshot()
         {
             this.isDisposed = true;
 

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -995,20 +995,47 @@ namespace Microsoft.VisualStudio.Composition
         {
             Requires.NotNull(instantiatedPart, nameof(instantiatedPart));
 
-            if (sharingBoundary is null)
+            bool disposeImmediately;
+            lock (this.disposalSyncObject)
             {
-                lock (this.disposableNonSharedParts)
+                disposeImmediately = this.isDisposed;
+                if (!disposeImmediately)
                 {
-                    this.disposableNonSharedParts.Add(instantiatedPart);
+                    if (sharingBoundary is null)
+                    {
+                        lock (this.disposableNonSharedParts)
+                        {
+                            this.disposableNonSharedParts.Add(instantiatedPart);
+                        }
+                    }
+                    else
+                    {
+                        var disposablePartsHashSet = this.disposableInstantiatedSharedParts[sharingBoundary];
+                        lock (disposablePartsHashSet)
+                        {
+                            disposablePartsHashSet.Add(instantiatedPart);
+                        }
+                    }
                 }
+            }
+
+            if (disposeImmediately)
+            {
+                this.DisposeLateTrackedValue(instantiatedPart);
+            }
+        }
+
+        private void DisposeLateTrackedValue(IDisposable disposable)
+        {
+            if (!this.disposalStartedSynchronously && disposable is IAsyncDisposable asyncDisposable)
+            {
+#pragma warning disable VSTHRD002 // Disposal must finish before the concurrent activation can expose the part.
+                asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
             }
             else
             {
-                var disposablePartsHashSet = this.disposableInstantiatedSharedParts[sharingBoundary];
-                lock (disposablePartsHashSet)
-                {
-                    disposablePartsHashSet.Add(instantiatedPart);
-                }
+                disposable.Dispose();
             }
         }
 
@@ -1701,16 +1728,34 @@ namespace Microsoft.VisualStudio.Composition
                 }
                 else
                 {
-                    this.OwningExportProvider.TrackDisposableValue(this, this.sharingBoundary);
-
+                    bool disposeDescendant;
                     lock (this.syncObject)
                     {
-                        if (this.nonSharedChildParts is null)
-                        {
-                            this.nonSharedChildParts = new HashSet<PartLifecycleTracker>();
-                        }
+                        disposeDescendant = this.isDisposed;
+                    }
 
-                        this.nonSharedChildParts.Add(nonSharedDescendant);
+                    if (!disposeDescendant)
+                    {
+                        this.OwningExportProvider.TrackDisposableValue(this, this.sharingBoundary);
+
+                        lock (this.syncObject)
+                        {
+                            disposeDescendant = this.isDisposed;
+                            if (!disposeDescendant)
+                            {
+                                if (this.nonSharedChildParts is null)
+                                {
+                                    this.nonSharedChildParts = new HashSet<PartLifecycleTracker>();
+                                }
+
+                                this.nonSharedChildParts.Add(nonSharedDescendant);
+                            }
+                        }
+                    }
+
+                    if (disposeDescendant)
+                    {
+                        this.OwningExportProvider.DisposeLateTrackedValue(nonSharedDescendant);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -1379,35 +1379,52 @@ namespace Microsoft.VisualStudio.Composition
             public void Dispose()
             {
                 (object? value, HashSet<PartLifecycleTracker>? nonSharedChildParts) = this.TakeDisposableValues();
-                if (value is IAsyncDisposable asyncDisposable)
+                List<Exception>? exceptions = null;
+                try
                 {
-                    if (this.OwningExportProvider.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
+                    if (value is IAsyncDisposable asyncDisposable)
                     {
-                        joinableTaskFactory.Run(async () => await asyncDisposable.DisposeAsync().ConfigureAwait(false));
-                    }
-                    else if (value is IDisposable disposable)
-                    {
-                        disposable.Dispose();
+                        if (this.OwningExportProvider.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
+                        {
+                            joinableTaskFactory.Run(async () => await asyncDisposable.DisposeAsync().ConfigureAwait(false));
+                        }
+                        else if (value is IDisposable disposable)
+                        {
+                            disposable.Dispose();
+                        }
+                        else
+                        {
+#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async-only parts are disposed.
+                            asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+                        }
                     }
                     else
                     {
-#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async-only parts are disposed.
-                        asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
+                        (value as IDisposable)?.Dispose();
                     }
                 }
-                else
+                catch (Exception ex)
                 {
-                    (value as IDisposable)?.Dispose();
+                    (exceptions ??= new List<Exception>()).Add(ex);
                 }
 
                 if (nonSharedChildParts is object)
                 {
                     foreach (PartLifecycleTracker descendant in nonSharedChildParts)
                     {
-                        descendant.Dispose();
+                        try
+                        {
+                            descendant.Dispose();
+                        }
+                        catch (Exception ex)
+                        {
+                            (exceptions ??= new List<Exception>()).Add(ex);
+                        }
                     }
                 }
+
+                ThrowDisposalExceptions(exceptions);
             }
 
             /// <summary>
@@ -1417,21 +1434,50 @@ namespace Microsoft.VisualStudio.Composition
             public async ValueTask DisposeAsync()
             {
                 (object? value, HashSet<PartLifecycleTracker>? nonSharedChildParts) = this.TakeDisposableValues();
-                if (value is IAsyncDisposable asyncDisposable)
+                List<Exception>? exceptions = null;
+                try
                 {
-                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    if (value is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        (value as IDisposable)?.Dispose();
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    (value as IDisposable)?.Dispose();
+                    (exceptions ??= new List<Exception>()).Add(ex);
                 }
 
                 if (nonSharedChildParts is object)
                 {
                     foreach (PartLifecycleTracker descendant in nonSharedChildParts)
                     {
-                        await descendant.DisposeAsync().ConfigureAwait(false);
+                        try
+                        {
+                            await descendant.DisposeAsync().ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            (exceptions ??= new List<Exception>()).Add(ex);
+                        }
                     }
+                }
+
+                ThrowDisposalExceptions(exceptions);
+            }
+
+            private static void ThrowDisposalExceptions(List<Exception>? exceptions)
+            {
+                if (exceptions?.Count == 1)
+                {
+                    ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+                }
+                else if (exceptions is object)
+                {
+                    throw new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -1027,11 +1027,11 @@ namespace Microsoft.VisualStudio.Composition
 
         private void DisposeLateTrackedValue(IDisposable disposable)
         {
-            if (!this.disposalStartedSynchronously && disposable is IAsyncDisposable asyncDisposable)
+            bool disposeSynchronously = this.disposalStartedSynchronously && this.joinableTaskFactory is null;
+            if (!disposeSynchronously && disposable is IAsyncDisposable asyncDisposable)
             {
-#pragma warning disable VSTHRD002 // Disposal must finish before the concurrent activation can expose the part.
-                asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
+                // Disposal must finish before the concurrent activation can expose the part.
+                this.WaitForDisposal(asyncDisposable.DisposeAsync().AsTask());
             }
             else
             {

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -66,6 +66,8 @@ namespace Microsoft.VisualStudio.Composition
 
         private readonly object disposalSyncObject = new object();
 
+        private readonly System.Threading.AsyncLocal<bool> invokingDisposeCallback = new System.Threading.AsyncLocal<bool>();
+
         private readonly JoinableTaskFactory? joinableTaskFactory;
 
         /// <summary>
@@ -481,7 +483,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public void Dispose()
         {
-            this.Dispose(true);
+            this.WaitForDisposal(this.GetOrStartDisposalTaskAsync());
             GC.SuppressFinalize(this);
         }
 
@@ -497,25 +499,17 @@ namespace Microsoft.VisualStudio.Composition
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && !this.invokingDisposeCallback.Value)
             {
-                Task disposalTask = this.GetOrStartDisposalTaskAsync();
-                if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
-                {
-#pragma warning disable VSTHRD003 // The JTF is intentionally joining the shared disposal operation initiated by any caller.
-                    joinableTaskFactory.Run(async () => await disposalTask.ConfigureAwait(false));
-#pragma warning restore VSTHRD003
-                }
-                else
-                {
-#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async parts are disposed.
-                    disposalTask.GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
-                }
+                this.WaitForDisposal(this.GetOrStartDisposalTaskAsync());
             }
         }
 
-        private protected virtual async ValueTask DisposeAsyncCore()
+        /// <summary>
+        /// Asynchronously disposes resources owned by this export provider.
+        /// </summary>
+        /// <returns>A task that completes when disposal finishes.</returns>
+        protected virtual async ValueTask DisposeAsyncCore()
         {
             List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
             await DisposeSnapshotAsync(disposableSnapshot).ConfigureAwait(false);
@@ -525,6 +519,16 @@ namespace Microsoft.VisualStudio.Composition
         {
             try
             {
+                this.invokingDisposeCallback.Value = true;
+                try
+                {
+                    this.Dispose(true);
+                }
+                finally
+                {
+                    this.invokingDisposeCallback.Value = false;
+                }
+
                 await this.DisposeAsyncCore().ConfigureAwait(false);
                 completionSource.SetResult(null);
             }
@@ -544,6 +548,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                     this.disposalTask = completionSource.Task;
+                    this.isDisposed = true;
                 }
 
                 result = this.disposalTask;
@@ -555,6 +560,22 @@ namespace Microsoft.VisualStudio.Composition
             }
 
             return result;
+        }
+
+        private void WaitForDisposal(Task disposalTask)
+        {
+            if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
+            {
+#pragma warning disable VSTHRD003 // The JTF is intentionally joining the shared disposal operation initiated by any caller.
+                joinableTaskFactory.Run(async () => await disposalTask.ConfigureAwait(false));
+#pragma warning restore VSTHRD003
+            }
+            else
+            {
+#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async parts are disposed.
+                disposalTask.GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+            }
         }
 
         private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot)
@@ -1894,7 +1915,7 @@ namespace Microsoft.VisualStudio.Composition
                 throw new InvalidOperationException(Strings.CannotDirectlyDisposeAnImport);
             }
 
-            private protected override ValueTask DisposeAsyncCore()
+            protected override ValueTask DisposeAsyncCore()
             {
                 throw new InvalidOperationException(Strings.CannotDirectlyDisposeAnImport);
             }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -109,6 +109,8 @@ namespace Microsoft.VisualStudio.Composition
 
         private Task? disposalTask;
 
+        private bool disposalStartedSynchronously;
+
         private bool isDisposed;
 
         private ExportProvider(
@@ -483,7 +485,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public void Dispose()
         {
-            this.WaitForDisposal(this.GetOrStartDisposalTaskAsync());
+            this.WaitForDisposal(this.GetOrStartDisposalTaskAsync(disposeSynchronously: true));
             GC.SuppressFinalize(this);
         }
 
@@ -493,7 +495,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>A task that completes when all disposable parts have been disposed.</returns>
         public async ValueTask DisposeAsync()
         {
-            await this.GetOrStartDisposalTaskAsync().ConfigureAwait(false);
+            await this.GetOrStartDisposalTaskAsync(disposeSynchronously: false).ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }
 
@@ -501,7 +503,7 @@ namespace Microsoft.VisualStudio.Composition
         {
             if (disposing && !this.invokingDisposeCallback.Value)
             {
-                this.WaitForDisposal(this.GetOrStartDisposalTaskAsync());
+                this.WaitForDisposal(this.GetOrStartDisposalTaskAsync(disposeSynchronously: true));
             }
         }
 
@@ -512,7 +514,7 @@ namespace Microsoft.VisualStudio.Composition
         protected virtual async ValueTask DisposeAsyncCore()
         {
             List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
-            await DisposeSnapshotAsync(disposableSnapshot).ConfigureAwait(false);
+            await DisposeSnapshotAsync(disposableSnapshot, this.disposalStartedSynchronously).ConfigureAwait(false);
         }
 
         private async Task CompleteDisposalAsync(TaskCompletionSource<object?> completionSource)
@@ -538,7 +540,7 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private Task GetOrStartDisposalTaskAsync()
+        private Task GetOrStartDisposalTaskAsync(bool disposeSynchronously)
         {
             TaskCompletionSource<object?>? completionSource = null;
             Task result;
@@ -548,6 +550,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                     this.disposalTask = completionSource.Task;
+                    this.disposalStartedSynchronously = disposeSynchronously;
                     this.isDisposed = true;
                 }
 
@@ -578,14 +581,14 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot)
+        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot, bool disposeSynchronously)
         {
             List<Exception>? exceptions = null;
             foreach (IDisposable item in disposableSnapshot)
             {
                 try
                 {
-                    if (item is IAsyncDisposable asyncDisposable)
+                    if (!disposeSynchronously && item is IAsyncDisposable asyncDisposable)
                     {
                         await asyncDisposable.DisposeAsync().ConfigureAwait(false);
                     }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -519,6 +519,7 @@ namespace Microsoft.VisualStudio.Composition
 
         private async Task CompleteDisposalAsync(TaskCompletionSource<object?> completionSource)
         {
+            Exception? disposeException = null;
             try
             {
                 this.invokingDisposeCallback.Value = true;
@@ -530,13 +531,52 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     this.invokingDisposeCallback.Value = false;
                 }
-
-                await this.DisposeAsyncCore().ConfigureAwait(false);
-                completionSource.SetResult(null);
             }
             catch (Exception ex)
             {
-                completionSource.SetException(ex);
+                disposeException = ex;
+            }
+
+            Exception? asyncDisposeException = null;
+            try
+            {
+                await this.DisposeAsyncCore().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                asyncDisposeException = ex;
+            }
+
+            if (disposeException is null && asyncDisposeException is null)
+            {
+                completionSource.SetResult(null);
+            }
+            else if (disposeException is null)
+            {
+                completionSource.SetException(asyncDisposeException!);
+            }
+            else if (asyncDisposeException is null)
+            {
+                completionSource.SetException(disposeException);
+            }
+            else
+            {
+                var exceptions = new List<Exception>();
+                AddFlattenedException(exceptions, disposeException);
+                AddFlattenedException(exceptions, asyncDisposeException);
+                completionSource.SetException(new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions));
+            }
+        }
+
+        private static void AddFlattenedException(List<Exception> exceptions, Exception exception)
+        {
+            if (exception is AggregateException aggregateException)
+            {
+                exceptions.AddRange(aggregateException.Flatten().InnerExceptions);
+            }
+            else
+            {
+                exceptions.Add(exception);
             }
         }
 
@@ -1966,7 +2006,7 @@ namespace Microsoft.VisualStudio.Composition
 
             protected override ValueTask DisposeAsyncCore()
             {
-                throw new InvalidOperationException(Strings.CannotDirectlyDisposeAnImport);
+                return default;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -64,6 +64,8 @@ namespace Microsoft.VisualStudio.Composition
         /// </remarks>
         private readonly Lazy<ImmutableArray<Lazy<IMetadataViewProvider, IReadOnlyDictionary<string, object?>>>> metadataViewProviders;
 
+        private readonly object disposalSyncObject = new object();
+
         private readonly JoinableTaskFactory? joinableTaskFactory;
 
         /// <summary>
@@ -102,6 +104,8 @@ namespace Microsoft.VisualStudio.Composition
         /// All access to this dictionary is guarded by a lock on this field.
         /// </remarks>
         private Dictionary<Type, IMetadataViewProvider> typeAndSelectedMetadataViewProviderCache = new Dictionary<Type, IMetadataViewProvider>();
+
+        private Task? disposalTask;
 
         private bool isDisposed;
 
@@ -487,7 +491,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>A task that completes when all disposable parts have been disposed.</returns>
         public async ValueTask DisposeAsync()
         {
-            await this.DisposeAsyncCore().ConfigureAwait(false);
+            await this.GetOrStartDisposalTaskAsync().ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }
 
@@ -495,36 +499,18 @@ namespace Microsoft.VisualStudio.Composition
         {
             if (disposing)
             {
-                List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
+                Task disposalTask = this.GetOrStartDisposalTaskAsync();
                 if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
                 {
-                    joinableTaskFactory.Run(async () => await DisposeSnapshotAsync(disposableSnapshot).ConfigureAwait(false));
-                    return;
+#pragma warning disable VSTHRD003 // The JTF is intentionally joining the shared disposal operation initiated by any caller.
+                    joinableTaskFactory.Run(async () => await disposalTask.ConfigureAwait(false));
+#pragma warning restore VSTHRD003
                 }
-
-                // Take care to give all disposal parts a chance to dispose
-                // even if some parts throw exceptions.
-                List<Exception>? exceptions = null;
-                foreach (var item in disposableSnapshot)
+                else
                 {
-                    try
-                    {
-                        item.Dispose();
-                    }
-                    catch (Exception ex)
-                    {
-                        if (exceptions == null)
-                        {
-                            exceptions = new List<Exception>();
-                        }
-
-                        exceptions.Add(ex);
-                    }
-                }
-
-                if (exceptions != null)
-                {
-                    throw new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions);
+#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async parts are disposed.
+                    disposalTask.GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
                 }
             }
         }
@@ -533,6 +519,42 @@ namespace Microsoft.VisualStudio.Composition
         {
             List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
             await DisposeSnapshotAsync(disposableSnapshot).ConfigureAwait(false);
+        }
+
+        private async Task CompleteDisposalAsync(TaskCompletionSource<object?> completionSource)
+        {
+            try
+            {
+                await this.DisposeAsyncCore().ConfigureAwait(false);
+                completionSource.SetResult(null);
+            }
+            catch (Exception ex)
+            {
+                completionSource.SetException(ex);
+            }
+        }
+
+        private Task GetOrStartDisposalTaskAsync()
+        {
+            TaskCompletionSource<object?>? completionSource = null;
+            Task result;
+            lock (this.disposalSyncObject)
+            {
+                if (this.disposalTask is null)
+                {
+                    completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    this.disposalTask = completionSource.Task;
+                }
+
+                result = this.disposalTask;
+            }
+
+            if (completionSource is object)
+            {
+                this.CompleteDisposalAsync(completionSource).Forget();
+            }
+
+            return result;
         }
 
         private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot)
@@ -1349,7 +1371,7 @@ namespace Microsoft.VisualStudio.Composition
                     else
                     {
 #pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async-only parts are disposed.
-                        asyncDisposable.DisposeAsync().AsTask().Wait();
+                        asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
                     }
                 }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -14,10 +14,13 @@ namespace Microsoft.VisualStudio.Composition
     using System.Reflection;
     using System.Runtime.ExceptionServices;
     using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
+    using Microsoft.VisualStudio.Threading;
     using DefaultMetadataType = System.Collections.Generic.IDictionary<string, object?>;
+    using IAsyncDisposable = System.IAsyncDisposable;
 
-    public abstract partial class ExportProvider : IDisposableObservable
+    public abstract partial class ExportProvider : IDisposableObservable, IAsyncDisposable
     {
         internal static readonly ExportDefinition ExportProviderExportDefinition = new ExportDefinition(
             ContractNameServices.GetTypeIdentity(typeof(ExportProvider)),
@@ -60,6 +63,8 @@ namespace Microsoft.VisualStudio.Composition
         /// This field is lazy to avoid a chicken-and-egg problem with initializing it in our constructor.
         /// </remarks>
         private readonly Lazy<ImmutableArray<Lazy<IMetadataViewProvider, IReadOnlyDictionary<string, object?>>>> metadataViewProviders;
+
+        private readonly JoinableTaskFactory? joinableTaskFactory;
 
         /// <summary>
         /// A map of shared boundary names to their shared instances.
@@ -106,7 +111,8 @@ namespace Microsoft.VisualStudio.Composition
             ImmutableDictionary<string, HashSet<IDisposable>> disposableInstantiatedSharedParts,
             ImmutableHashSet<string> freshSharingBoundaries,
             ImmutableDictionary<string, ExportProvider> sharingBoundaryExportProviderOwners,
-            Lazy<ImmutableArray<Lazy<IMetadataViewProvider, IReadOnlyDictionary<string, object?>>>>? inheritedMetadataViewProviders)
+            Lazy<ImmutableArray<Lazy<IMetadataViewProvider, IReadOnlyDictionary<string, object?>>>>? inheritedMetadataViewProviders,
+            JoinableTaskFactory? joinableTaskFactory)
         {
             Requires.NotNull(resolver, nameof(resolver));
             Requires.NotNull(sharedInstantiatedParts, nameof(sharedInstantiatedParts));
@@ -119,6 +125,7 @@ namespace Microsoft.VisualStudio.Composition
             this.disposableInstantiatedSharedParts = disposableInstantiatedSharedParts;
             this.freshSharingBoundaries = freshSharingBoundaries;
             this.sharingBoundaryExportProviderOwners = sharingBoundaryExportProviderOwners;
+            this.joinableTaskFactory = joinableTaskFactory;
 
             foreach (string freshSharingBoundary in freshSharingBoundaries)
             {
@@ -139,13 +146,24 @@ namespace Microsoft.VisualStudio.Composition
         }
 
         private protected ExportProvider(Resolver resolver)
+            : this(resolver, joinableTaskFactory: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportProvider"/> class.
+        /// </summary>
+        /// <param name="resolver">The resolver to use.</param>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing asynchronous parts.</param>
+        private protected ExportProvider(Resolver resolver, JoinableTaskFactory? joinableTaskFactory)
             : this(
                 resolver,
                 SharedInstantiatedPartsTemplate,
                 DisposableInstantiatedSharedPartsTemplate,
                 ImmutableHashSet.Create<string>().Add(string.Empty),
                 ImmutableDictionary.Create<string, ExportProvider>(),
-                null)
+                null,
+                joinableTaskFactory)
         {
         }
 
@@ -156,7 +174,8 @@ namespace Microsoft.VisualStudio.Composition
                   parent.disposableInstantiatedSharedParts,
                   freshSharingBoundaries,
                   parent.sharingBoundaryExportProviderOwners,
-                  parent.metadataViewProviders)
+                  parent.metadataViewProviders,
+                  parent.joinableTaskFactory)
         {
             this.Resolver = parent.Resolver;
         }
@@ -462,30 +481,25 @@ namespace Microsoft.VisualStudio.Composition
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Asynchronously disposes composed parts owned by this export provider.
+        /// </summary>
+        /// <returns>A task that completes when all disposable parts have been disposed.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            await this.DisposeAsyncCore().ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
-                this.isDisposed = true;
-
-                // Snapshot the contents of the collection within the lock,
-                // then dispose of the values outside the lock to avoid
-                // executing arbitrary 3rd-party code within our lock.
-                List<IDisposable> disposableSnapshot;
-                lock (this.disposableNonSharedParts)
+                List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
+                if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
                 {
-                    disposableSnapshot = new List<IDisposable>(this.disposableNonSharedParts);
-                    this.disposableNonSharedParts.Clear();
-                }
-
-                foreach (var sharingBoundary in this.freshSharingBoundaries)
-                {
-                    var disposablePartsHashSet = this.disposableInstantiatedSharedParts[sharingBoundary];
-                    lock (disposablePartsHashSet)
-                    {
-                        disposableSnapshot.AddRange(disposablePartsHashSet);
-                        disposablePartsHashSet.Clear();
-                    }
+                    joinableTaskFactory.Run(async () => await DisposeSnapshotAsync(disposableSnapshot).ConfigureAwait(false));
+                    return;
                 }
 
                 // Take care to give all disposal parts a chance to dispose
@@ -513,6 +527,68 @@ namespace Microsoft.VisualStudio.Composition
                     throw new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions);
                 }
             }
+        }
+
+        private protected virtual async ValueTask DisposeAsyncCore()
+        {
+            List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
+            await DisposeSnapshotAsync(disposableSnapshot).ConfigureAwait(false);
+        }
+
+        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot)
+        {
+            List<Exception>? exceptions = null;
+            foreach (IDisposable item in disposableSnapshot)
+            {
+                try
+                {
+                    if (item is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        item.Dispose();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions != null)
+            {
+                throw new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions);
+            }
+        }
+
+        private List<IDisposable> TakeDisposableSnapshot()
+        {
+            this.isDisposed = true;
+
+            // Snapshot the contents of the collection within the lock,
+            // then dispose of the values outside the lock to avoid
+            // executing arbitrary 3rd-party code within our lock.
+            List<IDisposable> disposableSnapshot;
+            lock (this.disposableNonSharedParts)
+            {
+                disposableSnapshot = new List<IDisposable>(this.disposableNonSharedParts);
+                this.disposableNonSharedParts.Clear();
+            }
+
+            foreach (string sharingBoundary in this.freshSharingBoundaries)
+            {
+                HashSet<IDisposable> disposablePartsHashSet = this.disposableInstantiatedSharedParts[sharingBoundary];
+                lock (disposablePartsHashSet)
+                {
+                    disposableSnapshot.AddRange(disposablePartsHashSet);
+                    disposablePartsHashSet.Clear();
+                }
+            }
+
+            return disposableSnapshot;
         }
 
         protected static object CannotInstantiatePartWithNoImportingConstructor()
@@ -1089,7 +1165,7 @@ namespace Microsoft.VisualStudio.Composition
         /// Every single instantiated MEF part (including each individual NonShared instance)
         /// has an associated instance of this class to track its lifecycle from initialization to disposal.
         /// </summary>
-        internal abstract class PartLifecycleTracker : IDisposable
+        internal abstract class PartLifecycleTracker : IDisposable, IAsyncDisposable
         {
             /// <summary>
             /// An object that locks when the state machine is transitioning between states.
@@ -1259,25 +1335,27 @@ namespace Microsoft.VisualStudio.Composition
             /// </summary>
             public void Dispose()
             {
-                this.isDisposed = true;
-
-                if (this.IsNonShared && this.nonSharedPartOwner is null)
+                (object? value, HashSet<PartLifecycleTracker>? nonSharedChildParts) = this.TakeDisposableValues();
+                if (value is IAsyncDisposable asyncDisposable)
                 {
-                    this.OwningExportProvider.ReleaseNonSharedPart(this);
+                    if (this.OwningExportProvider.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
+                    {
+                        joinableTaskFactory.Run(async () => await asyncDisposable.DisposeAsync().ConfigureAwait(false));
+                    }
+                    else if (value is IDisposable disposable)
+                    {
+                        disposable.Dispose();
+                    }
+                    else
+                    {
+#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async-only parts are disposed.
+                        asyncDisposable.DisposeAsync().AsTask().Wait();
+#pragma warning restore VSTHRD002
+                    }
                 }
-
-                IDisposable? disposableValue = this.value as IDisposable;
-                this.value = null;
-                if (disposableValue is object)
+                else
                 {
-                    disposableValue.Dispose();
-                }
-
-                HashSet<PartLifecycleTracker>? nonSharedChildParts;
-                lock (this.syncObject)
-                {
-                    nonSharedChildParts = this.nonSharedChildParts;
-                    this.nonSharedChildParts = null;
+                    (value as IDisposable)?.Dispose();
                 }
 
                 if (nonSharedChildParts is object)
@@ -1287,6 +1365,57 @@ namespace Microsoft.VisualStudio.Composition
                         descendant.Dispose();
                     }
                 }
+            }
+
+            /// <summary>
+            /// Asynchronously disposes of the MEF part if it is disposable.
+            /// </summary>
+            /// <returns>A task that completes when this part and its non-shared descendants have been disposed.</returns>
+            public async ValueTask DisposeAsync()
+            {
+                (object? value, HashSet<PartLifecycleTracker>? nonSharedChildParts) = this.TakeDisposableValues();
+                if (value is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    (value as IDisposable)?.Dispose();
+                }
+
+                if (nonSharedChildParts is object)
+                {
+                    foreach (PartLifecycleTracker descendant in nonSharedChildParts)
+                    {
+                        await descendant.DisposeAsync().ConfigureAwait(false);
+                    }
+                }
+            }
+
+            private (object? Value, HashSet<PartLifecycleTracker>? NonSharedChildParts) TakeDisposableValues()
+            {
+                object? value;
+                HashSet<PartLifecycleTracker>? nonSharedChildParts;
+                lock (this.syncObject)
+                {
+                    if (this.isDisposed)
+                    {
+                        return (null, null);
+                    }
+
+                    this.isDisposed = true;
+                    value = this.value;
+                    this.value = null;
+                    nonSharedChildParts = this.nonSharedChildParts;
+                    this.nonSharedChildParts = null;
+                }
+
+                if (this.IsNonShared && this.nonSharedPartOwner is null)
+                {
+                    this.OwningExportProvider.ReleaseNonSharedPart(this);
+                }
+
+                return (value, nonSharedChildParts);
             }
 
             /// <summary>
@@ -1392,7 +1521,7 @@ namespace Microsoft.VisualStudio.Composition
                             Assumes.True(this.State == PartLifecycleState.Creating);
                             this.Value = value;
 
-                            if (value is IDisposable)
+                            if (value is IDisposable || value is IAsyncDisposable)
                             {
                                 if (this.sharingBoundary is object || this.nonSharedPartOwner is null)
                                 {
@@ -1739,6 +1868,11 @@ namespace Microsoft.VisualStudio.Composition
 #pragma warning disable CA2215 // Dispose methods should call base class dispose
             protected override void Dispose(bool disposing)
 #pragma warning restore CA2215 // Dispose methods should call base class dispose
+            {
+                throw new InvalidOperationException(Strings.CannotDirectlyDisposeAnImport);
+            }
+
+            private protected override ValueTask DisposeAsyncCore()
             {
                 throw new InvalidOperationException(Strings.CannotDirectlyDisposeAnImport);
             }

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -513,7 +513,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>A task that completes when disposal finishes.</returns>
         protected virtual async ValueTask DisposeAsyncCore()
         {
-            IReadOnlyList<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
+            List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
             await DisposeSnapshotAsync(disposableSnapshot, this.disposalStartedSynchronously).ConfigureAwait(false);
         }
 
@@ -621,7 +621,7 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private static async ValueTask DisposeSnapshotAsync(IReadOnlyList<IDisposable> disposableSnapshot, bool disposeSynchronously)
+        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot, bool disposeSynchronously)
         {
             List<Exception>? exceptions = null;
             foreach (IDisposable item in disposableSnapshot)
@@ -650,7 +650,7 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private IReadOnlyList<IDisposable> TakeDisposableSnapshot()
+        private List<IDisposable> TakeDisposableSnapshot()
         {
             this.isDisposed = true;
 

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -524,7 +524,10 @@ namespace Microsoft.VisualStudio.Composition
         protected virtual async ValueTask DisposeAsyncCore()
         {
             List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
-            await DisposeSnapshotAsync(disposableSnapshot, this.disposalStartedSynchronously).ConfigureAwait(false);
+
+            // When a JTF is available, WaitForDisposal joins this whole asynchronous operation once.
+            bool disposeSynchronously = this.disposalStartedSynchronously && this.joinableTaskFactory is null;
+            await DisposeSnapshotAsync(disposableSnapshot, disposeSynchronously).ConfigureAwait(false);
         }
 
         private async Task CompleteDisposalAsync(TaskCompletionSource<object?> completionSource)

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Nerdbank.MessagePack" PrivateAssets="compile" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="System.ComponentModel.Composition" />
     <PackageReference Include="System.Composition" />

--- a/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
+++ b/src/Microsoft.VisualStudio.Composition/Microsoft.VisualStudio.Composition.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Nerdbank.MessagePack" PrivateAssets="compile" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Only" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="System.ComponentModel.Composition" />
     <PackageReference Include="System.Composition" />

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -14,6 +14,8 @@ namespace Microsoft.VisualStudio.Composition
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
+    using Microsoft.VisualStudio.Threading;
+    using IAsyncDisposable = System.IAsyncDisposable;
 
     public class RuntimeComposition : IEquatable<RuntimeComposition>
     {
@@ -115,7 +117,20 @@ namespace Microsoft.VisualStudio.Composition
 
         public IExportProviderFactory CreateExportProviderFactory()
         {
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return new RuntimeExportProviderFactory(this);
+#pragma warning restore VSTHRD012
+        }
+
+        /// <summary>
+        /// Creates a factory that synchronously disposes asynchronous parts using the specified joinable task factory.
+        /// </summary>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
+        /// <returns>A factory that creates export providers for this runtime composition.</returns>
+        public IExportProviderFactory CreateExportProviderFactory(JoinableTaskFactory joinableTaskFactory)
+        {
+            Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
+            return new RuntimeExportProviderFactory(this, joinableTaskFactory);
         }
 
         public IReadOnlyCollection<RuntimeExport> GetExports(string contractName)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Linq;
     using System.Reflection;
     using Microsoft.VisualStudio.Composition.Reflection;
+    using Microsoft.VisualStudio.Threading;
 
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
     {
@@ -35,20 +36,22 @@ namespace Microsoft.VisualStudio.Composition
             private readonly RuntimeComposition composition;
             private readonly ReportFaultCallback? faultCallback;
 
-            internal RuntimeExportProvider(RuntimeComposition composition, ReportFaultCallback faultCallback)
-                : this(composition)
+            internal RuntimeExportProvider(RuntimeComposition composition, ReportFaultCallback faultCallback, JoinableTaskFactory? joinableTaskFactory)
+                : this(composition, joinableTaskFactory)
             {
                 this.faultCallback = faultCallback;
             }
 
-            internal RuntimeExportProvider(RuntimeComposition composition)
-                : base(Requires.NotNull(composition, nameof(composition)).Resolver)
+            internal RuntimeExportProvider(RuntimeComposition composition, JoinableTaskFactory? joinableTaskFactory = null)
+                : base(Requires.NotNull(composition, nameof(composition)).Resolver, joinableTaskFactory)
             {
                 this.composition = composition;
             }
 
             internal RuntimeExportProvider(RuntimeComposition composition, ExportProvider parent, ImmutableHashSet<string> freshSharingBoundaries)
+#pragma warning disable VSTHRD012 // The parent constructor propagates its joinable task factory.
                 : base(parent, freshSharingBoundaries)
+#pragma warning restore VSTHRD012
             {
                 Requires.NotNull(composition, nameof(composition));
 
@@ -253,9 +256,11 @@ namespace Microsoft.VisualStudio.Composition
                 bool newSharingScope = sharingBoundaries.Count > 0;
                 Func<KeyValuePair<object?, IDisposable?>> valueFactory = () =>
                 {
+#pragma warning disable VSTHRD012 // The child export provider inherits the joinable task factory from its parent.
                     RuntimeExportProvider scope = newSharingScope
                         ? new RuntimeExportProvider(this.composition, this, sharingBoundaries)
                         : this;
+#pragma warning restore VSTHRD012
                     object? constructedValue = scope.GetExportedValue(import, export, importingPartTracker, out PartLifecycleTracker? partLifecycle);
                     partLifecycle!.GetValueReadyToExpose();
                     var disposableValue = newSharingScope ? scope : partLifecycle as IDisposable;

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -12,26 +12,29 @@ namespace Microsoft.VisualStudio.Composition
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
+    using Microsoft.VisualStudio.Threading;
 
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
     {
         private readonly RuntimeComposition composition;
+        private readonly JoinableTaskFactory? joinableTaskFactory;
 
-        internal RuntimeExportProviderFactory(RuntimeComposition composition)
+        internal RuntimeExportProviderFactory(RuntimeComposition composition, JoinableTaskFactory? joinableTaskFactory = null)
         {
             Requires.NotNull(composition, nameof(composition));
             this.composition = composition;
+            this.joinableTaskFactory = joinableTaskFactory;
         }
 
         public ExportProvider CreateExportProvider()
         {
-            return new RuntimeExportProvider(this.composition);
+            return new RuntimeExportProvider(this.composition, this.joinableTaskFactory);
         }
 
         public ExportProvider CreateExportProvider(ReportFaultCallback faultCallback)
         {
             Requires.NotNull(faultCallback, nameof(faultCallback));
-            return new RuntimeExportProvider(this.composition, faultCallback);
+            return new RuntimeExportProvider(this.composition, faultCallback, this.joinableTaskFactory);
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/DelegatingExportProviderTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DelegatingExportProviderTests.cs
@@ -42,6 +42,12 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal(2, unfilteredResults.Count());
         }
 
+        [Fact]
+        public void DelegatingExportProviderRejectsNullInnerProvider()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FilteringExportProvider(null!));
+        }
+
         public class ExportingPart
         {
             [Export]

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -149,6 +149,27 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task DisposeAsyncDisposesDescendantWhoseConstructionFinishesLate()
+        {
+            LateAsyncDisposableChild.Reset();
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(PartWithLateAsyncDisposableChild), typeof(LateAsyncDisposableChild));
+            Task<PartWithLateAsyncDisposableChild> activation = Task.Run(exportProvider.GetExportedValue<PartWithLateAsyncDisposableChild>);
+
+            await LateAsyncDisposableChild.ConstructionStarted.Task;
+            try
+            {
+                await exportProvider.DisposeAsync();
+            }
+            finally
+            {
+                LateAsyncDisposableChild.AllowConstructionToFinish.SetResult(null);
+            }
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await activation);
+            Assert.Equal(1, LateAsyncDisposableChild.DisposalCount);
+        }
+
+        [Fact]
         public async Task AsyncDisposablePartDisposedSynchronouslyWithJoinableTaskFactory()
         {
             AsyncDisposablePart.DisposalCount = 0;
@@ -354,6 +375,42 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 DisposalCount++;
                 return default;
+            }
+        }
+
+        [Export]
+        public class PartWithLateAsyncDisposableChild
+        {
+            [Import]
+            public LateAsyncDisposableChild Child { get; set; } = null!;
+        }
+
+        [Export]
+        public class LateAsyncDisposableChild : IAsyncDisposable
+        {
+            internal static TaskCompletionSource<object?> AllowConstructionToFinish = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            internal static TaskCompletionSource<object?> ConstructionStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            internal static int DisposalCount;
+
+            public LateAsyncDisposableChild()
+            {
+                ConstructionStarted.SetResult(null);
+#pragma warning disable VSTHRD002 // The test intentionally holds construction across provider disposal.
+                AllowConstructionToFinish.Task.GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                DisposalCount++;
+                return default;
+            }
+
+            internal static void Reset()
+            {
+                AllowConstructionToFinish = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                ConstructionStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                DisposalCount = 0;
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -69,6 +69,21 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task DelegatingExportProviderInheritsJoinableTaskFactory()
+        {
+            using var joinableTaskContext = new JoinableTaskContext();
+            ExportProvider innerExportProvider = await CreateExportProviderAsync(joinableTaskContext.Factory);
+            var part = new DualDisposablePart();
+            var exportProvider = new PartOwningDelegatingExportProvider(innerExportProvider, part);
+
+            exportProvider.Dispose();
+            innerExportProvider.Dispose();
+
+            Assert.False(part.DisposeCalled);
+            Assert.True(part.DisposeAsyncCalled);
+        }
+
+        [Fact]
         public async Task ConcurrentDisposalCallsAwaitSameOperation()
         {
             ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposalGatePart));
@@ -363,6 +378,20 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 this.DisposeCallCount++;
                 base.Dispose(disposing);
+            }
+        }
+
+        private class PartOwningDelegatingExportProvider : DelegatingExportProvider
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="PartOwningDelegatingExportProvider"/> class.
+            /// </summary>
+            /// <param name="inner">The export provider to delegate to.</param>
+            /// <param name="part">The part whose disposal should be tracked.</param>
+            internal PartOwningDelegatingExportProvider(ExportProvider inner, IDisposable part)
+                : base(inner)
+            {
+                this.TrackDisposableValue(part, sharingBoundary: null);
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -44,6 +44,31 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task SynchronousDisposalPrefersIDisposableWithoutJoinableTaskFactory()
+        {
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(DualDisposablePart));
+            DualDisposablePart part = exportProvider.GetExportedValue<DualDisposablePart>();
+
+            exportProvider.Dispose();
+
+            Assert.True(part.DisposeCalled);
+            Assert.False(part.DisposeAsyncCalled);
+        }
+
+        [Fact]
+        public async Task SynchronousDisposalPrefersIAsyncDisposableWithJoinableTaskFactory()
+        {
+            using var joinableTaskContext = new JoinableTaskContext();
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskContext.Factory, typeof(DualDisposablePart));
+            DualDisposablePart part = exportProvider.GetExportedValue<DualDisposablePart>();
+
+            exportProvider.Dispose();
+
+            Assert.False(part.DisposeCalled);
+            Assert.True(part.DisposeAsyncCalled);
+        }
+
+        [Fact]
         public async Task ConcurrentDisposalCallsAwaitSameOperation()
         {
             ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposalGatePart));

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -62,6 +62,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task DisposeAsyncInvokesDerivedDisposeOverride()
+        {
+            ExportProvider innerExportProvider = await CreateExportProviderAsync(joinableTaskFactory: null);
+            var exportProvider = new DisposeTrackingExportProvider(innerExportProvider);
+
+            await exportProvider.DisposeAsync();
+            await exportProvider.DisposeAsync();
+
+            Assert.Equal(1, exportProvider.DisposeCallCount);
+        }
+
+        [Fact]
         public async Task AsyncDisposablePartDisposedSynchronouslyWithJoinableTaskFactory()
         {
             AsyncDisposablePart.DisposalCount = 0;
@@ -100,6 +112,35 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.Equal(1, AsyncDisposablePart.DisposalCount);
             exportProvider.Dispose();
             Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+        }
+
+        [Fact]
+        public async Task DualDisposablePartCreatedByExportFactoryUsesIDisposableWithoutJoinableTaskFactory()
+        {
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(DualDisposablePart), typeof(DualDisposablePartFactory));
+            DualDisposablePartFactory partFactory = exportProvider.GetExportedValue<DualDisposablePartFactory>();
+            var export = partFactory.Factory.CreateExport();
+            DualDisposablePart part = export.Value;
+
+            export.Dispose();
+
+            Assert.True(part.DisposeCalled);
+            Assert.False(part.DisposeAsyncCalled);
+        }
+
+        [Fact]
+        public async Task DualDisposablePartCreatedByExportFactoryUsesIAsyncDisposableWithJoinableTaskFactory()
+        {
+            using var joinableTaskContext = new JoinableTaskContext();
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskContext.Factory, typeof(DualDisposablePart), typeof(DualDisposablePartFactory));
+            DualDisposablePartFactory partFactory = exportProvider.GetExportedValue<DualDisposablePartFactory>();
+            var export = partFactory.Factory.CreateExport();
+            DualDisposablePart part = export.Value;
+
+            export.Dispose();
+
+            Assert.False(part.DisposeCalled);
+            Assert.True(part.DisposeAsyncCalled);
         }
 
         [Fact]
@@ -194,11 +235,42 @@ namespace Microsoft.VisualStudio.Composition.Tests
             }
         }
 
+        private class DisposeTrackingExportProvider : DelegatingExportProvider
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DisposeTrackingExportProvider"/> class.
+            /// </summary>
+            /// <param name="inner">The export provider to delegate to.</param>
+            internal DisposeTrackingExportProvider(ExportProvider inner)
+                : base(inner)
+            {
+            }
+
+            /// <summary>
+            /// Gets the number of calls to <see cref="Dispose(bool)"/>.
+            /// </summary>
+            internal int DisposeCallCount { get; private set; }
+
+            /// <inheritdoc />
+            protected override void Dispose(bool disposing)
+            {
+                this.DisposeCallCount++;
+                base.Dispose(disposing);
+            }
+        }
+
         [Export]
         public class AsyncDisposablePartFactory
         {
             [Import]
             public ExportFactory<AsyncDisposablePart> Factory { get; set; } = null!;
+        }
+
+        [Export]
+        public class DualDisposablePartFactory
+        {
+            [Import]
+            public ExportFactory<DualDisposablePart> Factory { get; set; } = null!;
         }
 
         [MefV1.Export]

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -84,6 +84,22 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task LateTrackedPartUsesJoinableTaskFactoryDisposalPolicy()
+        {
+            using var joinableTaskContext = new JoinableTaskContext();
+            ExportProvider innerExportProvider = await CreateExportProviderAsync(joinableTaskContext.Factory);
+            var exportProvider = new PartOwningDelegatingExportProvider(innerExportProvider, new DualDisposablePart());
+            var latePart = new DualDisposablePart();
+            exportProvider.Dispose();
+
+            exportProvider.TrackPart(latePart);
+            innerExportProvider.Dispose();
+
+            Assert.False(latePart.DisposeCalled);
+            Assert.True(latePart.DisposeAsyncCalled);
+        }
+
+        [Fact]
         public async Task ConcurrentDisposalCallsAwaitSameOperation()
         {
             ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposalGatePart));
@@ -447,6 +463,15 @@ namespace Microsoft.VisualStudio.Composition.Tests
             /// <param name="part">The part whose disposal should be tracked.</param>
             internal PartOwningDelegatingExportProvider(ExportProvider inner, IDisposable part)
                 : base(inner)
+            {
+                this.TrackDisposableValue(part, sharingBoundary: null);
+            }
+
+            /// <summary>
+            /// Tracks another part for disposal.
+            /// </summary>
+            /// <param name="part">The part whose disposal should be tracked.</param>
+            internal void TrackPart(IDisposable part)
             {
                 this.TrackDisposableValue(part, sharingBoundary: null);
             }

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -74,6 +74,30 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task DisposeContinuesWithNonSharedDescendantsAfterPartThrows()
+        {
+            DisposableChildPart.DisposalCount = 0;
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(ThrowingDisposablePartWithChild), typeof(DisposableChildPart));
+            exportProvider.GetExportedValue<ThrowingDisposablePartWithChild>();
+
+            Assert.Throws<AggregateException>(() => exportProvider.Dispose());
+
+            Assert.Equal(1, DisposableChildPart.DisposalCount);
+        }
+
+        [Fact]
+        public async Task DisposeAsyncContinuesWithNonSharedDescendantsAfterPartThrows()
+        {
+            AsyncDisposableChildPart.DisposalCount = 0;
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(ThrowingAsyncDisposablePartWithChild), typeof(AsyncDisposableChildPart));
+            exportProvider.GetExportedValue<ThrowingAsyncDisposablePartWithChild>();
+
+            await Assert.ThrowsAsync<AggregateException>(() => exportProvider.DisposeAsync().AsTask());
+
+            Assert.Equal(1, AsyncDisposableChildPart.DisposalCount);
+        }
+
+        [Fact]
         public async Task AsyncDisposablePartDisposedSynchronouslyWithJoinableTaskFactory()
         {
             AsyncDisposablePart.DisposalCount = 0;
@@ -232,6 +256,53 @@ namespace Microsoft.VisualStudio.Composition.Tests
 #pragma warning disable VSTHRD003 // This test part intentionally awaits a signal controlled by the test.
                 await this.AllowDisposalToComplete.Task;
 #pragma warning restore VSTHRD003
+            }
+        }
+
+        [Export]
+        public class ThrowingDisposablePartWithChild : IDisposable
+        {
+            [Import]
+            public DisposableChildPart Child { get; set; } = null!;
+
+            public void Dispose()
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        [Export]
+        public class DisposableChildPart : IDisposable
+        {
+            internal static int DisposalCount;
+
+            public void Dispose()
+            {
+                DisposalCount++;
+            }
+        }
+
+        [Export]
+        public class ThrowingAsyncDisposablePartWithChild : IAsyncDisposable
+        {
+            [Import]
+            public AsyncDisposableChildPart Child { get; set; } = null!;
+
+            public ValueTask DisposeAsync()
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        [Export]
+        public class AsyncDisposableChildPart : IAsyncDisposable
+        {
+            internal static int DisposalCount;
+
+            public ValueTask DisposeAsync()
+            {
+                DisposalCount++;
+                return default;
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -99,6 +99,17 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task DisposeAsyncCoreRunsWhenDerivedDisposeOverrideThrows()
+        {
+            ExportProvider innerExportProvider = await CreateExportProviderAsync(joinableTaskFactory: null);
+            var exportProvider = new ThrowingDisposeExportProvider(innerExportProvider);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => exportProvider.DisposeAsync().AsTask());
+
+            Assert.True(exportProvider.DisposeAsyncCoreCalled);
+        }
+
+        [Fact]
         public async Task DisposeContinuesWithNonSharedDescendantsAfterPartThrows()
         {
             DisposableChildPart.DisposalCount = 0;
@@ -352,6 +363,36 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 this.DisposeCallCount++;
                 base.Dispose(disposing);
+            }
+        }
+
+        private class ThrowingDisposeExportProvider : DelegatingExportProvider
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ThrowingDisposeExportProvider"/> class.
+            /// </summary>
+            /// <param name="inner">The export provider to delegate to.</param>
+            internal ThrowingDisposeExportProvider(ExportProvider inner)
+                : base(inner)
+            {
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether <see cref="DisposeAsyncCore"/> was invoked.
+            /// </summary>
+            internal bool DisposeAsyncCoreCalled { get; private set; }
+
+            /// <inheritdoc />
+            protected override void Dispose(bool disposing)
+            {
+                throw new InvalidOperationException();
+            }
+
+            /// <inheritdoc />
+            protected override async ValueTask DisposeAsyncCore()
+            {
+                this.DisposeAsyncCoreCalled = true;
+                await base.DisposeAsyncCore();
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -10,12 +10,167 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Threading;
     using Xunit;
+    using IAsyncDisposable = System.IAsyncDisposable;
     using MefV1 = System.ComponentModel.Composition;
 
     [Trait("Disposal", "")]
     public class DisposablePartsTests
     {
+        [Fact]
+        public async Task AsyncDisposablePartDisposedWithExportProviderAsync()
+        {
+            AsyncDisposablePart.DisposalCount = 0;
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposablePart));
+            exportProvider.GetExportedValue<AsyncDisposablePart>();
+
+            await exportProvider.DisposeAsync();
+            await exportProvider.DisposeAsync();
+
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+        }
+
+        [Fact]
+        public async Task AsyncDisposalPrefersIAsyncDisposableOverIDisposable()
+        {
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(DualDisposablePart));
+            DualDisposablePart part = exportProvider.GetExportedValue<DualDisposablePart>();
+
+            await exportProvider.DisposeAsync();
+
+            Assert.True(part.DisposeAsyncCalled);
+            Assert.False(part.DisposeCalled);
+        }
+
+        [Fact]
+        public async Task AsyncDisposablePartDisposedSynchronouslyWithJoinableTaskFactory()
+        {
+            AsyncDisposablePart.DisposalCount = 0;
+            using var joinableTaskContext = new JoinableTaskContext();
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskContext.Factory, typeof(AsyncDisposablePart));
+            exportProvider.GetExportedValue<AsyncDisposablePart>();
+
+            exportProvider.Dispose();
+
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+        }
+
+        [Fact]
+        public async Task AsyncDisposablePartDisposedSynchronouslyWithoutJoinableTaskFactory()
+        {
+            AsyncDisposablePart.DisposalCount = 0;
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposablePart));
+            exportProvider.GetExportedValue<AsyncDisposablePart>();
+
+            exportProvider.Dispose();
+
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+        }
+
+        [Fact]
+        public async Task AsyncDisposablePartCreatedByExportFactoryDisposedSynchronouslyWithoutJoinableTaskFactory()
+        {
+            AsyncDisposablePart.DisposalCount = 0;
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposablePart), typeof(AsyncDisposablePartFactory));
+            AsyncDisposablePartFactory partFactory = exportProvider.GetExportedValue<AsyncDisposablePartFactory>();
+
+            using (partFactory.Factory.CreateExport())
+            {
+            }
+
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+            exportProvider.Dispose();
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+        }
+
+        [Fact]
+        public async Task AsyncDisposablePartCreatedByMefV1ExportFactoryDisposedSynchronouslyWithJoinableTaskFactory()
+        {
+            AsyncDisposablePart.DisposalCount = 0;
+            using var joinableTaskContext = new JoinableTaskContext();
+            ExportProvider exportProvider = await CreateExportProviderAsync(TestUtilities.V1Discovery, joinableTaskContext.Factory, typeof(AsyncDisposablePart), typeof(AsyncDisposablePartFactoryV1));
+            AsyncDisposablePartFactoryV1 partFactory = exportProvider.GetExportedValue<AsyncDisposablePartFactoryV1>();
+
+            using (partFactory.Factory.CreateExport())
+            {
+            }
+
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+            exportProvider.Dispose();
+            Assert.Equal(1, AsyncDisposablePart.DisposalCount);
+        }
+
+        private static async Task<ExportProvider> CreateExportProviderAsync(JoinableTaskFactory? joinableTaskFactory, params Type[] partTypes)
+        {
+            return await CreateExportProviderAsync(TestUtilities.V2Discovery, joinableTaskFactory, partTypes);
+        }
+
+        private static async Task<ExportProvider> CreateExportProviderAsync(PartDiscovery partDiscovery, JoinableTaskFactory? joinableTaskFactory, params Type[] partTypes)
+        {
+            var catalog = TestUtilities.EmptyCatalog.AddParts(await partDiscovery.CreatePartsAsync(partTypes));
+            CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+            IExportProviderFactory exportProviderFactory;
+            if (joinableTaskFactory is object)
+            {
+                exportProviderFactory = configuration.CreateExportProviderFactory(joinableTaskFactory);
+            }
+            else
+            {
+#pragma warning disable VSTHRD012 // This path tests direct blocking and asynchronous disposal without a joinable task factory.
+                exportProviderFactory = configuration.CreateExportProviderFactory();
+#pragma warning restore VSTHRD012
+            }
+
+            return exportProviderFactory.CreateExportProvider();
+        }
+
+        [Export]
+        [MefV1.Export, MefV1.PartCreationPolicy(MefV1.CreationPolicy.NonShared)]
+        public class AsyncDisposablePart : IAsyncDisposable
+        {
+            internal static int DisposalCount;
+
+            public async ValueTask DisposeAsync()
+            {
+                await Task.Yield();
+                DisposalCount++;
+            }
+        }
+
+        [Export]
+        public class DualDisposablePart : IDisposable, IAsyncDisposable
+        {
+            internal bool DisposeCalled { get; private set; }
+
+            internal bool DisposeAsyncCalled { get; private set; }
+
+            public void Dispose()
+            {
+                this.DisposeCalled = true;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                this.DisposeAsyncCalled = true;
+                return default;
+            }
+        }
+
+        [Export]
+        public class AsyncDisposablePartFactory
+        {
+            [Import]
+            public ExportFactory<AsyncDisposablePart> Factory { get; set; } = null!;
+        }
+
+        [MefV1.Export]
+        public class AsyncDisposablePartFactoryV1
+        {
+            [MefV1.Import]
+            public MefV1.ExportFactory<AsyncDisposablePart> Factory { get; set; } = null!;
+        }
+
         #region Disposable part happy path test
 
         [MefFact(CompositionEngines.V1Compat | CompositionEngines.V2Compat, typeof(DisposableNonSharedPart), typeof(UninstantiatedNonSharedPart))]

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -44,6 +44,24 @@ namespace Microsoft.VisualStudio.Composition.Tests
         }
 
         [Fact]
+        public async Task ConcurrentDisposalCallsAwaitSameOperation()
+        {
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposalGatePart));
+            AsyncDisposalGatePart part = exportProvider.GetExportedValue<AsyncDisposalGatePart>();
+
+            Task firstDisposal = exportProvider.DisposeAsync().AsTask();
+#pragma warning disable VSTHRD003 // This test intentionally awaits signals initiated by the disposal operation.
+            await part.DisposalStarted.Task;
+#pragma warning restore VSTHRD003
+            Task secondDisposal = exportProvider.DisposeAsync().AsTask();
+
+            Assert.False(secondDisposal.IsCompleted);
+            part.AllowDisposalToComplete.SetResult(null);
+            await Task.WhenAll(firstDisposal, secondDisposal);
+            Assert.Equal(1, part.DisposalCount);
+        }
+
+        [Fact]
         public async Task AsyncDisposablePartDisposedSynchronouslyWithJoinableTaskFactory()
         {
             AsyncDisposablePart.DisposalCount = 0;
@@ -154,6 +172,25 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 this.DisposeAsyncCalled = true;
                 return default;
+            }
+        }
+
+        [Export]
+        public class AsyncDisposalGatePart : IAsyncDisposable
+        {
+            internal TaskCompletionSource<object?> AllowDisposalToComplete { get; } = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal TaskCompletionSource<object?> DisposalStarted { get; } = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal int DisposalCount { get; private set; }
+
+            public async ValueTask DisposeAsync()
+            {
+                this.DisposalCount++;
+                this.DisposalStarted.SetResult(null);
+#pragma warning disable VSTHRD003 // This test part intentionally awaits a signal controlled by the test.
+                await this.AllowDisposalToComplete.Task;
+#pragma warning restore VSTHRD003
             }
         }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/Microsoft.VisualStudio.Composition.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Composition.Tests/Microsoft.VisualStudio.Composition.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="DiffPlex" />
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Only" />
     <PackageReference Include="xunit.extensibility.execution" />
     <PackageReference Include="xunit.runner.console" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
VS MEF currently recognizes only synchronous part cleanup, leaving parts that implement only `IAsyncDisposable` without a MEF-managed disposal path. This adds predictable asynchronous cleanup while preserving synchronous host and `ExportFactory<T>` disposal paths.

- Make `ExportProvider` implement `IAsyncDisposable` and await async part cleanup exactly once.
- Allow hosts to supply a `JoinableTaskFactory` when creating an export provider factory. Synchronous provider disposal uses one `JTF.Run` for all async cleanup; without a JTF, async-only cleanup is synchronously blocked on.
- Propagate the disposal policy through sharing boundaries and MEF v1/v2 `ExportFactory<T>` lifetimes.
- Prefer `DisposeAsync` when asynchronous disposal encounters a part implementing both disposal interfaces.
- Document behavior for part authors and MEF hosts.

Tests cover asynchronous and synchronous provider disposal, with and without JTF, dual-interface parts, and MEF v1/v2 export factories across `net8.0` and `net472`.

Fixes #777

## Alternative fixes

I also have an alternative fix prepared that, instead of adding support for `IAsyncDisposable`, adds an analyzer to flag when MEF parts implement that without also implementing `IDisposable`. This alternative is a far simpler way to address the problem of MEF parts accidentally not being disposed of by virtue of not implementing the right disposable interface. But the way this PR takes seems preferable as it is more future looking.