### PR TITLE
Reject exports in uncreatable sharing boundaries

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -140,10 +140,11 @@ namespace Microsoft.VisualStudio.Composition
                 errors.AddRange(part.Validate(metadataViewsAndProviders));
             }
 
-            errors.AddRange(FindPartsInUncreatableSharingBoundaries(parts, sharingBoundaryOverrides));
-
             // Detect loops of all non-shared parts.
             errors.AddRange(FindLoops(parts));
+
+            var initiallyViableParts = parts.Except(errors.SelectMany(error => error.Parts));
+            errors.AddRange(FindPartsInUncreatableSharingBoundaries(initiallyViableParts, sharingBoundaryOverrides));
 
             // If errors are found, re-validate the salvaged parts in case there are parts whose dependencies are affected by the initial errors
             if (errors.Count > 0)
@@ -180,6 +181,9 @@ namespace Microsoft.VisualStudio.Composition
                     {
                         previousErrors.AddRange(part.RemoveSatisfyingExports(invalidPartDefinitionsSet));
                     }
+
+                    var viableParts = salvagedParts.Except(previousErrors.SelectMany(error => error.Parts));
+                    previousErrors.AddRange(FindPartsInUncreatableSharingBoundaries(viableParts, sharingBoundaryOverrides));
                 }
 
                 var finalCatalog = ComposableCatalog.Create(catalog.Resolver).AddParts(salvagedPartDefinitions);

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -462,8 +462,8 @@ namespace Microsoft.VisualStudio.Composition
 
             HashSet<ComposedPart> AnalyzeUnreachableParts(IReadOnlyCollection<ComposedPart> prunedOptionalExports)
             {
-                // The query-directed search normally visits only scopes relevant to one part. Report an
-                // indeterminate result at this bound so pathological graphs cannot exhaust composition-time memory.
+                // The query-directed search normally visits only scopes relevant to one part. Return null
+                // at this bound so the caller does not diagnose an indeterminate result as unreachable.
                 const int MaxScopesPerPart = 1024;
 
                 var requiredSharingBoundaries = partsList.ToDictionary(

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -398,34 +398,117 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(sharingBoundaryOverrides, nameof(sharingBoundaryOverrides));
 
             var partsList = parts.ToList();
-            var creatableSharingBoundaries = new HashSet<string>();
-            bool addedSharingBoundary;
+            var partsByDefinition = partsList.ToDictionary(part => part.Definition);
+            var requiredSharingBoundaries = partsList.ToDictionary(
+                part => part,
+                part =>
+                {
+                    var boundaries = new HashSet<string>();
+                    string? sharingBoundary = GetEffectiveSharingBoundary(part);
+                    if (!string.IsNullOrEmpty(sharingBoundary))
+                    {
+                        boundaries.Add(sharingBoundary!);
+                    }
+
+                    return boundaries;
+                });
+            var blockedParts = new HashSet<ComposedPart>();
+            bool requirementsChanged;
             do
             {
-                addedSharingBoundary = false;
-                foreach (var part in partsList.Where(part => part.RequiredSharingBoundaries.All(creatableSharingBoundaries.Contains)))
+                requirementsChanged = false;
+                foreach (var part in partsList.Where(part => !blockedParts.Contains(part)))
                 {
-                    var sharingBoundariesCreatedBySatisfiedImports = part.SatisfyingExports
-                        .Where(import => import.Key.IsExportFactory && import.Value.Count > 0)
-                        .SelectMany(import => import.Key.ImportDefinition.ExportFactorySharingBoundaries)
-                        .Where(sharingBoundary => !string.IsNullOrEmpty(sharingBoundary));
-                    foreach (string sharingBoundary in sharingBoundariesCreatedBySatisfiedImports)
+                    foreach (var import in part.SatisfyingExports.Where(import => import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne))
                     {
-                        addedSharingBoundary |= creatableSharingBoundaries.Add(sharingBoundary);
+                        var viableExports = import.Value
+                            .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
+                            .ToList();
+                        if (viableExports.Count != 1)
+                        {
+                            requirementsChanged |= blockedParts.Add(part);
+                            break;
+                        }
+
+                        if (!import.Key.IsExportFactory || import.Key.ImportDefinition.ExportFactorySharingBoundaries.Count == 0)
+                        {
+                            var exportedPart = partsByDefinition[viableExports[0].PartDefinition];
+                            int previousBoundaryCount = requiredSharingBoundaries[part].Count;
+                            requiredSharingBoundaries[part].UnionWith(requiredSharingBoundaries[exportedPart]);
+                            requirementsChanged |= requiredSharingBoundaries[part].Count != previousBoundaryCount;
+                        }
                     }
                 }
             }
-            while (addedSharingBoundary);
+            while (requirementsChanged);
+
+            var reachableScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>
+            {
+                (ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty),
+            };
+            bool scopeAdded;
+            do
+            {
+                scopeAdded = false;
+                foreach (var scope in reachableScopes.ToList())
+                {
+                    foreach (var part in partsList.Where(part => CanInstantiatePartInScope(part, scope)))
+                    {
+                        foreach (var import in part.SatisfyingExports.Where(import => import.Key.IsExportFactory))
+                        {
+                            bool hasViableExport = import.Value.Any(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart));
+                            var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
+                                .Where(boundary => !string.IsNullOrEmpty(boundary))
+                                .ToImmutableHashSet();
+                            if (hasViableExport && freshBoundaries.Count > 0)
+                            {
+                                var allBoundaries = scope.AllBoundaries.Union(freshBoundaries);
+                                if (!reachableScopes.Any(existing => existing.AllBoundaries.SetEquals(allBoundaries) && existing.FreshBoundaries.SetEquals(freshBoundaries)))
+                                {
+                                    reachableScopes.Add((allBoundaries, freshBoundaries));
+                                    scopeAdded = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            while (scopeAdded);
 
             foreach (var part in partsList)
             {
-                string? sharingBoundary = sharingBoundaryOverrides.TryGetValue(part.Definition, out string? effectiveSharingBoundary)
-                    ? effectiveSharingBoundary
-                    : part.Definition.SharingBoundary;
-                if (!string.IsNullOrEmpty(sharingBoundary) && !creatableSharingBoundaries.Contains(sharingBoundary!))
+                string? sharingBoundary = GetEffectiveSharingBoundary(part);
+                if (!string.IsNullOrEmpty(sharingBoundary) && !reachableScopes.Any(scope => CanInstantiatePartInScope(part, scope)))
                 {
                     yield return new ComposedPartDiagnostic(part, Strings.SharingBoundaryHasNoExportFactory, sharingBoundary);
                 }
+            }
+
+            string? GetEffectiveSharingBoundary(ComposedPart part)
+            {
+                return sharingBoundaryOverrides.TryGetValue(part.Definition, out string? effectiveSharingBoundary)
+                    ? effectiveSharingBoundary
+                    : part.Definition.SharingBoundary;
+            }
+
+            bool CanInstantiatePartInScope(
+                ComposedPart part,
+                (ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries) scope)
+            {
+                if (blockedParts.Contains(part) || !requiredSharingBoundaries[part].IsSubsetOf(scope.AllBoundaries))
+                {
+                    return false;
+                }
+
+                string? sharingBoundary = GetEffectiveSharingBoundary(part);
+                if (!part.Definition.IsShared)
+                {
+                    return true;
+                }
+
+                return string.IsNullOrEmpty(sharingBoundary)
+                    ? scope.AllBoundaries.Count == 0
+                    : scope.FreshBoundaries.Contains(sharingBoundary!);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -406,6 +406,55 @@ namespace Microsoft.VisualStudio.Composition
             var partsByDefinition = partsList.ToDictionary(part => part.Definition, ReferenceEquality<ComposablePartDefinition>.Default);
             var pessimisticUnreachableParts = AnalyzeUnreachableParts(ImmutableHashSet<ComposedPart>.Empty);
             var unreachableParts = AnalyzeUnreachableParts(pessimisticUnreachableParts);
+            while (true)
+            {
+                var currentlyUnreachableParts = AnalyzeUnreachableParts(unreachableParts);
+                currentlyUnreachableParts.ExceptWith(unreachableParts);
+                if (currentlyUnreachableParts.Count == 0)
+                {
+                    break;
+                }
+
+                // Reject terminal groups first. Parts that merely depend on a rejected optional export
+                // are reconsidered after that export is removed from the graph.
+                var optionalDependencies = currentlyUnreachableParts.ToDictionary(
+                    part => part,
+                    part => new HashSet<ComposedPart>(part.SatisfyingExports
+                        .Where(import => import.Key.ImportDefinition.Cardinality != ImportCardinality.ExactlyOne
+                            && (!import.Key.IsExportFactory || import.Key.ImportDefinition.ExportFactorySharingBoundaries.Count == 0))
+                        .SelectMany(import => import.Value)
+                        .Select(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) ? exportedPart : null)
+                        .OfType<ComposedPart>()
+                        .Where(currentlyUnreachableParts.Contains)));
+                var reachableDependenciesByPart = currentlyUnreachableParts.ToDictionary(part => part, GetReachableDependencies);
+                foreach (var part in currentlyUnreachableParts)
+                {
+                    if (reachableDependenciesByPart[part].All(dependency => reachableDependenciesByPart[dependency].Contains(part)))
+                    {
+                        unreachableParts.Add(part);
+                    }
+                }
+
+                HashSet<ComposedPart> GetReachableDependencies(ComposedPart part)
+                {
+                    var reachableDependencies = new HashSet<ComposedPart> { part };
+                    var pendingDependencies = new Stack<ComposedPart>();
+                    pendingDependencies.Push(part);
+                    while (pendingDependencies.Count > 0)
+                    {
+                        foreach (var dependency in optionalDependencies[pendingDependencies.Pop()])
+                        {
+                            if (reachableDependencies.Add(dependency))
+                            {
+                                pendingDependencies.Push(dependency);
+                            }
+                        }
+                    }
+
+                    return reachableDependencies;
+                }
+            }
+
             foreach (var part in unreachableParts)
             {
                 yield return new ComposedPartDiagnostic(part, Strings.SharingBoundaryHasNoExportFactory, GetEffectiveSharingBoundary(part));
@@ -413,8 +462,8 @@ namespace Microsoft.VisualStudio.Composition
 
             HashSet<ComposedPart> AnalyzeUnreachableParts(IReadOnlyCollection<ComposedPart> prunedOptionalExports)
             {
-                // The query-directed search normally visits only scopes relevant to one part. Fail open at this
-                // explicit bound so pathological boundary graphs cannot exhaust composition-time memory.
+                // The query-directed search normally visits only scopes relevant to one part. Report an
+                // indeterminate result at this bound so pathological graphs cannot exhaust composition-time memory.
                 const int MaxScopesPerPart = 1024;
 
                 var requiredSharingBoundaries = partsList.ToDictionary(
@@ -465,7 +514,7 @@ namespace Microsoft.VisualStudio.Composition
                 foreach (var part in partsList)
                 {
                     string? sharingBoundary = GetEffectiveSharingBoundary(part);
-                    if (!string.IsNullOrEmpty(sharingBoundary) && !IsPartReachable(part))
+                    if (!string.IsNullOrEmpty(sharingBoundary) && IsPartReachable(part) == false)
                     {
                         unreachable.Add(part);
                     }
@@ -473,7 +522,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 return unreachable;
 
-                bool IsPartReachable(ComposedPart targetPart)
+                bool? IsPartReachable(ComposedPart targetPart)
                 {
                     if (blockedParts.Contains(targetPart))
                     {
@@ -508,6 +557,18 @@ namespace Microsoft.VisualStudio.Composition
                     }
                     while (relevantBoundariesChanged);
 
+                    string targetSharingBoundary = GetEffectiveSharingBoundary(targetPart)!;
+                    bool targetBoundaryHasFactory = partsList
+                        .Where(part => !blockedParts.Contains(part))
+                        .SelectMany(part => part.SatisfyingExports)
+                        .Where(import => import.Key.IsExportFactory && import.Value.Count > 0)
+                        .Any(import => import.Key.ImportDefinition.ExportFactorySharingBoundaries.Contains(targetSharingBoundary)
+                            && import.Value.Any(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart)));
+                    if (!targetBoundaryHasFactory)
+                    {
+                        return false;
+                    }
+
                     var reachableScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>
                     {
                         (ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty),
@@ -541,7 +602,7 @@ namespace Microsoft.VisualStudio.Composition
                                 {
                                     if (reachableScopes.Count >= MaxScopesPerPart)
                                     {
-                                        return true;
+                                        return null;
                                     }
 
                                     reachableScopes.Add(childScope);

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -538,9 +538,7 @@ namespace Microsoft.VisualStudio.Composition
                         {
                             foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory && import.Value.Count > 0))
                             {
-                                var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
-                                    .Where(boundary => !string.IsNullOrEmpty(boundary))
-                                    .ToImmutableHashSet();
+                                var freshBoundaries = ((ImmutableHashSet<string>)import.Key.ImportDefinition.ExportFactorySharingBoundaries).Remove(string.Empty);
                                 if (freshBoundaries.Overlaps(relevantBoundaries))
                                 {
                                     int previousBoundaryCount = relevantBoundaries.Count;
@@ -585,9 +583,7 @@ namespace Microsoft.VisualStudio.Composition
                         {
                             foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory && import.Value.Count > 0))
                             {
-                                var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
-                                    .Where(boundary => !string.IsNullOrEmpty(boundary))
-                                    .ToImmutableHashSet();
+                                var freshBoundaries = ((ImmutableHashSet<string>)import.Key.ImportDefinition.ExportFactorySharingBoundaries).Remove(string.Empty);
                                 if (freshBoundaries.Count == 0 || !freshBoundaries.Overlaps(relevantBoundaries))
                                 {
                                     continue;

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -482,7 +482,7 @@ namespace Microsoft.VisualStudio.Composition
                         relevantBoundariesChanged = false;
                         foreach (var factoryOwner in partsList.Where(part => !blockedParts.Contains(part)))
                         {
-                            foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory))
+                            foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory && import.Value.Count > 0))
                             {
                                 var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
                                     .Where(boundary => !string.IsNullOrEmpty(boundary))
@@ -517,7 +517,7 @@ namespace Microsoft.VisualStudio.Composition
 
                         foreach (var factoryOwner in partsList.Where(part => CanInstantiatePartInScope(part, scope)))
                         {
-                            foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory))
+                            foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory && import.Value.Count > 0))
                             {
                                 var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
                                     .Where(boundary => !string.IsNullOrEmpty(boundary))

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -140,6 +140,8 @@ namespace Microsoft.VisualStudio.Composition
                 errors.AddRange(part.Validate(metadataViewsAndProviders));
             }
 
+            errors.AddRange(FindPartsInUncreatableSharingBoundaries(parts));
+
             // Detect loops of all non-shared parts.
             errors.AddRange(FindLoops(parts));
 
@@ -380,6 +382,36 @@ namespace Microsoft.VisualStudio.Composition
                             yield return new ComposedPartDiagnostic(path, Strings.LoopInvolvingImportingCtorArgumentAndAllNonLazyImports);
                         }
                     }
+                }
+            }
+        }
+
+        private static IEnumerable<ComposedPartDiagnostic> FindPartsInUncreatableSharingBoundaries(IEnumerable<ComposedPart> parts)
+        {
+            Requires.NotNull(parts, nameof(parts));
+
+            var partsList = parts.ToList();
+            var creatableSharingBoundaries = new HashSet<string>();
+            bool addedSharingBoundary;
+            do
+            {
+                addedSharingBoundary = false;
+                foreach (var part in partsList.Where(part => part.RequiredSharingBoundaries.All(creatableSharingBoundaries.Contains)))
+                {
+                    foreach (string sharingBoundary in part.Definition.Imports.SelectMany(import => import.ImportDefinition.ExportFactorySharingBoundaries))
+                    {
+                        addedSharingBoundary |= creatableSharingBoundaries.Add(sharingBoundary);
+                    }
+                }
+            }
+            while (addedSharingBoundary);
+
+            foreach (var part in partsList)
+            {
+                string? sharingBoundary = part.Definition.SharingBoundary;
+                if (!string.IsNullOrEmpty(sharingBoundary) && !creatableSharingBoundaries.Contains(sharingBoundary!))
+                {
+                    yield return new ComposedPartDiagnostic(part, Strings.SharingBoundaryHasNoExportFactory, sharingBoundary);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.Composition
                 errors.AddRange(part.Validate(metadataViewsAndProviders));
             }
 
-            errors.AddRange(FindPartsInUncreatableSharingBoundaries(parts));
+            errors.AddRange(FindPartsInUncreatableSharingBoundaries(parts, sharingBoundaryOverrides));
 
             // Detect loops of all non-shared parts.
             errors.AddRange(FindLoops(parts));
@@ -386,9 +386,12 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private static IEnumerable<ComposedPartDiagnostic> FindPartsInUncreatableSharingBoundaries(IEnumerable<ComposedPart> parts)
+        private static IEnumerable<ComposedPartDiagnostic> FindPartsInUncreatableSharingBoundaries(
+            IEnumerable<ComposedPart> parts,
+            ImmutableDictionary<ComposablePartDefinition, string> sharingBoundaryOverrides)
         {
             Requires.NotNull(parts, nameof(parts));
+            Requires.NotNull(sharingBoundaryOverrides, nameof(sharingBoundaryOverrides));
 
             var partsList = parts.ToList();
             var creatableSharingBoundaries = new HashSet<string>();
@@ -412,7 +415,9 @@ namespace Microsoft.VisualStudio.Composition
 
             foreach (var part in partsList)
             {
-                string? sharingBoundary = part.Definition.SharingBoundary;
+                string? sharingBoundary = sharingBoundaryOverrides.TryGetValue(part.Definition, out string? effectiveSharingBoundary)
+                    ? effectiveSharingBoundary
+                    : part.Definition.SharingBoundary;
                 if (!string.IsNullOrEmpty(sharingBoundary) && !creatableSharingBoundaries.Contains(sharingBoundary!))
                 {
                     yield return new ComposedPartDiagnostic(part, Strings.SharingBoundaryHasNoExportFactory, sharingBoundary);

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -399,88 +399,173 @@ namespace Microsoft.VisualStudio.Composition
 
             var partsList = parts.ToList();
             var partsByDefinition = partsList.ToDictionary(part => part.Definition, ReferenceEquality<ComposablePartDefinition>.Default);
-            var requiredSharingBoundaries = partsList.ToDictionary(
-                part => part,
-                part =>
-                {
-                    var boundaries = new HashSet<string>();
-                    string? sharingBoundary = GetEffectiveSharingBoundary(part);
-                    if (!string.IsNullOrEmpty(sharingBoundary))
-                    {
-                        boundaries.Add(sharingBoundary!);
-                    }
-
-                    return boundaries;
-                });
-            var blockedParts = new HashSet<ComposedPart>();
-            bool requirementsChanged;
-            do
+            var pessimisticUnreachableParts = AnalyzeUnreachableParts(ImmutableHashSet<ComposedPart>.Empty);
+            var unreachableParts = AnalyzeUnreachableParts(pessimisticUnreachableParts);
+            foreach (var part in unreachableParts)
             {
-                requirementsChanged = false;
-                foreach (var part in partsList.Where(part => !blockedParts.Contains(part)))
-                {
-                    foreach (var import in part.SatisfyingExports.Where(import => import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne))
-                    {
-                        var viableExports = import.Value
-                            .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
-                            .ToList();
-                        if (viableExports.Count != 1)
-                        {
-                            requirementsChanged |= blockedParts.Add(part);
-                            break;
-                        }
-
-                        if (!import.Key.IsExportFactory || import.Key.ImportDefinition.ExportFactorySharingBoundaries.Count == 0)
-                        {
-                            var exportedPart = partsByDefinition[viableExports[0].PartDefinition];
-                            int previousBoundaryCount = requiredSharingBoundaries[part].Count;
-                            requiredSharingBoundaries[part].UnionWith(requiredSharingBoundaries[exportedPart]);
-                            requirementsChanged |= requiredSharingBoundaries[part].Count != previousBoundaryCount;
-                        }
-                    }
-                }
+                yield return new ComposedPartDiagnostic(part, Strings.SharingBoundaryHasNoExportFactory, GetEffectiveSharingBoundary(part));
             }
-            while (requirementsChanged);
 
-            var reachableScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>
+            HashSet<ComposedPart> AnalyzeUnreachableParts(IReadOnlyCollection<ComposedPart> prunedOptionalExports)
             {
-                (ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty),
-            };
-            bool scopeAdded;
-            do
-            {
-                scopeAdded = false;
-                foreach (var scope in reachableScopes.ToList())
-                {
-                    foreach (var part in partsList.Where(part => CanInstantiatePartInScope(part, scope)))
+                // The query-directed search normally visits only scopes relevant to one part. Fail open at this
+                // explicit bound so pathological boundary graphs cannot exhaust composition-time memory.
+                const int MaxScopesPerPart = 1024;
+
+                var requiredSharingBoundaries = partsList.ToDictionary(
+                    part => part,
+                    part =>
                     {
-                        foreach (var import in part.SatisfyingExports.Where(import => import.Key.IsExportFactory))
+                        var boundaries = new HashSet<string>();
+                        string? sharingBoundary = GetEffectiveSharingBoundary(part);
+                        if (!string.IsNullOrEmpty(sharingBoundary))
                         {
-                            bool hasViableExport = import.Value.Any(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart));
-                            var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
-                                .Where(boundary => !string.IsNullOrEmpty(boundary))
-                                .ToImmutableHashSet();
-                            if (hasViableExport && freshBoundaries.Count > 0)
+                            boundaries.Add(sharingBoundary!);
+                        }
+
+                        return boundaries;
+                    });
+                var blockedParts = new HashSet<ComposedPart>();
+                bool requirementsChanged;
+                do
+                {
+                    requirementsChanged = false;
+                    foreach (var part in partsList.Where(part => !blockedParts.Contains(part)))
+                    {
+                        foreach (var import in part.SatisfyingExports.Where(import => !import.Key.IsExportFactory || import.Key.ImportDefinition.ExportFactorySharingBoundaries.Count == 0))
+                        {
+                            var viableExports = import.Value
+                                .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
+                                .Where(export => import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne || !prunedOptionalExports.Contains(partsByDefinition[export.PartDefinition]))
+                                .ToList();
+                            if (import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne && viableExports.Count != 1)
                             {
-                                var allBoundaries = scope.AllBoundaries.Union(freshBoundaries);
-                                if (!reachableScopes.Any(existing => existing.AllBoundaries.SetEquals(allBoundaries) && existing.FreshBoundaries.SetEquals(freshBoundaries)))
-                                {
-                                    reachableScopes.Add((allBoundaries, freshBoundaries));
-                                    scopeAdded = true;
-                                }
+                                requirementsChanged |= blockedParts.Add(part);
+                                break;
+                            }
+
+                            foreach (var export in viableExports)
+                            {
+                                var exportedPart = partsByDefinition[export.PartDefinition];
+                                int previousBoundaryCount = requiredSharingBoundaries[part].Count;
+                                requiredSharingBoundaries[part].UnionWith(requiredSharingBoundaries[exportedPart]);
+                                requirementsChanged |= requiredSharingBoundaries[part].Count != previousBoundaryCount;
                             }
                         }
                     }
                 }
-            }
-            while (scopeAdded);
+                while (requirementsChanged);
 
-            foreach (var part in partsList)
-            {
-                string? sharingBoundary = GetEffectiveSharingBoundary(part);
-                if (!string.IsNullOrEmpty(sharingBoundary) && !reachableScopes.Any(scope => CanInstantiatePartInScope(part, scope)))
+                var unreachable = new HashSet<ComposedPart>();
+                foreach (var part in partsList)
                 {
-                    yield return new ComposedPartDiagnostic(part, Strings.SharingBoundaryHasNoExportFactory, sharingBoundary);
+                    string? sharingBoundary = GetEffectiveSharingBoundary(part);
+                    if (!string.IsNullOrEmpty(sharingBoundary) && !IsPartReachable(part))
+                    {
+                        unreachable.Add(part);
+                    }
+                }
+
+                return unreachable;
+
+                bool IsPartReachable(ComposedPart targetPart)
+                {
+                    if (blockedParts.Contains(targetPart))
+                    {
+                        return false;
+                    }
+
+                    var relevantBoundaries = new HashSet<string>(requiredSharingBoundaries[targetPart]);
+                    bool relevantBoundariesChanged;
+                    do
+                    {
+                        relevantBoundariesChanged = false;
+                        foreach (var factoryOwner in partsList.Where(part => !blockedParts.Contains(part)))
+                        {
+                            foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory))
+                            {
+                                var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
+                                    .Where(boundary => !string.IsNullOrEmpty(boundary))
+                                    .ToImmutableHashSet();
+                                if (freshBoundaries.Overlaps(relevantBoundaries))
+                                {
+                                    int previousBoundaryCount = relevantBoundaries.Count;
+                                    relevantBoundaries.UnionWith(requiredSharingBoundaries[factoryOwner]);
+                                    foreach (var export in import.Value.Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart)))
+                                    {
+                                        relevantBoundaries.UnionWith(requiredSharingBoundaries[partsByDefinition[export.PartDefinition]]);
+                                    }
+
+                                    relevantBoundariesChanged |= relevantBoundaries.Count != previousBoundaryCount;
+                                }
+                            }
+                        }
+                    }
+                    while (relevantBoundariesChanged);
+
+                    var reachableScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>
+                    {
+                        (ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty),
+                    };
+                    for (int scopeIndex = 0; scopeIndex < reachableScopes.Count; scopeIndex++)
+                    {
+                        var scope = reachableScopes[scopeIndex];
+                        if (CanInstantiatePartInScope(targetPart, scope))
+                        {
+                            return true;
+                        }
+
+                        foreach (var factoryOwner in partsList.Where(part => CanInstantiatePartInScope(part, scope)))
+                        {
+                            foreach (var import in factoryOwner.SatisfyingExports.Where(import => import.Key.IsExportFactory))
+                            {
+                                var freshBoundaries = import.Key.ImportDefinition.ExportFactorySharingBoundaries
+                                    .Where(boundary => !string.IsNullOrEmpty(boundary))
+                                    .ToImmutableHashSet();
+                                if (freshBoundaries.Count == 0 || !freshBoundaries.Overlaps(relevantBoundaries))
+                                {
+                                    continue;
+                                }
+
+                                var allBoundaries = scope.AllBoundaries.Union(freshBoundaries);
+                                var childScope = (AllBoundaries: allBoundaries, FreshBoundaries: freshBoundaries);
+                                bool hasInstantiableTarget = import.Value
+                                    .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
+                                    .Any(export => CanInstantiatePartInScope(partsByDefinition[export.PartDefinition], childScope));
+                                if (hasInstantiableTarget && !reachableScopes.Any(existing => existing.AllBoundaries.SetEquals(allBoundaries) && existing.FreshBoundaries.SetEquals(freshBoundaries)))
+                                {
+                                    if (reachableScopes.Count >= MaxScopesPerPart)
+                                    {
+                                        return true;
+                                    }
+
+                                    reachableScopes.Add(childScope);
+                                }
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanInstantiatePartInScope(
+                    ComposedPart part,
+                    (ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries) scope)
+                {
+                    if (blockedParts.Contains(part) || !requiredSharingBoundaries[part].IsSubsetOf(scope.AllBoundaries))
+                    {
+                        return false;
+                    }
+
+                    string? sharingBoundary = GetEffectiveSharingBoundary(part);
+                    if (!part.Definition.IsShared)
+                    {
+                        return true;
+                    }
+
+                    return string.IsNullOrEmpty(sharingBoundary)
+                        ? scope.AllBoundaries.Count == 0
+                        : scope.FreshBoundaries.Contains(sharingBoundary!);
                 }
             }
 
@@ -489,26 +574,6 @@ namespace Microsoft.VisualStudio.Composition
                 return sharingBoundaryOverrides.TryGetValue(part.Definition, out string? effectiveSharingBoundary)
                     ? effectiveSharingBoundary
                     : part.Definition.SharingBoundary;
-            }
-
-            bool CanInstantiatePartInScope(
-                ComposedPart part,
-                (ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries) scope)
-            {
-                if (blockedParts.Contains(part) || !requiredSharingBoundaries[part].IsSubsetOf(scope.AllBoundaries))
-                {
-                    return false;
-                }
-
-                string? sharingBoundary = GetEffectiveSharingBoundary(part);
-                if (!part.Definition.IsShared)
-                {
-                    return true;
-                }
-
-                return string.IsNullOrEmpty(sharingBoundary)
-                    ? scope.AllBoundaries.Count == 0
-                    : scope.FreshBoundaries.Contains(sharingBoundary!);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -571,6 +571,11 @@ namespace Microsoft.VisualStudio.Composition
 
             string? GetEffectiveSharingBoundary(ComposedPart part)
             {
+                if (!part.Definition.IsSharingBoundaryInferred)
+                {
+                    return part.Definition.SharingBoundary;
+                }
+
                 return sharingBoundaryOverrides.TryGetValue(part.Definition, out string? effectiveSharingBoundary)
                     ? effectiveSharingBoundary
                     : part.Definition.SharingBoundary;
@@ -588,7 +593,7 @@ namespace Microsoft.VisualStudio.Composition
 
             var sharingBoundariesAndMetadata = ComputeSharingBoundaryMetadata(partBuilders);
 
-            var sharingBoundaryOverrides = ImmutableDictionary.CreateBuilder<ComposablePartDefinition, string>();
+            var sharingBoundaryOverrides = ImmutableDictionary.CreateBuilder<ComposablePartDefinition, string>(ReferenceEquality<ComposablePartDefinition>.Default);
             foreach (PartBuilder partBuilder in partBuilders)
             {
                 if (partBuilder.PartDefinition.IsSharingBoundaryInferred)

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -398,7 +398,11 @@ namespace Microsoft.VisualStudio.Composition
                 addedSharingBoundary = false;
                 foreach (var part in partsList.Where(part => part.RequiredSharingBoundaries.All(creatableSharingBoundaries.Contains)))
                 {
-                    foreach (string sharingBoundary in part.Definition.Imports.SelectMany(import => import.ImportDefinition.ExportFactorySharingBoundaries))
+                    var sharingBoundariesCreatedBySatisfiedImports = part.SatisfyingExports
+                        .Where(import => import.Key.IsExportFactory && import.Value.Count > 0)
+                        .SelectMany(import => import.Key.ImportDefinition.ExportFactorySharingBoundaries)
+                        .Where(sharingBoundary => !string.IsNullOrEmpty(sharingBoundary));
+                    foreach (string sharingBoundary in sharingBoundariesCreatedBySatisfiedImports)
                     {
                         addedSharingBoundary |= creatableSharingBoundaries.Add(sharingBoundary);
                     }

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -398,6 +398,11 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(sharingBoundaryOverrides, nameof(sharingBoundaryOverrides));
 
             var partsList = parts.ToList();
+            if (!partsList.Any(part => !string.IsNullOrEmpty(GetEffectiveSharingBoundary(part))))
+            {
+                yield break;
+            }
+
             var partsByDefinition = partsList.ToDictionary(part => part.Definition, ReferenceEquality<ComposablePartDefinition>.Default);
             var pessimisticUnreachableParts = AnalyzeUnreachableParts(ImmutableHashSet<ComposedPart>.Empty);
             var unreachableParts = AnalyzeUnreachableParts(pessimisticUnreachableParts);

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -462,9 +462,32 @@ namespace Microsoft.VisualStudio.Composition
 
             HashSet<ComposedPart> AnalyzeUnreachableParts(IReadOnlyCollection<ComposedPart> prunedOptionalExports)
             {
-                // The query-directed search normally visits only scopes relevant to one part. Return null
-                // at this bound so the caller does not diagnose an indeterminate result as unreachable.
+                // The query-directed search normally visits only scopes relevant to one part. Treat exhaustion
+                // as non-reachability so an indeterminate part cannot survive to fail during activation.
                 const int MaxScopesPerPart = 1024;
+
+                var blockedParts = new HashSet<ComposedPart>();
+                bool blockedPartsChanged;
+                do
+                {
+                    blockedPartsChanged = false;
+                    foreach (var part in partsList.Where(part => !blockedParts.Contains(part)))
+                    {
+                        foreach (var import in part.SatisfyingExports.Where(import => !import.Key.IsExportFactory || import.Key.ImportDefinition.ExportFactorySharingBoundaries.Count == 0))
+                        {
+                            var viableExports = import.Value
+                                .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
+                                .Where(export => import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne || !prunedOptionalExports.Contains(partsByDefinition[export.PartDefinition]))
+                                .ToList();
+                            if (import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne && viableExports.Count != 1)
+                            {
+                                blockedPartsChanged |= blockedParts.Add(part);
+                                break;
+                            }
+                        }
+                    }
+                }
+                while (blockedPartsChanged);
 
                 var requiredSharingBoundaries = partsList.ToDictionary(
                     part => part,
@@ -479,7 +502,6 @@ namespace Microsoft.VisualStudio.Composition
 
                         return boundaries;
                     });
-                var blockedParts = new HashSet<ComposedPart>();
                 bool requirementsChanged;
                 do
                 {
@@ -488,21 +510,12 @@ namespace Microsoft.VisualStudio.Composition
                     {
                         foreach (var import in part.SatisfyingExports.Where(import => !import.Key.IsExportFactory || import.Key.ImportDefinition.ExportFactorySharingBoundaries.Count == 0))
                         {
-                            var viableExports = import.Value
+                            foreach (var export in import.Value
                                 .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
-                                .Where(export => import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne || !prunedOptionalExports.Contains(partsByDefinition[export.PartDefinition]))
-                                .ToList();
-                            if (import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne && viableExports.Count != 1)
+                                .Where(export => import.Key.ImportDefinition.Cardinality == ImportCardinality.ExactlyOne || !prunedOptionalExports.Contains(partsByDefinition[export.PartDefinition])))
                             {
-                                requirementsChanged |= blockedParts.Add(part);
-                                break;
-                            }
-
-                            foreach (var export in viableExports)
-                            {
-                                var exportedPart = partsByDefinition[export.PartDefinition];
                                 int previousBoundaryCount = requiredSharingBoundaries[part].Count;
-                                requiredSharingBoundaries[part].UnionWith(requiredSharingBoundaries[exportedPart]);
+                                requiredSharingBoundaries[part].UnionWith(requiredSharingBoundaries[partsByDefinition[export.PartDefinition]]);
                                 requirementsChanged |= requiredSharingBoundaries[part].Count != previousBoundaryCount;
                             }
                         }
@@ -514,7 +527,7 @@ namespace Microsoft.VisualStudio.Composition
                 foreach (var part in partsList)
                 {
                     string? sharingBoundary = GetEffectiveSharingBoundary(part);
-                    if (!string.IsNullOrEmpty(sharingBoundary) && IsPartReachable(part) == false)
+                    if (!string.IsNullOrEmpty(sharingBoundary) && !IsPartReachable(part))
                     {
                         unreachable.Add(part);
                     }
@@ -522,7 +535,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 return unreachable;
 
-                bool? IsPartReachable(ComposedPart targetPart)
+                bool IsPartReachable(ComposedPart targetPart)
                 {
                     if (blockedParts.Contains(targetPart))
                     {
@@ -567,13 +580,26 @@ namespace Microsoft.VisualStudio.Composition
                         return false;
                     }
 
-                    var reachableScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>
+                    var pendingScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>
                     {
                         (ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty),
                     };
-                    for (int scopeIndex = 0; scopeIndex < reachableScopes.Count; scopeIndex++)
+                    var exploredScopes = new List<(ImmutableHashSet<string> AllBoundaries, ImmutableHashSet<string> FreshBoundaries)>();
+                    int discoveredScopeCount = 1;
+                    while (pendingScopes.Count > 0)
                     {
-                        var scope = reachableScopes[scopeIndex];
+                        int scopeIndex = 0;
+                        for (int i = 1; i < pendingScopes.Count; i++)
+                        {
+                            if (pendingScopes[i].AllBoundaries.Count > pendingScopes[scopeIndex].AllBoundaries.Count)
+                            {
+                                scopeIndex = i;
+                            }
+                        }
+
+                        var scope = pendingScopes[scopeIndex];
+                        pendingScopes.RemoveAt(scopeIndex);
+                        exploredScopes.Add(scope);
                         if (CanInstantiatePartInScope(targetPart, scope))
                         {
                             return true;
@@ -594,14 +620,21 @@ namespace Microsoft.VisualStudio.Composition
                                 bool hasInstantiableTarget = import.Value
                                     .Where(export => partsByDefinition.TryGetValue(export.PartDefinition, out ComposedPart? exportedPart) && !blockedParts.Contains(exportedPart))
                                     .Any(export => CanInstantiatePartInScope(partsByDefinition[export.PartDefinition], childScope));
-                                if (hasInstantiableTarget && !reachableScopes.Any(existing => existing.AllBoundaries.SetEquals(allBoundaries) && existing.FreshBoundaries.SetEquals(freshBoundaries)))
+                                bool isDominated = pendingScopes.Concat(exploredScopes).Any(existing =>
+                                    existing.FreshBoundaries.SetEquals(freshBoundaries)
+                                    && allBoundaries.IsSubsetOf(existing.AllBoundaries));
+                                if (hasInstantiableTarget && !isDominated)
                                 {
-                                    if (reachableScopes.Count >= MaxScopesPerPart)
+                                    if (discoveredScopeCount >= MaxScopesPerPart)
                                     {
-                                        return null;
+                                        return false;
                                     }
 
-                                    reachableScopes.Add(childScope);
+                                    pendingScopes.RemoveAll(existing =>
+                                        existing.FreshBoundaries.SetEquals(freshBoundaries)
+                                        && existing.AllBoundaries.IsSubsetOf(allBoundaries));
+                                    pendingScopes.Add(childScope);
+                                    discoveredScopeCount++;
                                 }
                             }
                         }

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -398,7 +398,7 @@ namespace Microsoft.VisualStudio.Composition
             Requires.NotNull(sharingBoundaryOverrides, nameof(sharingBoundaryOverrides));
 
             var partsList = parts.ToList();
-            var partsByDefinition = partsList.ToDictionary(part => part.Definition);
+            var partsByDefinition = partsList.ToDictionary(part => part.Definition, ReferenceEquality<ComposablePartDefinition>.Default);
             var requiredSharingBoundaries = partsList.ToDictionary(
                 part => part,
                 part =>

--- a/src/Microsoft.VisualStudio.Composition/Strings.resx
+++ b/src/Microsoft.VisualStudio.Composition/Strings.resx
@@ -159,6 +159,9 @@
   <data name="ScanningMEFAssemblies" xml:space="preserve">
     <value>Scanning MEF assemblies...</value>
   </data>
+  <data name="SharingBoundaryHasNoExportFactory" xml:space="preserve">
+    <value>The part belongs to sharing boundary "{0}", but no ExportFactory creates that boundary.</value>
+  </data>
   <data name="TypeOfMetadataViewUnsupported" xml:space="preserve">
     <value>The type {0} is an unsupported type of metadata view.</value>
     <comment>{0} is the metadata view type.</comment>

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -157,6 +157,38 @@ public class UncreatableSharingBoundaryTests
         Assert.IsType<SiblingScopeB>(root.FactoryB.CreateExport().Value);
     }
 
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithSiblingServiceFactories),
+        typeof(SiblingServiceA),
+        typeof(SiblingServiceB),
+        typeof(ImportManyOwnerWithNestedFactory),
+        typeof(NestedFromIncompatibleImportMany),
+        InvalidConfiguration = true)]
+    public void ImportManyAcrossSiblingScopesDoesNotEnableNestedFactory(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(NestedFromIncompatibleImportMany), Assert.Single(rootCause.Parts).Definition.Type);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithInvalidSiblingFactoryTarget),
+        typeof(ExistingScopeC),
+        typeof(TargetForScopeA),
+        typeof(UnrelatedScopeA),
+        InvalidConfiguration = true)]
+    public void FactoryTargetMustBeInstantiableInProspectiveScope(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(UnrelatedScopeA), Assert.Single(rootCause.Parts).Definition.Type);
+
+        var root = container.GetExportedValue<RootWithInvalidSiblingFactoryTarget>();
+        Assert.IsType<ExistingScopeC>(root.FactoryC.CreateExport().Value);
+    }
+
     public interface IMessageHandler { }
 
     [Export(typeof(IMessageHandler))]
@@ -288,4 +320,58 @@ public class UncreatableSharingBoundaryTests
 
     [Export, Shared("C")]
     public class UncreatableNestedScope { }
+
+    public interface ISiblingService { }
+
+    [Export, Export(typeof(ISiblingService)), Shared("serviceA")]
+    public class SiblingServiceA : ISiblingService { }
+
+    [Export, Export(typeof(ISiblingService)), Shared("serviceB")]
+    public class SiblingServiceB : ISiblingService { }
+
+    [Export, Shared]
+    public class RootWithSiblingServiceFactories
+    {
+        [Import, SharingBoundary("serviceA")]
+        public ExportFactory<SiblingServiceA> FactoryA { get; set; } = null!;
+
+        [Import, SharingBoundary("serviceB")]
+        public ExportFactory<SiblingServiceB> FactoryB { get; set; } = null!;
+    }
+
+    [Export]
+    public class ImportManyOwnerWithNestedFactory
+    {
+        [ImportMany]
+        public ICollection<ISiblingService> Services { get; set; } = null!;
+
+        [Import, SharingBoundary("nestedFromImportMany")]
+        public ExportFactory<NestedFromIncompatibleImportMany> Factory { get; set; } = null!;
+    }
+
+    [Export, Shared("nestedFromImportMany")]
+    public class NestedFromIncompatibleImportMany { }
+
+    [Export, Shared]
+    public class RootWithInvalidSiblingFactoryTarget
+    {
+        [Import, SharingBoundary("scopeC")]
+        public ExportFactory<ExistingScopeC> FactoryC { get; set; } = null!;
+
+        [Import, SharingBoundary("scopeA")]
+        public ExportFactory<TargetForScopeA> FactoryA { get; set; } = null!;
+    }
+
+    [Export, Shared("scopeC")]
+    public class ExistingScopeC { }
+
+    [Export]
+    public class TargetForScopeA
+    {
+        [Import]
+        public ExistingScopeC ScopeC { get; set; } = null!;
+    }
+
+    [Export, Shared("scopeA")]
+    public class UnrelatedScopeA { }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -261,6 +261,43 @@ public class UncreatableSharingBoundaryTests
         Assert.Contains(typeof(ScalePartWithBlockedBoundary), rejectedPartTypes);
     }
 
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithManyBoundaryFactories),
+        typeof(ScaleBoundary0),
+        typeof(ScaleBoundary1),
+        typeof(ScaleBoundary2),
+        typeof(ScaleBoundary3),
+        typeof(ScaleBoundary4),
+        typeof(ScaleBoundary5),
+        typeof(ScaleBoundary6),
+        typeof(ScaleBoundary7),
+        typeof(ScaleBoundary8),
+        typeof(ScaleBoundary9),
+        typeof(ScaleBudgetTarget),
+        typeof(ScaleMissingBoundary),
+        InvalidConfiguration = true)]
+    public void NominalFactoryForImpossiblePartIsPruned(IContainer container)
+    {
+        Assert.Null(container.GetExportedValue<RootWithManyBoundaryFactories>().BudgetFactory);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithOrderIndependentSalvage),
+        typeof(OrderIndependentServiceA),
+        typeof(OrderIndependentPartX),
+        typeof(OrderIndependentPartY),
+        typeof(OrderIndependentPartZ),
+        typeof(OrderIndependentBadPart),
+        InvalidConfiguration = true)]
+    public void BlockedOptionalExportDoesNotContributeSharingBoundary(IContainer container)
+    {
+        var root = container.GetExportedValue<RootWithOrderIndependentSalvage>();
+        Assert.IsType<OrderIndependentServiceA>(root.FactoryA.CreateExport().Value);
+        Assert.Empty(root.FactoryB.CreateExport().Value.Values);
+    }
+
     public interface IMessageHandler { }
 
     [Export(typeof(IMessageHandler))]
@@ -506,6 +543,9 @@ public class UncreatableSharingBoundaryTests
 
         [Import(AllowDefault = true), SharingBoundary("blockedAtScale")]
         public ExportFactory<BlockedScaleFactoryTarget>? BlockedFactory { get; set; }
+
+        [Import(AllowDefault = true), SharingBoundary("budget")]
+        public ExportFactory<ScaleBudgetTarget>? BudgetFactory { get; set; }
     }
 
     [Export, Shared("scale0")]
@@ -572,6 +612,9 @@ public class UncreatableSharingBoundaryTests
         public ScaleBoundary9 Boundary9 { get; set; } = null!;
     }
 
+    [Export, Shared("scaleMissing")]
+    public class ScaleMissingBoundary { }
+
     [Export, Shared("blockedAtScale")]
     public class BlockedScaleFactoryTarget
     {
@@ -611,5 +654,86 @@ public class UncreatableSharingBoundaryTests
 
         [Import]
         public ScaleBoundary9 Boundary9 { get; set; } = null!;
+    }
+
+    [Export, Shared("budget")]
+    public class ScaleBudgetTarget
+    {
+        [Import]
+        public ScaleBoundary0 Boundary0 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary1 Boundary1 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary2 Boundary2 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary3 Boundary3 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary4 Boundary4 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary5 Boundary5 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary6 Boundary6 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary7 Boundary7 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary8 Boundary8 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary9 Boundary9 { get; set; } = null!;
+
+        [Import]
+        public ScaleMissingBoundary MissingBoundary { get; set; } = null!;
+    }
+
+    [Export, Shared]
+    public class RootWithOrderIndependentSalvage
+    {
+        [Import, SharingBoundary("orderA")]
+        public ExportFactory<OrderIndependentServiceA> FactoryA { get; set; } = null!;
+
+        [Import, SharingBoundary("orderB")]
+        public ExportFactory<OrderIndependentPartX> FactoryB { get; set; } = null!;
+    }
+
+    [Export, Shared("orderA")]
+    public class OrderIndependentServiceA { }
+
+    [Export, Shared("orderB")]
+    public class OrderIndependentPartX
+    {
+        [ImportMany]
+        public ICollection<OrderIndependentPartY> Values { get; set; } = null!;
+    }
+
+    [Export]
+    public class OrderIndependentPartY
+    {
+        [Import]
+        public OrderIndependentServiceA ServiceA { get; set; } = null!;
+
+        [Import]
+        public OrderIndependentPartZ PartZ { get; set; } = null!;
+    }
+
+    [Export]
+    public class OrderIndependentPartZ
+    {
+        [Import]
+        public OrderIndependentBadPart BadPart { get; set; } = null!;
+    }
+
+    [Export]
+    public class OrderIndependentBadPart
+    {
+        [Import]
+        public IMissing Missing { get; set; } = null!;
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -112,15 +112,49 @@ public class UncreatableSharingBoundaryTests
     public void TransitivelyInvalidPartDoesNotMakeSharingBoundaryCreatable(IContainer container)
     {
         var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
-        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
-        Assert.Equal(typeof(InvalidDependency), Assert.Single(rootCause.Parts).Definition.Type);
-
-        var secondOrderRejectedPartTypes = v3Container.Configuration.CompositionErrors.Pop().Peek()
+        var rootRejectedPartTypes = v3Container.Configuration.CompositionErrors.Peek()
             .Select(error => Assert.Single(error.Parts).Definition.Type)
             .ToHashSet();
-        Assert.Equal(2, secondOrderRejectedPartTypes.Count);
-        Assert.Contains(typeof(FactoryOwnerWithInvalidDependency), secondOrderRejectedPartTypes);
-        Assert.Contains(typeof(ScopedFromTransitivelyInvalidFactory), secondOrderRejectedPartTypes);
+        Assert.Equal(2, rootRejectedPartTypes.Count);
+        Assert.Contains(typeof(InvalidDependency), rootRejectedPartTypes);
+        Assert.Contains(typeof(ScopedFromTransitivelyInvalidFactory), rootRejectedPartTypes);
+
+        var secondOrderRejections = v3Container.Configuration.CompositionErrors.Pop().Peek();
+        Assert.Equal(2, secondOrderRejections.Count);
+        Assert.All(secondOrderRejections, rejection => Assert.Equal(typeof(FactoryOwnerWithInvalidDependency), Assert.Single(rejection.Parts).Definition.Type));
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(UniqueMessageHandler),
+        typeof(ScopedMessageHandler),
+        typeof(RootWithImportManyAndValidFactory),
+        typeof(ValidScopedPart),
+        InvalidConfiguration = true)]
+    public void ImportManyPruningDoesNotInvalidateFactoryOwner(IContainer container)
+    {
+        var root = container.GetExportedValue<RootWithImportManyAndValidFactory>();
+        Assert.IsType<UniqueMessageHandler>(Assert.Single(root.Handlers));
+        Assert.IsType<ValidScopedPart>(root.Factory.CreateExport().Value);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithSiblingFactories),
+        typeof(SiblingScopeA),
+        typeof(SiblingScopeB),
+        typeof(PartRequiringSiblingScopes),
+        typeof(UncreatableNestedScope),
+        InvalidConfiguration = true)]
+    public void SiblingSharingBoundariesDoNotCombineForReachability(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(UncreatableNestedScope), Assert.Single(rootCause.Parts).Definition.Type);
+
+        var root = container.GetExportedValue<RootWithSiblingFactories>();
+        Assert.IsType<SiblingScopeA>(root.FactoryA.CreateExport().Value);
+        Assert.IsType<SiblingScopeB>(root.FactoryB.CreateExport().Value);
     }
 
     public interface IMessageHandler { }
@@ -209,4 +243,49 @@ public class UncreatableSharingBoundaryTests
 
     [Export, Shared("madeByTransitivelyInvalid")]
     public class ScopedFromTransitivelyInvalidFactory { }
+
+    [Export, Shared]
+    public class RootWithImportManyAndValidFactory
+    {
+        [ImportMany]
+        public ICollection<IMessageHandler> Handlers { get; set; } = null!;
+
+        [Import, SharingBoundary("valid")]
+        public ExportFactory<ValidScopedPart> Factory { get; set; } = null!;
+    }
+
+    [Export, Shared("valid")]
+    public class ValidScopedPart { }
+
+    [Export, Shared]
+    public class RootWithSiblingFactories
+    {
+        [Import, SharingBoundary("A")]
+        public ExportFactory<SiblingScopeA> FactoryA { get; set; } = null!;
+
+        [Import, SharingBoundary("B")]
+        public ExportFactory<SiblingScopeB> FactoryB { get; set; } = null!;
+    }
+
+    [Export, Shared("A")]
+    public class SiblingScopeA { }
+
+    [Export, Shared("B")]
+    public class SiblingScopeB { }
+
+    [Export]
+    public class PartRequiringSiblingScopes
+    {
+        [Import]
+        public SiblingScopeA ScopeA { get; set; } = null!;
+
+        [Import]
+        public SiblingScopeB ScopeB { get; set; } = null!;
+
+        [Import, SharingBoundary("C")]
+        public ExportFactory<UncreatableNestedScope> FactoryC { get; set; } = null!;
+    }
+
+    [Export, Shared("C")]
+    public class UncreatableNestedScope { }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -189,6 +189,78 @@ public class UncreatableSharingBoundaryTests
         Assert.IsType<ExistingScopeC>(root.FactoryC.CreateExport().Value);
     }
 
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithOptionalCycleFactories),
+        typeof(OptionalCycleA),
+        typeof(OptionalCycleB),
+        InvalidConfiguration = true)]
+    public void OptionalImportsAcrossSiblingScopesDoNotMutuallySalvageParts(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rejectedPartTypes = v3Container.Configuration.CompositionErrors.Peek()
+            .Select(error => Assert.Single(error.Parts).Definition.Type)
+            .ToHashSet();
+
+        Assert.Equal(2, rejectedPartTypes.Count);
+        Assert.Contains(typeof(OptionalCycleA), rejectedPartTypes);
+        Assert.Contains(typeof(OptionalCycleB), rejectedPartTypes);
+
+        var root = container.GetExportedValue<RootWithOptionalCycleFactories>();
+        Assert.Null(root.FactoryA);
+        Assert.Null(root.FactoryB);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithManyBoundaryFactories),
+        typeof(ScaleBoundary0),
+        typeof(ScaleBoundary1),
+        typeof(ScaleBoundary2),
+        typeof(ScaleBoundary3),
+        typeof(ScaleBoundary4),
+        typeof(ScaleBoundary5),
+        typeof(ScaleBoundary6),
+        typeof(ScaleBoundary7),
+        typeof(ScaleBoundary8),
+        typeof(ScaleBoundary9),
+        typeof(ScaleOrphan),
+        InvalidConfiguration = true)]
+    public void MissingBoundaryIsRejectedBeforeLargeScopeSearch(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(ScaleOrphan), Assert.Single(rootCause.Parts).Definition.Type);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithManyBoundaryFactories),
+        typeof(ScaleBoundary0),
+        typeof(ScaleBoundary1),
+        typeof(ScaleBoundary2),
+        typeof(ScaleBoundary3),
+        typeof(ScaleBoundary4),
+        typeof(ScaleBoundary5),
+        typeof(ScaleBoundary6),
+        typeof(ScaleBoundary7),
+        typeof(ScaleBoundary8),
+        typeof(ScaleBoundary9),
+        typeof(BlockedScaleFactoryTarget),
+        typeof(ScalePartWithBlockedBoundary),
+        InvalidConfiguration = true)]
+    public void BoundaryWithOnlyBlockedFactoryTargetIsRejectedBeforeLargeScopeSearch(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rejectedPartTypes = v3Container.Configuration.CompositionErrors
+            .SelectMany(batch => batch)
+            .SelectMany(error => error.Parts)
+            .Select(part => part.Definition.Type)
+            .ToHashSet();
+
+        Assert.Contains(typeof(ScalePartWithBlockedBoundary), rejectedPartTypes);
+    }
+
     public interface IMessageHandler { }
 
     [Export(typeof(IMessageHandler))]
@@ -374,4 +446,170 @@ public class UncreatableSharingBoundaryTests
 
     [Export, Shared("scopeA")]
     public class UnrelatedScopeA { }
+
+    [Export]
+    public class RootWithOptionalCycleFactories
+    {
+        [Import(AllowDefault = true), SharingBoundary("optionalCycleA")]
+        public ExportFactory<OptionalCycleA>? FactoryA { get; set; }
+
+        [Import(AllowDefault = true), SharingBoundary("optionalCycleB")]
+        public ExportFactory<OptionalCycleB>? FactoryB { get; set; }
+    }
+
+    [Export, Shared("optionalCycleA")]
+    public class OptionalCycleA
+    {
+        [Import(AllowDefault = true)]
+        public OptionalCycleB? Dependency { get; set; }
+    }
+
+    [Export, Shared("optionalCycleB")]
+    public class OptionalCycleB
+    {
+        [Import(AllowDefault = true)]
+        public OptionalCycleA? Dependency { get; set; }
+    }
+
+    [Export]
+    public class RootWithManyBoundaryFactories
+    {
+        [Import, SharingBoundary("scale0")]
+        public ExportFactory<ScaleBoundary0> Factory0 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale1")]
+        public ExportFactory<ScaleBoundary1> Factory1 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale2")]
+        public ExportFactory<ScaleBoundary2> Factory2 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale3")]
+        public ExportFactory<ScaleBoundary3> Factory3 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale4")]
+        public ExportFactory<ScaleBoundary4> Factory4 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale5")]
+        public ExportFactory<ScaleBoundary5> Factory5 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale6")]
+        public ExportFactory<ScaleBoundary6> Factory6 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale7")]
+        public ExportFactory<ScaleBoundary7> Factory7 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale8")]
+        public ExportFactory<ScaleBoundary8> Factory8 { get; set; } = null!;
+
+        [Import, SharingBoundary("scale9")]
+        public ExportFactory<ScaleBoundary9> Factory9 { get; set; } = null!;
+
+        [Import(AllowDefault = true), SharingBoundary("blockedAtScale")]
+        public ExportFactory<BlockedScaleFactoryTarget>? BlockedFactory { get; set; }
+    }
+
+    [Export, Shared("scale0")]
+    public class ScaleBoundary0 { }
+
+    [Export, Shared("scale1")]
+    public class ScaleBoundary1 { }
+
+    [Export, Shared("scale2")]
+    public class ScaleBoundary2 { }
+
+    [Export, Shared("scale3")]
+    public class ScaleBoundary3 { }
+
+    [Export, Shared("scale4")]
+    public class ScaleBoundary4 { }
+
+    [Export, Shared("scale5")]
+    public class ScaleBoundary5 { }
+
+    [Export, Shared("scale6")]
+    public class ScaleBoundary6 { }
+
+    [Export, Shared("scale7")]
+    public class ScaleBoundary7 { }
+
+    [Export, Shared("scale8")]
+    public class ScaleBoundary8 { }
+
+    [Export, Shared("scale9")]
+    public class ScaleBoundary9 { }
+
+    [Export, Shared("missingAtScale")]
+    public class ScaleOrphan
+    {
+        [Import]
+        public ScaleBoundary0 Boundary0 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary1 Boundary1 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary2 Boundary2 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary3 Boundary3 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary4 Boundary4 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary5 Boundary5 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary6 Boundary6 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary7 Boundary7 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary8 Boundary8 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary9 Boundary9 { get; set; } = null!;
+    }
+
+    [Export, Shared("blockedAtScale")]
+    public class BlockedScaleFactoryTarget
+    {
+        [Import]
+        public IMissing Missing { get; set; } = null!;
+    }
+
+    [Export, Shared("blockedAtScale")]
+    public class ScalePartWithBlockedBoundary
+    {
+        [Import]
+        public ScaleBoundary0 Boundary0 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary1 Boundary1 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary2 Boundary2 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary3 Boundary3 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary4 Boundary4 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary5 Boundary5 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary6 Boundary6 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary7 Boundary7 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary8 Boundary8 { get; set; } = null!;
+
+        [Import]
+        public ScaleBoundary9 Boundary9 { get; set; } = null!;
+    }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using Xunit;
+using MefV1 = System.ComponentModel.Composition;
 
 /// <summary>
 /// Verifies that parts in sharing boundaries that cannot be created are rejected during composition.
@@ -68,6 +69,23 @@ public class UncreatableSharingBoundaryTests
         Assert.Null(container.GetExportedValue<RootWithUnsatisfiedBoundaryFactory>().Factory);
     }
 
+    [MefFact(
+        CompositionEngines.V3EmulatingV1AndV2AtOnce | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(InferredOrphanPart),
+        typeof(OrphanPart),
+        InvalidConfiguration = true)]
+    public void InferredUncreatableSharingBoundaryRejectsPart(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rejectedPartTypes = v3Container.Configuration.CompositionErrors.Peek()
+            .Select(error => Assert.Single(error.Parts).Definition.Type)
+            .ToHashSet();
+
+        Assert.Equal(2, rejectedPartTypes.Count);
+        Assert.Contains(typeof(InferredOrphanPart), rejectedPartTypes);
+        Assert.Contains(typeof(OrphanPart), rejectedPartTypes);
+    }
+
     public interface IMessageHandler { }
 
     [Export(typeof(IMessageHandler))]
@@ -114,4 +132,11 @@ public class UncreatableSharingBoundaryTests
 
     [Export, Shared("orphan")]
     public class OrphanPart { }
+
+    [MefV1.Export, MefV1.PartCreationPolicy(MefV1.CreationPolicy.Shared)]
+    public class InferredOrphanPart
+    {
+        [MefV1.ImportMany]
+        public ICollection<OrphanPart> Parts { get; set; } = null!;
+    }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// Verifies that parts in sharing boundaries that cannot be created are rejected during composition.
+/// </summary>
+/// <remarks>
+/// These scenarios reproduce <see href="https://github.com/microsoft/vs-mef/issues/132">issue #132</see>.
+/// </remarks>
+public class UncreatableSharingBoundaryTests
+{
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(UniqueMessageHandler),
+        typeof(GlobalMessageHandler),
+        typeof(ScopedMessageHandler),
+        typeof(Helper1),
+        typeof(Helper2),
+        InvalidConfiguration = true)]
+    public void ImportManyWithUncreatableSharingBoundaryRejectsScopedExport(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(ScopedMessageHandler), Assert.Single(rootCause.Parts).Definition.Type);
+
+        var helper = container.GetExportedValue<Helper2>().LazyHelper.Value;
+        Assert.Equal(2, helper.Handlers.Count);
+        Assert.Contains(helper.Handlers, handler => handler.Value is UniqueMessageHandler);
+        Assert.Contains(helper.Handlers, handler => handler.Value is GlobalMessageHandler);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(UncreatableParent),
+        typeof(UncreatableChild),
+        InvalidConfiguration = true)]
+    public void SharingBoundaryFactoryOnUncreatablePartDoesNotMakeChildBoundaryCreatable(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rejectedPartTypes = v3Container.Configuration.CompositionErrors.Peek()
+            .Select(error => Assert.Single(error.Parts).Definition.Type)
+            .ToHashSet();
+
+        Assert.Equal(2, rejectedPartTypes.Count);
+        Assert.Contains(typeof(UncreatableParent), rejectedPartTypes);
+        Assert.Contains(typeof(UncreatableChild), rejectedPartTypes);
+    }
+
+    public interface IMessageHandler { }
+
+    [Export(typeof(IMessageHandler))]
+    public class UniqueMessageHandler : IMessageHandler { }
+
+    [Export(typeof(IMessageHandler)), Shared]
+    public class GlobalMessageHandler : IMessageHandler { }
+
+    [Export(typeof(IMessageHandler)), Shared("somewhere")]
+    public class ScopedMessageHandler : IMessageHandler { }
+
+    [Export]
+    public class Helper1
+    {
+        [ImportMany]
+        public ICollection<Lazy<IMessageHandler>> Handlers { get; set; } = null!;
+    }
+
+    [Export]
+    public class Helper2
+    {
+        [Import]
+        public Lazy<Helper1> LazyHelper { get; set; } = null!;
+    }
+
+    [Export, Shared("parent")]
+    public class UncreatableParent
+    {
+        [Import, SharingBoundary("child")]
+        public ExportFactory<UncreatableChild> ChildFactory { get; set; } = null!;
+    }
+
+    [Export, Shared("child")]
+    public class UncreatableChild { }
+}

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -54,6 +54,20 @@ public class UncreatableSharingBoundaryTests
         Assert.Contains(typeof(UncreatableChild), rejectedPartTypes);
     }
 
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(RootWithUnsatisfiedBoundaryFactory),
+        typeof(OrphanPart),
+        InvalidConfiguration = true)]
+    public void UnsatisfiedExportFactoryDoesNotMakeSharingBoundaryCreatable(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(OrphanPart), Assert.Single(rootCause.Parts).Definition.Type);
+
+        Assert.Null(container.GetExportedValue<RootWithUnsatisfiedBoundaryFactory>().Factory);
+    }
+
     public interface IMessageHandler { }
 
     [Export(typeof(IMessageHandler))]
@@ -88,4 +102,16 @@ public class UncreatableSharingBoundaryTests
 
     [Export, Shared("child")]
     public class UncreatableChild { }
+
+    public interface IMissing { }
+
+    [Export]
+    public class RootWithUnsatisfiedBoundaryFactory
+    {
+        [Import(AllowDefault = true), SharingBoundary("orphan")]
+        public ExportFactory<IMissing>? Factory { get; set; }
+    }
+
+    [Export, Shared("orphan")]
+    public class OrphanPart { }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/UncreatableSharingBoundaryTests.cs
@@ -86,6 +86,43 @@ public class UncreatableSharingBoundaryTests
         Assert.Contains(typeof(OrphanPart), rejectedPartTypes);
     }
 
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(InvalidFactoryOwner),
+        typeof(ScopedFromInvalidFactory),
+        InvalidConfiguration = true)]
+    public void InvalidPartDoesNotMakeSharingBoundaryCreatable(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rejectedPartTypes = v3Container.Configuration.CompositionErrors.Peek()
+            .Select(error => Assert.Single(error.Parts).Definition.Type)
+            .ToHashSet();
+
+        Assert.Equal(2, rejectedPartTypes.Count);
+        Assert.Contains(typeof(InvalidFactoryOwner), rejectedPartTypes);
+        Assert.Contains(typeof(ScopedFromInvalidFactory), rejectedPartTypes);
+    }
+
+    [MefFact(
+        CompositionEngines.V3EmulatingV2 | CompositionEngines.V3AllowConfigurationWithErrors,
+        typeof(InvalidDependency),
+        typeof(FactoryOwnerWithInvalidDependency),
+        typeof(ScopedFromTransitivelyInvalidFactory),
+        InvalidConfiguration = true)]
+    public void TransitivelyInvalidPartDoesNotMakeSharingBoundaryCreatable(IContainer container)
+    {
+        var v3Container = Assert.IsType<TestUtilities.V3ContainerWrapper>(container);
+        var rootCause = Assert.Single(v3Container.Configuration.CompositionErrors.Peek());
+        Assert.Equal(typeof(InvalidDependency), Assert.Single(rootCause.Parts).Definition.Type);
+
+        var secondOrderRejectedPartTypes = v3Container.Configuration.CompositionErrors.Pop().Peek()
+            .Select(error => Assert.Single(error.Parts).Definition.Type)
+            .ToHashSet();
+        Assert.Equal(2, secondOrderRejectedPartTypes.Count);
+        Assert.Contains(typeof(FactoryOwnerWithInvalidDependency), secondOrderRejectedPartTypes);
+        Assert.Contains(typeof(ScopedFromTransitivelyInvalidFactory), secondOrderRejectedPartTypes);
+    }
+
     public interface IMessageHandler { }
 
     [Export(typeof(IMessageHandler))]
@@ -139,4 +176,37 @@ public class UncreatableSharingBoundaryTests
         [MefV1.ImportMany]
         public ICollection<OrphanPart> Parts { get; set; } = null!;
     }
+
+    [Export]
+    public class InvalidFactoryOwner
+    {
+        [Import]
+        public IMissing Missing { get; set; } = null!;
+
+        [Import, SharingBoundary("madeByInvalid")]
+        public ExportFactory<ScopedFromInvalidFactory> Factory { get; set; } = null!;
+    }
+
+    [Export, Shared("madeByInvalid")]
+    public class ScopedFromInvalidFactory { }
+
+    [Export]
+    public class InvalidDependency
+    {
+        [Import]
+        public IMissing Missing { get; set; } = null!;
+    }
+
+    [Export]
+    public class FactoryOwnerWithInvalidDependency
+    {
+        [Import]
+        public InvalidDependency InvalidDependency { get; set; } = null!;
+
+        [Import, SharingBoundary("madeByTransitivelyInvalid")]
+        public ExportFactory<ScopedFromTransitivelyInvalidFactory> Factory { get; set; } = null!;
+    }
+
+    [Export, Shared("madeByTransitivelyInvalid")]
+    public class ScopedFromTransitivelyInvalidFactory { }
 }


### PR DESCRIPTION
Named sharing-boundary exports can currently remain in an otherwise valid composition even when no reachable `ExportFactory` can create their scope. Lazy imports then expose exports that fail only when evaluated at runtime, making the underlying composition problem difficult to diagnose.

Detect creatable sharing boundaries from the root composition using a fixed-point traversal. Parts assigned to unreachable boundaries are now reported in `CompositionErrors` and removed by stable-composition salvage, allowing `ImportMany` to retain only usable exports. Regression coverage includes the original lazy `ImportMany` scenario and nested boundaries whose apparent factory belongs to an unreachable parent scope.

Fixes #132