### PR TITLE
Add opt-in compiled activation plans

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -4,7 +4,7 @@ This document records performance investigations, implemented optimizations, and
 
 ## Activation benchmarks
 
-`test/Microsoft.VisualStudio.Composition.Benchmarks/ActivationBenchmarks.cs` covers six steady-state activation shapes:
+`test/Microsoft.VisualStudio.Composition.Benchmarks/ActivationBenchmarks.cs` covers six steady-state activation shapes with expression compilation both disabled and enabled:
 
 - Retrieval of a shared part.
 - Activation of a non-shared part without imports.
@@ -36,7 +36,10 @@ These changes primarily improve shared export retrieval and simple non-shared ac
 
 The `perf/compiled-activation-plans` branch preserves the expression-compilation work separately. It adds:
 
-- Compiled constructor delegates for repeatedly activated non-shared parts.
+- An explicit `EnableActivationExpressionCompilation` export provider factory option. Compilation is disabled by default.
+- Compiled constructor delegates only for repeatedly activated non-shared parts and parts shared within named sharing boundaries.
+- Factory-scoped activation counts and delegate caches so repeated sharing-boundary instances can amortize compilation.
+- Tiering that keeps the first activation on the reflection path and compiles a constructor only when it is activated again.
 - Compiled property and field setters.
 - Recursive direct activation plans for supported acyclic non-shared graphs.
 - Direct construction of constructor imports, property imports, and array or `IEnumerable<T>` imports.
@@ -45,18 +48,18 @@ Unsupported cases fall back to the normal lifecycle engine. These include cycles
 
 The compiled approach substantially improves throughput and allocations, but it also creates many additional generated methods that must be JIT-compiled. A short BenchmarkDotNet run on one machine produced the following indicative results:
 
-| Scenario | Without compiled activation | With compiled activation |
+| Scenario | Compilation disabled | Compilation enabled |
 | --- | ---: | ---: |
-| Shared | 15.62 ns, 0 B | 17.57 ns, 0 B |
-| Simple non-shared | 477.01 ns, 160 B | 30.86 ns, 24 B |
-| Constructor imports | 1,732.26 ns, 712 B | 61.97 ns, 88 B |
-| Complex constructor graph | 7,605.75 ns, 3,176 B | 246.24 ns, 408 B |
-| Property imports | 5,661.30 ns, 2,440 B | 115.68 ns, 136 B |
-| `ImportMany` | 3,772.01 ns, 1,440 B | 227.34 ns, 240 B |
+| Shared | 15.30 ns, 0 B | 16.10 ns, 0 B |
+| Simple non-shared | 414.60 ns, 160 B | 31.81 ns, 24 B |
+| Constructor imports | 1,542.92 ns, 712 B | 58.01 ns, 88 B |
+| Complex constructor graph | 7,273.72 ns, 3,176 B | 219.41 ns, 408 B |
+| Property imports | 5,655.45 ns, 2,440 B | 122.89 ns, 136 B |
+| `ImportMany` | 3,756.29 ns, 1,440 B | 235.00 ns, 240 B |
 
 These numbers came from separate BenchmarkDotNet short runs and are intended to show the magnitude of the tradeoff, not to establish release-quality baselines.
 
-Compiling activation for an application-wide shared part is generally unattractive because it increases startup and JIT cost for an operation that normally runs only once. Compilation is more likely to pay for:
+Application-wide shared parts are excluded from compilation because they normally activate only once. Compilation is limited to:
 
 - Non-shared parts that may be activated repeatedly.
 - Parts shared within a sharing boundary that is instantiated repeatedly.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -40,22 +40,27 @@ The `perf/compiled-activation-plans` branch preserves the expression-compilation
 - Compiled constructor delegates only for repeatedly activated non-shared parts and parts shared within named sharing boundaries.
 - Factory-scoped activation counts and delegate caches so repeated sharing-boundary instances can amortize compilation.
 - Tiering that keeps the first activation on the reflection path and compiles a constructor only when it is activated again.
+- Factory-scoped, provider-independent activation plans that are reused across repeated sharing-boundary instances.
+- Plan execution against the current provider and lifecycle tracker so boundary-local sharing, cycles, and disposal ownership remain isolated.
+- Weak provider-keyed shared-value lookups so reusable plans do not retain disposed boundary instances.
+- A minimum plan size for named-boundary parts so small graphs remain on the lower-cost constructor-delegate path.
 - Compiled property and field setters.
-- Recursive direct activation plans for supported acyclic non-shared graphs.
+- Recursive direct activation plans for supported non-shared subgraphs and named-boundary roots.
 - Direct construction of constructor imports, property imports, and array or `IEnumerable<T>` imports.
 
-Unsupported cases fall back to the normal lifecycle engine. These include cycles, disposable parts, open generic parts, lazy imports, export factories, exported members, custom collections, and `OnImportsSatisfied`.
+Unsupported cases fall back to the normal lifecycle engine. These include non-shared cycles, disposable parts, open generic parts, lazy imports, export factories, exported members, custom collections, and `OnImportsSatisfied`. Shared edges continue through the lifecycle engine, preserving boundary-local sharing and property-import cycles.
 
 The compiled approach substantially improves throughput and allocations, but it also creates many additional generated methods that must be JIT-compiled. A short BenchmarkDotNet run on one machine produced the following indicative results:
 
 | Scenario | Compilation disabled | Compilation enabled |
 | --- | ---: | ---: |
-| Shared | 15.30 ns, 0 B | 16.10 ns, 0 B |
-| Simple non-shared | 414.60 ns, 160 B | 31.81 ns, 24 B |
-| Constructor imports | 1,542.92 ns, 712 B | 58.01 ns, 88 B |
-| Complex constructor graph | 7,273.72 ns, 3,176 B | 219.41 ns, 408 B |
-| Property imports | 5,655.45 ns, 2,440 B | 122.89 ns, 136 B |
-| `ImportMany` | 3,756.29 ns, 1,440 B | 235.00 ns, 240 B |
+| Shared | 15.33 ns, 0 B | 15.69 ns, 0 B |
+| Simple non-shared | 472.66 ns, 160 B | 36.32 ns, 24 B |
+| Constructor imports | 1,772.14 ns, 712 B | 69.65 ns, 88 B |
+| Complex constructor graph | 8,022.69 ns, 3,176 B | 258.23 ns, 408 B |
+| Property imports | 5,846.28 ns, 2,440 B | 596.97 ns, 136 B |
+| `ImportMany` | 4,271.04 ns, 1,440 B | 231.00 ns, 240 B |
+| Repeated complex sharing boundary | 13.81 us, 8,992 B | 10.02 us, 7,126 B |
 
 These numbers came from separate BenchmarkDotNet short runs and are intended to show the magnitude of the tradeoff, not to establish release-quality baselines.
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -44,6 +44,8 @@ The `perf/compiled-activation-plans` branch preserves the expression-compilation
 - Plan execution against the current provider and lifecycle tracker so boundary-local sharing, cycles, and disposal ownership remain isolated.
 - Weak provider-keyed shared-value lookups so reusable plans do not retain disposed boundary instances.
 - A minimum plan size for named-boundary parts so small graphs remain on the lower-cost constructor-delegate path.
+- Fused construction and member-satisfaction delegates for roots exercised repeatedly through `ExportFactory<T>` or `ExportFactory<T, TMetadata>`.
+- A maximum of 64 constructor/member operations per fused factory island.
 - Compiled property and field setters.
 - Recursive direct activation plans for supported non-shared subgraphs and named-boundary roots.
 - Direct construction of constructor imports, property imports, and array or `IEnumerable<T>` imports.
@@ -60,9 +62,11 @@ The compiled approach substantially improves throughput and allocations, but it 
 | Complex constructor graph | 8,022.69 ns, 3,176 B | 258.23 ns, 408 B |
 | Property imports | 5,846.28 ns, 2,440 B | 596.97 ns, 136 B |
 | `ImportMany` | 4,271.04 ns, 1,440 B | 231.00 ns, 240 B |
-| Repeated complex sharing boundary | 13.81 us, 8,992 B | 10.02 us, 7,126 B |
+| Repeated complex sharing boundary | 12.39 us, 8,992 B | 10.75 us, 6,406 B |
 
-These numbers came from separate BenchmarkDotNet short runs and are intended to show the magnitude of the tradeoff, not to establish release-quality baselines.
+These numbers came from separate BenchmarkDotNet short and medium runs and are intended to show the magnitude of the tradeoff, not to establish release-quality baselines.
+
+In a medium BenchmarkDotNet run, fusing the representative factory island preserved throughput within measurement noise compared with the separate-delegate implementation (10.68 us versus 10.75 us) while reducing allocations from 6.63 KB to 6.26 KB. The island requires two generated methods for its construction and member-satisfaction phases instead of eight separate constructor and setter methods. One additional small constructor delegate remains for a lifecycle-managed dependency outside the fused island.
 
 Application-wide shared parts are excluded from compilation because they normally activate only once. Compilation is limited to:
 
@@ -89,13 +93,13 @@ Expression compilation should be restricted to parts with a credible opportunity
 
 Application-wide shared parts should normally remain on the reflection path. Selection may be based on composition metadata and sharing policy rather than compiling every eligible part eagerly.
 
-### 3. Fused eager subgraphs
+### 3. Further fused eager subgraph work
 
-For a repeatedly activated root, build a typed delegate for the eager activation closure that must be created synchronously with that root. This is not the whole application graph. The closure stops at existing shared values, lazy imports, export factories, unsupported lifecycle edges, and other deferred boundaries.
+The experiment now builds typed delegates only for roots exercised repeatedly through an export factory. This is not the whole application graph. The closure stops at existing shared values, lazy imports, nested export factories, unsupported lifecycle edges, and other deferred boundaries.
 
-A fused delegate could use typed locals, direct constructor calls, direct member assignments, and typed collection creation. This can eliminate intermediate `object[]` arrays, recursive `Func<object?>` dispatch, repeated casts, and reflection-based collection assignment.
+The fused delegates use typed locals, direct constructor calls, direct member assignments, and typed collection creation. This eliminates intermediate `object[]` arrays, recursive `Func<object?>` dispatch, repeated casts, and reflection-based collection assignment within the supported island.
 
-Large plans should be segmented at sharing and lifecycle boundaries to avoid very large generated methods. Compilation may also need thresholds based on expected activation count or graph size.
+Further work could segment plans rather than rejecting islands that exceed the current operation budget, and could support more lifecycle edges without expanding the fused method excessively.
 
 ## Required measurements
 

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -243,9 +243,17 @@ namespace Microsoft.VisualStudio.Composition
         }
 
         public IExportProviderFactory CreateExportProviderFactory()
+            => this.CreateExportProviderFactory(ExportProviderFactoryOptions.None);
+
+        /// <summary>
+        /// Creates an export provider factory with runtime behavior configured by the specified options.
+        /// </summary>
+        /// <param name="options">Options that control export provider runtime behavior.</param>
+        /// <returns>The export provider factory.</returns>
+        public IExportProviderFactory CreateExportProviderFactory(ExportProviderFactoryOptions options)
         {
             var composition = RuntimeComposition.CreateRuntimeComposition(this);
-            return composition.CreateExportProviderFactory();
+            return composition.CreateExportProviderFactory(options);
         }
 
         public string? GetEffectiveSharingBoundary(ComposablePartDefinition partDefinition)

--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -245,7 +245,9 @@ namespace Microsoft.VisualStudio.Composition
         }
 
         public IExportProviderFactory CreateExportProviderFactory()
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             => this.CreateExportProviderFactory(ExportProviderFactoryOptions.None);
+#pragma warning restore VSTHRD012
 
         /// <summary>
         /// Creates an export provider factory with runtime behavior configured by the specified options.
@@ -255,7 +257,9 @@ namespace Microsoft.VisualStudio.Composition
         public IExportProviderFactory CreateExportProviderFactory(ExportProviderFactoryOptions options)
         {
             var composition = RuntimeComposition.CreateRuntimeComposition(this);
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return composition.CreateExportProviderFactory(options);
+#pragma warning restore VSTHRD012
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -73,7 +73,9 @@ namespace Microsoft.VisualStudio.Composition
 
         public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, CancellationToken cancellationToken = default(CancellationToken))
         {
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return await this.LoadExportProviderFactoryAsync(cacheStream, resolver, ExportProviderFactoryOptions.None, cancellationToken).ConfigureAwait(false);
+#pragma warning restore VSTHRD012
         }
 
         /// <summary>
@@ -87,7 +89,9 @@ namespace Microsoft.VisualStudio.Composition
         public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, ExportProviderFactoryOptions options, CancellationToken cancellationToken)
         {
             var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return runtimeComposition.CreateExportProviderFactory(options);
+#pragma warning restore VSTHRD012
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <param name="options">Options that control export provider behavior.</param>
         /// <param name="cancellationToken">A token that may cancel the operation.</param>
         /// <returns>The loaded export provider factory.</returns>
-        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, ExportProviderFactoryOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, ExportProviderFactoryOptions options, CancellationToken cancellationToken)
         {
             var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
             return runtimeComposition.CreateExportProviderFactory(options);

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -71,8 +71,21 @@ namespace Microsoft.VisualStudio.Composition
 
         public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, CancellationToken cancellationToken = default(CancellationToken))
         {
+            return await this.LoadExportProviderFactoryAsync(cacheStream, resolver, ExportProviderFactoryOptions.None, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Loads an export provider factory with optional runtime behavior enabled.
+        /// </summary>
+        /// <param name="cacheStream">The stream containing the cached composition.</param>
+        /// <param name="resolver">The resolver to use when loading the composition.</param>
+        /// <param name="options">Options that control export provider behavior.</param>
+        /// <param name="cancellationToken">A token that may cancel the operation.</param>
+        /// <returns>The loaded export provider factory.</returns>
+        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, ExportProviderFactoryOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
             var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
-            return runtimeComposition.CreateExportProviderFactory();
+            return runtimeComposition.CreateExportProviderFactory(options);
         }
 
         private class SerializationContext : SerializationContextBase

--- a/src/Microsoft.VisualStudio.Composition/ExportProviderFactoryOptions.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProviderFactoryOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition
+{
+    using System;
+
+    /// <summary>
+    /// Controls optional behavior when creating an export provider factory.
+    /// </summary>
+    [Flags]
+    public enum ExportProviderFactoryOptions
+    {
+        /// <summary>
+        /// Uses the default export provider behavior.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Enables tiered expression compilation for repeatedly activated non-shared and sharing-boundary parts.
+        /// </summary>
+        EnableActivationExpressionCompilation = 0x1,
+    }
+}

--- a/src/Microsoft.VisualStudio.Composition/ExportProviderFactoryOptions.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProviderFactoryOptions.cs
@@ -1,24 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.VisualStudio.Composition
+namespace Microsoft.VisualStudio.Composition;
+
+using System;
+
+/// <summary>
+/// Controls optional behavior when creating an export provider factory.
+/// </summary>
+[Flags]
+public enum ExportProviderFactoryOptions
 {
-    using System;
+    /// <summary>
+    /// Uses the default export provider behavior.
+    /// </summary>
+    None = 0,
 
     /// <summary>
-    /// Controls optional behavior when creating an export provider factory.
+    /// Enables tiered expression compilation for repeatedly activated non-shared and sharing-boundary parts.
     /// </summary>
-    [Flags]
-    public enum ExportProviderFactoryOptions
-    {
-        /// <summary>
-        /// Uses the default export provider behavior.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// Enables tiered expression compilation for repeatedly activated non-shared and sharing-boundary parts.
-        /// </summary>
-        EnableActivationExpressionCompilation = 0x1,
-    }
+    EnableActivationExpressionCompilation = 0x1,
 }

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Runtime.ExceptionServices;
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.Composition.Reflection;
 
@@ -702,6 +703,25 @@ namespace Microsoft.VisualStudio.Composition
         }
 
         /// <summary>
+        /// Invokes a constructor or static factory method without exposing reflection's invocation wrapper.
+        /// </summary>
+        /// <param name="ctorOrFactoryMethod">The constructor or static factory method to invoke.</param>
+        /// <param name="arguments">The invocation arguments.</param>
+        /// <returns>The constructed value.</returns>
+        internal static object InstantiateWithoutTargetInvocationException(this MethodBase ctorOrFactoryMethod, object?[] arguments)
+        {
+            try
+            {
+                return ctorOrFactoryMethod.Instantiate(arguments);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is object)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw Assumes.NotReachable();
+            }
+        }
+
+        /// <summary>
         /// Creates a delegate that invokes a constructor or static factory method.
         /// </summary>
         /// <param name="ctorOrFactoryMethod">The constructor or static factory method to invoke.</param>
@@ -793,6 +813,7 @@ namespace Microsoft.VisualStudio.Composition
                 or InvalidOperationException
                 or MemberAccessException
                 or NotSupportedException
+                or PlatformNotSupportedException
                 or TypeAccessException
                 or System.Security.SecurityException;
         }

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -701,6 +701,71 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
+        /// <summary>
+        /// Creates a delegate that invokes a constructor or static factory method.
+        /// </summary>
+        /// <param name="ctorOrFactoryMethod">The constructor or static factory method to invoke.</param>
+        /// <returns>A delegate that accepts the invocation arguments and returns the constructed value.</returns>
+        internal static Func<object?[], object?> CreateInstanceFactory(this MethodBase ctorOrFactoryMethod)
+        {
+            Requires.NotNull(ctorOrFactoryMethod, nameof(ctorOrFactoryMethod));
+
+            var arguments = Expression.Parameter(typeof(object[]), "arguments");
+            ParameterInfo[] parameters = ctorOrFactoryMethod.GetParameters();
+            var convertedArguments = new Expression[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                Expression argument = Expression.ArrayIndex(arguments, Expression.Constant(i));
+                convertedArguments[i] = ConvertInvocationValue(argument, parameters[i].ParameterType);
+            }
+
+            Expression invocation = ctorOrFactoryMethod switch
+            {
+                ConstructorInfo constructor => Expression.New(constructor, convertedArguments),
+                MethodInfo method when method.IsStatic => Expression.Call(method, convertedArguments),
+                _ => throw ThrowUnsupportedImportingConstructor(ctorOrFactoryMethod),
+            };
+
+            return Expression.Lambda<Func<object?[], object?>>(
+                Expression.Convert(invocation, typeof(object)),
+                arguments).Compile();
+        }
+
+        /// <summary>
+        /// Creates a delegate that assigns a value to an importing field or property.
+        /// </summary>
+        /// <param name="member">The importing field or property.</param>
+        /// <returns>A delegate that assigns an imported value to a part instance.</returns>
+        internal static Action<object, object?> CreateImportingMemberSetter(this MemberInfo member)
+        {
+            Requires.NotNull(member, nameof(member));
+
+            var instance = Expression.Parameter(typeof(object), "instance");
+            var value = Expression.Parameter(typeof(object), "value");
+            Expression assignment = member switch
+            {
+                PropertyInfo property => Expression.Assign(
+                    Expression.Property(Expression.Convert(instance, property.DeclaringType!), property),
+                    ConvertInvocationValue(value, property.PropertyType)),
+                FieldInfo field => Expression.Assign(
+                    Expression.Field(Expression.Convert(instance, field.DeclaringType!), field),
+                    ConvertInvocationValue(value, field.FieldType)),
+                _ => throw new NotSupportedException(),
+            };
+
+            return Expression.Lambda<Action<object, object?>>(assignment, instance, value).Compile();
+        }
+
+        private static Expression ConvertInvocationValue(Expression value, Type destinationType)
+        {
+            return destinationType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(destinationType) is null
+                ? Expression.Condition(
+                    Expression.ReferenceEqual(value, Expression.Constant(null)),
+                    Expression.Default(destinationType),
+                    Expression.Convert(value, destinationType))
+                : Expression.Convert(value, destinationType);
+        }
+
         [DoesNotReturn]
         internal static Exception ThrowUnsupportedImportingConstructor(MethodBase ctorOrFactoryMethod)
         {

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -756,6 +756,33 @@ namespace Microsoft.VisualStudio.Composition
             return Expression.Lambda<Action<object, object?>>(assignment, instance, value).Compile();
         }
 
+        internal static bool TryCompile<TDelegate>(this Expression<TDelegate> expression, [NotNullWhen(true)] out TDelegate? compiledDelegate)
+            where TDelegate : Delegate
+        {
+            Requires.NotNull(expression, nameof(expression));
+
+            try
+            {
+                compiledDelegate = expression.Compile();
+                return true;
+            }
+            catch (Exception ex) when (ex.IsExpressionCompilationFailure())
+            {
+                compiledDelegate = null;
+                return false;
+            }
+        }
+
+        internal static bool IsExpressionCompilationFailure(this Exception exception)
+        {
+            return exception is ArgumentException
+                or InvalidOperationException
+                or MemberAccessException
+                or NotSupportedException
+                or TypeAccessException
+                or System.Security.SecurityException;
+        }
+
         private static Expression ConvertInvocationValue(Expression value, Type destinationType)
         {
             return destinationType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(destinationType) is null

--- a/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
+++ b/src/Microsoft.VisualStudio.Composition/ReflectionHelpers.cs
@@ -753,7 +753,21 @@ namespace Microsoft.VisualStudio.Composition
                 _ => throw new NotSupportedException(),
             };
 
-            return Expression.Lambda<Action<object, object?>>(assignment, instance, value).Compile();
+            Expression body = Expression.Block(assignment, Expression.Empty());
+            if (member is PropertyInfo)
+            {
+                var exception = Expression.Parameter(typeof(Exception), "exception");
+                body = Expression.TryCatch(
+                    body,
+                    Expression.Catch(
+                        exception,
+                        Expression.Throw(
+                            Expression.New(
+                                typeof(TargetInvocationException).GetConstructor(new[] { typeof(Exception) })!,
+                                exception))));
+            }
+
+            return Expression.Lambda<Action<object, object?>>(body, instance, value).Compile();
         }
 
         internal static bool TryCompile<TDelegate>(this Expression<TDelegate> expression, [NotNullWhen(true)] out TDelegate? compiledDelegate)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -117,7 +117,9 @@ namespace Microsoft.VisualStudio.Composition
 
         public IExportProviderFactory CreateExportProviderFactory()
         {
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return this.CreateExportProviderFactory(ExportProviderFactoryOptions.None);
+#pragma warning restore VSTHRD012
         }
 
         /// <summary>
@@ -131,7 +133,9 @@ namespace Microsoft.VisualStudio.Composition
                 (options & ~ExportProviderFactoryOptions.EnableActivationExpressionCompilation) == 0,
                 nameof(options),
                 "Unsupported export provider factory options.");
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
             return new RuntimeExportProviderFactory(this, options);
+#pragma warning restore VSTHRD012
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -115,7 +115,21 @@ namespace Microsoft.VisualStudio.Composition
 
         public IExportProviderFactory CreateExportProviderFactory()
         {
-            return new RuntimeExportProviderFactory(this);
+            return this.CreateExportProviderFactory(ExportProviderFactoryOptions.None);
+        }
+
+        /// <summary>
+        /// Creates an export provider factory with optional runtime behavior enabled.
+        /// </summary>
+        /// <param name="options">Options that control export provider behavior.</param>
+        /// <returns>The export provider factory.</returns>
+        public IExportProviderFactory CreateExportProviderFactory(ExportProviderFactoryOptions options)
+        {
+            Requires.Argument(
+                (options & ~ExportProviderFactoryOptions.EnableActivationExpressionCompilation) == 0,
+                nameof(options),
+                "Unsupported export provider factory options.");
+            return new RuntimeExportProviderFactory(this, options);
         }
 
         public IReadOnlyCollection<RuntimeExport> GetExports(string contractName)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -12,6 +12,8 @@ namespace Microsoft.VisualStudio.Composition
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
     using Microsoft.VisualStudio.Composition.Reflection;
 
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
@@ -115,18 +117,15 @@ namespace Microsoft.VisualStudio.Composition
 
             private object? GetRuntimeExportedValue(RuntimeExportLookup lookup, Type type, out bool isFullyInitialized)
             {
-                if (lookup.TryGetDirectValueFactory(out Func<object?>? directValueFactory))
+                if (!lookup.Part!.IsShared
+                    && (lookup.TryGetDirectActivationPlan(out DirectActivationPlan? directActivationPlan)
+                        || (lookup.Export!.MemberRef is null
+                            && this.activationPlanRegistry.IsExpressionCompilationEnabled
+                            && this.activationPlanRegistry.TryGetExistingDirectActivationPlan(lookup.Part, out directActivationPlan)
+                            && lookup.SetDirectActivationPlan(directActivationPlan))))
                 {
                     isFullyInitialized = true;
-                    return directValueFactory();
-                }
-
-                if (lookup.ShouldAttemptDirectValueFactory(this.activationPlanRegistry.IsExpressionCompilationEnabled)
-                    && this.TryCreateDirectValueFactory(lookup.Part!, lookup.Export!, new HashSet<TypeRef>(), out directValueFactory))
-                {
-                    lookup.SetDirectValueFactory(directValueFactory);
-                    isFullyInitialized = true;
-                    return directValueFactory();
+                    return directActivationPlan.Activate(this, importingPartTracker: null);
                 }
 
                 isFullyInitialized = false;
@@ -152,9 +151,18 @@ namespace Microsoft.VisualStudio.Composition
 
             internal override PartLifecycleTracker CreatePartLifecycleTracker(TypeRef partType, IReadOnlyDictionary<string, object?> importMetadata, PartLifecycleTracker? nonSharedPartOwner)
             {
+                RuntimeComposition.RuntimePart part = this.composition.GetPart(partType);
+                if (this.activationPlanRegistry.IsExpressionCompilationEnabled
+                    && this.activationPlanRegistry.TryGetDirectActivationPlan(this, part, out DirectActivationPlan? activationPlan))
+                {
+                    return nonSharedPartOwner is object
+                        ? new DirectActivationRuntimePartLifecycleTracker(this, part, importMetadata, nonSharedPartOwner, activationPlan)
+                        : new DirectActivationRuntimePartLifecycleTracker(this, part, importMetadata, activationPlan);
+                }
+
                 return nonSharedPartOwner is object
-                    ? new RuntimePartLifecycleTracker(this, this.composition.GetPart(partType), importMetadata, nonSharedPartOwner)
-                    : new RuntimePartLifecycleTracker(this, this.composition.GetPart(partType), importMetadata);
+                    ? new RuntimePartLifecycleTracker(this, part, importMetadata, nonSharedPartOwner)
+                    : new RuntimePartLifecycleTracker(this, part, importMetadata);
             }
 
             private RuntimeExportLookup CreateRuntimeExportLookup(Type type, string contractName)
@@ -184,15 +192,13 @@ namespace Microsoft.VisualStudio.Composition
                     : new RuntimeExportLookup(part, matchingExport!);
             }
 
-            private bool TryCreateDirectValueFactory(
+            internal bool TryCreateDirectActivationPlan(
                 RuntimeComposition.RuntimePart part,
-                RuntimeComposition.RuntimeExport export,
                 HashSet<TypeRef> partsBeingBuilt,
-                [NotNullWhen(true)] out Func<object?>? valueFactory)
+                [NotNullWhen(true)] out DirectActivationPlan? activationPlan)
             {
-                valueFactory = null;
-                if (part.IsShared
-                    || export.MemberRef is object
+                activationPlan = null;
+                if (part.SharingBoundary?.Length == 0
                     || !part.IsInstantiable
                     || part.TypeRef.IsGenericTypeDefinition
                     || part.OnImportsSatisfiedMethodRefs.Count > 0
@@ -212,7 +218,8 @@ namespace Microsoft.VisualStudio.Composition
                     }
 
                     IReadOnlyList<RuntimeComposition.RuntimeImport> constructorImports = part.ImportingConstructorArguments;
-                    var argumentFactories = new Func<object?>[constructorImports.Count];
+                    var argumentFactories = new Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>[constructorImports.Count];
+                    int operationCount = 1;
                     for (int i = 0; i < constructorImports.Count; i++)
                     {
                         RuntimeComposition.RuntimeImport import = constructorImports[i];
@@ -233,25 +240,32 @@ namespace Microsoft.VisualStudio.Composition
                                 return false;
                             }
 
-                            Func<object?>[] elementFactories = new Func<object?>[import.SatisfyingExports.Count];
+                            Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>[] elementFactories =
+                                new Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>[import.SatisfyingExports.Count];
                             int elementIndex = 0;
                             foreach (RuntimeComposition.RuntimeExport importedExport in import.SatisfyingExports)
                             {
-                                if (!this.TryCreateDirectImportFactory(import, importedExport, partsBeingBuilt, out Func<object?>? elementFactory))
+                                if (!this.TryCreateDirectImportFactory(
+                                    import,
+                                    importedExport,
+                                    partsBeingBuilt,
+                                    out Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>? elementFactory,
+                                    out int elementOperationCount))
                                 {
                                     return false;
                                 }
 
                                 elementFactories[elementIndex++] = elementFactory;
+                                operationCount += elementOperationCount;
                             }
 
                             Type elementType = import.ImportingSiteTypeWithoutCollection;
-                            argumentFactories[i] = () =>
+                            argumentFactories[i] = (exportProvider, importingPartTracker) =>
                             {
                                 Array values = Array.CreateInstance(elementType, elementFactories.Length);
                                 for (int j = 0; j < elementFactories.Length; j++)
                                 {
-                                    values.SetValue(elementFactories[j](), j);
+                                    values.SetValue(elementFactories[j](exportProvider, importingPartTracker), j);
                                 }
 
                                 return values;
@@ -260,12 +274,18 @@ namespace Microsoft.VisualStudio.Composition
                         else
                         {
                             if (import.SatisfyingExports.Count != 1
-                                || !this.TryCreateDirectImportFactory(import, import.SatisfyingExports.First(), partsBeingBuilt, out Func<object?>? argumentFactory))
+                                || !this.TryCreateDirectImportFactory(
+                                    import,
+                                    import.SatisfyingExports.First(),
+                                    partsBeingBuilt,
+                                    out Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>? argumentFactory,
+                                    out int argumentOperationCount))
                             {
                                 return false;
                             }
 
                             argumentFactories[i] = argumentFactory;
+                            operationCount += argumentOperationCount;
                         }
                     }
 
@@ -279,71 +299,29 @@ namespace Microsoft.VisualStudio.Composition
                             || import.IsExportFactory
                             || import.IsNonSharedInstanceRequired
                             || import.SatisfyingExports.Count != 1
-                            || !this.TryCreateDirectImportFactory(import, import.SatisfyingExports.First(), partsBeingBuilt, out Func<object?>? importValueFactory))
+                            || !this.TryCreateDirectImportFactory(
+                                import,
+                                import.SatisfyingExports.First(),
+                                partsBeingBuilt,
+                                out Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>? importValueFactory,
+                                out int importOperationCount))
                         {
                             return false;
                         }
 
+                        operationCount += importOperationCount + 1;
                         memberAssignments[i] = new DirectMemberImport(
                             import,
                             importValueFactory,
                             this.GetOrCreateImportingMemberSetter(import.ImportingMember!));
                     }
 
-                    Func<object?[], object?> instanceFactory = this.GetOrCreateInstanceFactory(importingConstructorOrFactoryMethod);
-                    valueFactory = () =>
-                    {
-                        object?[] arguments = argumentFactories.Length == 0 ? EmptyObjectArray : new object?[argumentFactories.Length];
-                        for (int i = 0; i < argumentFactories.Length; i++)
-                        {
-                            arguments[i] = argumentFactories[i]();
-                        }
-
-                        object instance;
-                        try
-                        {
-                            instance = instanceFactory(arguments)!;
-                            Assumes.NotNull(instance);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new CompositionFailedException(
-                                Strings.FormatExceptionThrownByPartUnderInitialization(part.TypeRef.Resolve().FullName),
-                                ex);
-                        }
-
-                        for (int i = 0; i < memberAssignments.Length; i++)
-                        {
-                            DirectMemberImport assignment = memberAssignments[i];
-                            object? importedValue;
-                            try
-                            {
-                                importedValue = assignment.ValueFactory();
-                            }
-                            catch (CompositionFailedException ex)
-                            {
-                                throw new CompositionFailedException(
-                                    string.Format(
-                                        CultureInfo.CurrentCulture,
-                                        Strings.ErrorWhileSettingImport,
-                                        RuntimeComposition.GetDiagnosticLocation(assignment.Import)),
-                                    ex);
-                            }
-
-                            try
-                            {
-                                assignment.Setter(instance, importedValue);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw new CompositionFailedException(
-                                    Strings.FormatExceptionThrownByPartUnderInitialization(part.TypeRef.Resolve().FullName),
-                                    ex);
-                            }
-                        }
-
-                        return instance;
-                    };
+                    activationPlan = new DirectActivationPlan(
+                        part,
+                        argumentFactories,
+                        memberAssignments,
+                        this.GetOrCreateInstanceFactory(importingConstructorOrFactoryMethod),
+                        operationCount);
                     return true;
                 }
                 finally
@@ -356,9 +334,11 @@ namespace Microsoft.VisualStudio.Composition
                 RuntimeComposition.RuntimeImport import,
                 RuntimeComposition.RuntimeExport importedExport,
                 HashSet<TypeRef> partsBeingBuilt,
-                [NotNullWhen(true)] out Func<object?>? valueFactory)
+                [NotNullWhen(true)] out Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>? valueFactory,
+                out int operationCount)
             {
                 valueFactory = null;
+                operationCount = 0;
                 if (importedExport.MemberRef is object)
                 {
                     return false;
@@ -372,32 +352,44 @@ namespace Microsoft.VisualStudio.Composition
 
                 if (importedPart.IsShared)
                 {
-                    var sharedLookup = new RuntimeExportLookup(importedPart, importedExport);
-                    valueFactory = () =>
+                    var providerLookups = new ProviderScopedRuntimeExportLookup(importedPart, importedExport);
+                    valueFactory = (exportProvider, importingPartTracker) =>
                     {
-                        if (sharedLookup.TryGetSharedValue(out object? sharedValue))
+                        RuntimeExportLookup lookup = providerLookups.GetLookup(exportProvider);
+                        if (lookup.TryGetSharedValue(out object? sharedValue))
                         {
                             return sharedValue;
                         }
 
-                        sharedValue = this.GetRuntimeExportedValue(sharedLookup, import.ImportingSiteTypeWithoutCollection, out _);
-                        sharedLookup.SetSharedValue(sharedValue);
+                        sharedValue = exportProvider.GetExportedValue(import, importedExport, importingPartTracker, out PartLifecycleTracker? partLifecycle);
+                        if (partLifecycle?.State == PartLifecycleState.Final)
+                        {
+                            lookup.SetSharedValue(sharedValue);
+                        }
+
                         return sharedValue;
                     };
                     return true;
                 }
 
-                return this.TryCreateDirectValueFactory(importedPart, importedExport, partsBeingBuilt, out valueFactory);
+                if (this.TryCreateDirectActivationPlan(importedPart, partsBeingBuilt, out DirectActivationPlan? activationPlan))
+                {
+                    valueFactory = activationPlan.Activate;
+                    operationCount = activationPlan.OperationCount;
+                    return true;
+                }
+
+                return false;
             }
 
-            private Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)
+            private Lazy<Action<object, object?>> GetOrCreateImportingMemberSetter(MemberInfo member)
             {
-                return this.activationPlanRegistry.GetOrCreateImportingMemberSetter(member);
+                return this.activationPlanRegistry.GetOrCreateLazyImportingMemberSetter(member);
             }
 
-            private Func<object?[], object?> GetOrCreateInstanceFactory(MethodBase method)
+            private Lazy<Func<object?[], object?>> GetOrCreateInstanceFactory(MethodBase method)
             {
-                return this.activationPlanRegistry.GetOrCreateInstanceFactory(method);
+                return this.activationPlanRegistry.GetOrCreateLazyInstanceFactory(method);
             }
 
             internal override IMetadataViewProvider GetMetadataViewProvider(Type metadataView)
@@ -799,9 +791,98 @@ namespace Microsoft.VisualStudio.Composition
                 public object? Value { get; private set; }
             }
 
-            private readonly struct DirectMemberImport
+            internal sealed class DirectActivationPlan
             {
-                internal DirectMemberImport(RuntimeComposition.RuntimeImport import, Func<object?> valueFactory, Action<object, object?> setter)
+                private readonly Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>[] argumentFactories;
+                private readonly Lazy<Func<object?[], object?>> instanceFactory;
+                private readonly DirectMemberImport[] memberAssignments;
+                private readonly RuntimeComposition.RuntimePart part;
+
+                internal DirectActivationPlan(
+                    RuntimeComposition.RuntimePart part,
+                    Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>[] argumentFactories,
+                    DirectMemberImport[] memberAssignments,
+                    Lazy<Func<object?[], object?>> instanceFactory,
+                    int operationCount)
+                {
+                    this.part = part;
+                    this.argumentFactories = argumentFactories;
+                    this.memberAssignments = memberAssignments;
+                    this.instanceFactory = instanceFactory;
+                    this.OperationCount = operationCount;
+                }
+
+                internal int OperationCount { get; }
+
+                internal object Activate(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker)
+                {
+                    object instance = this.CreateValue(exportProvider, importingPartTracker);
+                    this.SatisfyImports(exportProvider, importingPartTracker, instance);
+                    return instance;
+                }
+
+                internal object CreateValue(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker)
+                {
+                    object?[] arguments = this.argumentFactories.Length == 0 ? EmptyObjectArray : new object?[this.argumentFactories.Length];
+                    for (int i = 0; i < this.argumentFactories.Length; i++)
+                    {
+                        arguments[i] = this.argumentFactories[i](exportProvider, importingPartTracker);
+                    }
+
+                    try
+                    {
+                        object? instance = this.instanceFactory.Value(arguments);
+                        Assumes.NotNull(instance);
+                        return instance;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new CompositionFailedException(
+                            Strings.FormatExceptionThrownByPartUnderInitialization(this.part.TypeRef.Resolve().FullName),
+                            ex);
+                    }
+                }
+
+                internal void SatisfyImports(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker, object instance)
+                {
+                    for (int i = 0; i < this.memberAssignments.Length; i++)
+                    {
+                        DirectMemberImport assignment = this.memberAssignments[i];
+                        object? importedValue;
+                        try
+                        {
+                            importedValue = assignment.ValueFactory(exportProvider, importingPartTracker);
+                        }
+                        catch (CompositionFailedException ex)
+                        {
+                            throw new CompositionFailedException(
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    Strings.ErrorWhileSettingImport,
+                                    RuntimeComposition.GetDiagnosticLocation(assignment.Import)),
+                                ex);
+                        }
+
+                        try
+                        {
+                            assignment.Setter.Value(instance, importedValue);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new CompositionFailedException(
+                                Strings.FormatExceptionThrownByPartUnderInitialization(this.part.TypeRef.Resolve().FullName),
+                                ex);
+                        }
+                    }
+                }
+            }
+
+            internal readonly struct DirectMemberImport
+            {
+                internal DirectMemberImport(
+                    RuntimeComposition.RuntimeImport import,
+                    Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?> valueFactory,
+                    Lazy<Action<object, object?>> setter)
                 {
                     this.Import = import;
                     this.ValueFactory = valueFactory;
@@ -810,17 +891,66 @@ namespace Microsoft.VisualStudio.Composition
 
                 internal RuntimeComposition.RuntimeImport Import { get; }
 
-                internal Action<object, object?> Setter { get; }
+                internal Lazy<Action<object, object?>> Setter { get; }
 
-                internal Func<object?> ValueFactory { get; }
+                internal Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?> ValueFactory { get; }
+            }
+
+            private sealed class ProviderScopedRuntimeExportLookup
+            {
+                private readonly ConditionalWeakTable<RuntimeExportProvider, RuntimeExportLookup> providerLookups = new();
+                private readonly RuntimeComposition.RuntimeExport export;
+                private readonly RuntimeComposition.RuntimePart part;
+                private FirstProviderLookup? firstProviderLookup;
+
+                internal ProviderScopedRuntimeExportLookup(RuntimeComposition.RuntimePart part, RuntimeComposition.RuntimeExport export)
+                {
+                    this.part = part;
+                    this.export = export;
+                }
+
+                internal RuntimeExportLookup GetLookup(RuntimeExportProvider exportProvider)
+                {
+                    FirstProviderLookup? firstLookup = Volatile.Read(ref this.firstProviderLookup);
+                    if (firstLookup is null)
+                    {
+                        RuntimeExportLookup lookup = this.providerLookups.GetValue(
+                            exportProvider,
+                            _ => new RuntimeExportLookup(this.part, this.export));
+                        var newFirstLookup = new FirstProviderLookup(exportProvider, lookup);
+                        firstLookup = Interlocked.CompareExchange(ref this.firstProviderLookup, newFirstLookup, null) ?? newFirstLookup;
+                    }
+
+                    if (firstLookup.ExportProvider.TryGetTarget(out RuntimeExportProvider? firstProvider)
+                        && ReferenceEquals(firstProvider, exportProvider)
+                        && firstLookup.Lookup.TryGetTarget(out RuntimeExportLookup? firstProviderRuntimeLookup))
+                    {
+                        return firstProviderRuntimeLookup;
+                    }
+
+                    return this.providerLookups.GetValue(
+                        exportProvider,
+                        _ => new RuntimeExportLookup(this.part, this.export));
+                }
+
+                private sealed class FirstProviderLookup
+                {
+                    internal FirstProviderLookup(RuntimeExportProvider exportProvider, RuntimeExportLookup lookup)
+                    {
+                        this.ExportProvider = new WeakReference<RuntimeExportProvider>(exportProvider);
+                        this.Lookup = new WeakReference<RuntimeExportLookup>(lookup);
+                    }
+
+                    internal WeakReference<RuntimeExportProvider> ExportProvider { get; }
+
+                    internal WeakReference<RuntimeExportLookup> Lookup { get; }
+                }
             }
 
             private sealed class RuntimeExportLookup
             {
                 internal static readonly RuntimeExportLookup Unsupported = new RuntimeExportLookup();
-                private int directValueFactoryActivationCount;
-                private int directValueFactoryAttempted;
-                private volatile Func<object?>? directValueFactory;
+                private volatile DirectActivationPlan? directActivationPlan;
                 private volatile bool hasSharedValue;
                 private object? sharedValue;
 
@@ -861,32 +991,21 @@ namespace Microsoft.VisualStudio.Composition
                     }
                 }
 
-                internal bool ShouldAttemptDirectValueFactory(bool expressionCompilationEnabled)
+                internal bool SetDirectActivationPlan(DirectActivationPlan activationPlan)
                 {
-                    if (!expressionCompilationEnabled || this.Part!.IsShared)
-                    {
-                        return false;
-                    }
-
-                    int activationCount = Interlocked.Increment(ref this.directValueFactoryActivationCount);
-                    return activationCount >= ActivationExpressionCompilationThreshold
-                        && Interlocked.CompareExchange(ref this.directValueFactoryAttempted, 1, 0) == 0;
+                    this.directActivationPlan = activationPlan;
+                    return true;
                 }
 
-                internal void SetDirectValueFactory(Func<object?> valueFactory)
+                internal bool TryGetDirectActivationPlan([NotNullWhen(true)] out DirectActivationPlan? activationPlan)
                 {
-                    this.directValueFactory = valueFactory;
-                }
-
-                internal bool TryGetDirectValueFactory([NotNullWhen(true)] out Func<object?>? valueFactory)
-                {
-                    valueFactory = this.directValueFactory;
-                    return valueFactory is object;
+                    activationPlan = this.directActivationPlan;
+                    return activationPlan is object;
                 }
             }
 
             [DebuggerDisplay("{" + nameof(partDefinition) + "." + nameof(RuntimeComposition.RuntimePart.TypeRef) + "." + nameof(TypeRef.ResolvedType) + ".FullName,nq} ({State})")]
-            private class RuntimePartLifecycleTracker : PartLifecycleTracker
+            internal class RuntimePartLifecycleTracker : PartLifecycleTracker
             {
                 private readonly RuntimeComposition.RuntimePart partDefinition;
                 private readonly IReadOnlyDictionary<string, object?> importMetadata;
@@ -1045,6 +1164,42 @@ namespace Microsoft.VisualStudio.Composition
                     return new CompositionFailedException(
                         Strings.FormatExceptionThrownByPartUnderInitialization(this.PartType.FullName),
                         ex.InnerException);
+                }
+            }
+
+            private sealed class DirectActivationRuntimePartLifecycleTracker : RuntimePartLifecycleTracker
+            {
+                private readonly DirectActivationPlan activationPlan;
+
+                internal DirectActivationRuntimePartLifecycleTracker(
+                    RuntimeExportProvider owningExportProvider,
+                    RuntimeComposition.RuntimePart partDefinition,
+                    IReadOnlyDictionary<string, object?> importMetadata,
+                    DirectActivationPlan activationPlan)
+                    : base(owningExportProvider, partDefinition, importMetadata)
+                {
+                    this.activationPlan = activationPlan;
+                }
+
+                internal DirectActivationRuntimePartLifecycleTracker(
+                    RuntimeExportProvider owningExportProvider,
+                    RuntimeComposition.RuntimePart partDefinition,
+                    IReadOnlyDictionary<string, object?> importMetadata,
+                    PartLifecycleTracker nonSharedPartOwner,
+                    DirectActivationPlan activationPlan)
+                    : base(owningExportProvider, partDefinition, importMetadata, nonSharedPartOwner)
+                {
+                    this.activationPlan = activationPlan;
+                }
+
+                protected override object CreateValue()
+                {
+                    return this.activationPlan.CreateValue(this.OwningExportProvider, this);
+                }
+
+                protected override void SatisfyImports()
+                {
+                    this.activationPlan.SatisfyImports(this.OwningExportProvider, this, this.Value!);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -1614,6 +1614,7 @@ namespace Microsoft.VisualStudio.Composition
                             out Func<object?[], object?>? instanceFactory)
                             ? instanceFactory!(ctorArgs)
                             : importingConstructorOrFactoryMethod.Instantiate(ctorArgs);
+                        Assumes.NotNull(part);
                         return part;
                     }
                     catch (Exception ex)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -370,6 +370,23 @@ namespace Microsoft.VisualStudio.Composition
                 int maximumOperationCount,
                 [NotNullWhen(true)] out DirectActivationPlan? activationPlan)
             {
+                try
+                {
+                    return this.TryCreateFusedActivationPlanCore(part, minimumOperationCount, maximumOperationCount, out activationPlan);
+                }
+                catch (Exception ex) when (ex.IsExpressionCompilationFailure())
+                {
+                    activationPlan = null;
+                    return false;
+                }
+            }
+
+            private bool TryCreateFusedActivationPlanCore(
+                RuntimeComposition.RuntimePart part,
+                int minimumOperationCount,
+                int maximumOperationCount,
+                [NotNullWhen(true)] out DirectActivationPlan? activationPlan)
+            {
                 activationPlan = null;
                 var exportProviderParameter = Expression.Parameter(typeof(RuntimeExportProvider), "exportProvider");
                 var importingPartTrackerParameter = Expression.Parameter(typeof(RuntimePartLifecycleTracker), "importingPartTracker");
@@ -405,12 +422,15 @@ namespace Microsoft.VisualStudio.Composition
                     return false;
                 }
 
-                Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object> createValue =
+                Expression<Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>> createValueExpression =
                     Expression.Lambda<Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>>(
                         Expression.Convert(creationExpression, typeof(object)),
                         exportProviderParameter,
-                        importingPartTrackerParameter).Compile();
-                this.activationPlanRegistry.RecordFusedExpressionCompilation();
+                        importingPartTrackerParameter);
+                if (!createValueExpression.TryCompile(out Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>? createValue))
+                {
+                    return false;
+                }
 
                 Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>? satisfyImports = null;
                 if (memberAssignments.Count > 0)
@@ -422,11 +442,21 @@ namespace Microsoft.VisualStudio.Composition
                     }
 
                     satisfactionExpressions[memberAssignments.Count] = Expression.Empty();
-                    satisfyImports = Expression.Lambda<Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>>(
-                        Expression.Block(satisfactionExpressions),
-                        exportProviderParameter,
-                        importingPartTrackerParameter,
-                        instanceParameter).Compile();
+                    Expression<Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>> satisfyImportsExpression =
+                        Expression.Lambda<Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>>(
+                            Expression.Block(satisfactionExpressions),
+                            exportProviderParameter,
+                            importingPartTrackerParameter,
+                            instanceParameter);
+                    if (!satisfyImportsExpression.TryCompile(out satisfyImports))
+                    {
+                        return false;
+                    }
+                }
+
+                this.activationPlanRegistry.RecordFusedExpressionCompilation();
+                if (satisfyImports is object)
+                {
                     this.activationPlanRegistry.RecordFusedExpressionCompilation();
                 }
 

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Threading;
     using Microsoft.VisualStudio.Composition.Reflection;
     using Microsoft.VisualStudio.Threading;
+    using IAsyncDisposable = System.IAsyncDisposable;
 
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
     {
@@ -240,6 +241,7 @@ namespace Microsoft.VisualStudio.Composition
                     || part.TypeRef.IsGenericTypeDefinition
                     || part.OnImportsSatisfiedMethodRefs.Count > 0
                     || typeof(IDisposable).GetTypeInfo().IsAssignableFrom(part.TypeRef.Resolve().GetTypeInfo())
+                    || typeof(IAsyncDisposable).GetTypeInfo().IsAssignableFrom(part.TypeRef.Resolve().GetTypeInfo())
                     || !partsBeingBuilt.Add(part.TypeRef))
                 {
                     return false;
@@ -485,6 +487,7 @@ namespace Microsoft.VisualStudio.Composition
                     || part.TypeRef.IsGenericTypeDefinition
                     || part.OnImportsSatisfiedMethodRefs.Count > 0
                     || typeof(IDisposable).GetTypeInfo().IsAssignableFrom(part.TypeRef.Resolve().GetTypeInfo())
+                    || typeof(IAsyncDisposable).GetTypeInfo().IsAssignableFrom(part.TypeRef.Resolve().GetTypeInfo())
                     || !partsBeingBuilt.Add(part.TypeRef))
                 {
                     return false;

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -798,12 +798,19 @@ namespace Microsoft.VisualStudio.Composition
 
             private static Expression ConvertFusedImportValue(Expression valueExpression, Type destinationType)
             {
-                return destinationType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(destinationType) is null
-                    ? Expression.Condition(
-                        Expression.ReferenceEqual(Expression.Convert(valueExpression, typeof(object)), Expression.Constant(null)),
+                if (!destinationType.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(destinationType) is object)
+                {
+                    return Expression.Convert(valueExpression, destinationType);
+                }
+
+                var valueVariable = Expression.Variable(valueExpression.Type, "value");
+                return Expression.Block(
+                    new[] { valueVariable },
+                    Expression.Assign(valueVariable, valueExpression),
+                    Expression.Condition(
+                        Expression.ReferenceEqual(Expression.Convert(valueVariable, typeof(object)), Expression.Constant(null)),
                         Expression.Default(destinationType),
-                        Expression.Convert(valueExpression, destinationType))
-                    : Expression.Convert(valueExpression, destinationType);
+                        Expression.Convert(valueVariable, destinationType)));
             }
 
             private bool TryCreateDirectImportFactory(

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
+    using System.Linq.Expressions;
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Threading;
@@ -24,6 +25,18 @@ namespace Microsoft.VisualStudio.Composition
             /// BindingFlags that find members declared exactly on the receiving type, whether they be public or not, instance or static.
             /// </summary>
             private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            private static readonly MethodInfo CreateFusedImportAssignmentExceptionMethod = typeof(RuntimeExportProvider).GetMethod(
+                nameof(CreateFusedImportAssignmentException),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            private static readonly MethodInfo CreateFusedPartActivationExceptionMethod = typeof(RuntimeExportProvider).GetMethod(
+                nameof(CreateFusedPartActivationException),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            private static readonly MethodInfo GetValueForImportSiteMethod = typeof(RuntimeExportProvider).GetMethod(
+                nameof(GetValueForImportSite),
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
 
             private static readonly RuntimeComposition.RuntimeImport MetadataViewProviderImport = new RuntimeComposition.RuntimeImport(
                 default(MemberRef),
@@ -330,6 +343,405 @@ namespace Microsoft.VisualStudio.Composition
                 }
             }
 
+            internal bool TryCreateFusedActivationPlan(
+                RuntimeComposition.RuntimePart part,
+                int minimumOperationCount,
+                int maximumOperationCount,
+                [NotNullWhen(true)] out DirectActivationPlan? activationPlan)
+            {
+                activationPlan = null;
+                var exportProviderParameter = Expression.Parameter(typeof(RuntimeExportProvider), "exportProvider");
+                var importingPartTrackerParameter = Expression.Parameter(typeof(RuntimePartLifecycleTracker), "importingPartTracker");
+                int operationCount = 0;
+                if (!this.TryCreateFusedPartExpression(
+                    part,
+                    exportProviderParameter,
+                    importingPartTrackerParameter,
+                    includeMemberImports: false,
+                    allowLifecycleFallback: true,
+                    new HashSet<TypeRef>(),
+                    ref operationCount,
+                    maximumOperationCount,
+                    out Expression? creationExpression))
+                {
+                    return false;
+                }
+
+                var instanceParameter = Expression.Parameter(typeof(object), "instance");
+                var rootPartsBeingBuilt = new HashSet<TypeRef> { part.TypeRef };
+                if (!this.TryCreateFusedMemberAssignments(
+                    part,
+                    Expression.Convert(instanceParameter, part.TypeRef.Resolve()),
+                    exportProviderParameter,
+                    importingPartTrackerParameter,
+                    rootPartsBeingBuilt,
+                    allowLifecycleFallback: true,
+                    ref operationCount,
+                    maximumOperationCount,
+                    out IReadOnlyList<Expression>? memberAssignments)
+                    || operationCount < minimumOperationCount)
+                {
+                    return false;
+                }
+
+                Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object> createValue =
+                    Expression.Lambda<Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>>(
+                        Expression.Convert(creationExpression, typeof(object)),
+                        exportProviderParameter,
+                        importingPartTrackerParameter).Compile();
+                this.activationPlanRegistry.RecordFusedExpressionCompilation();
+
+                Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>? satisfyImports = null;
+                if (memberAssignments.Count > 0)
+                {
+                    var satisfactionExpressions = new Expression[memberAssignments.Count + 1];
+                    for (int i = 0; i < memberAssignments.Count; i++)
+                    {
+                        satisfactionExpressions[i] = memberAssignments[i];
+                    }
+
+                    satisfactionExpressions[memberAssignments.Count] = Expression.Empty();
+                    satisfyImports = Expression.Lambda<Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>>(
+                        Expression.Block(satisfactionExpressions),
+                        exportProviderParameter,
+                        importingPartTrackerParameter,
+                        instanceParameter).Compile();
+                    this.activationPlanRegistry.RecordFusedExpressionCompilation();
+                }
+
+                activationPlan = new DirectActivationPlan(part, createValue, satisfyImports, operationCount);
+                return true;
+            }
+
+            private bool TryCreateFusedPartExpression(
+                RuntimeComposition.RuntimePart part,
+                ParameterExpression exportProviderParameter,
+                ParameterExpression importingPartTrackerParameter,
+                bool includeMemberImports,
+                bool allowLifecycleFallback,
+                HashSet<TypeRef> partsBeingBuilt,
+                ref int operationCount,
+                int maximumOperationCount,
+                [NotNullWhen(true)] out Expression? partExpression)
+            {
+                partExpression = null;
+                if (operationCount >= maximumOperationCount
+                    || part.SharingBoundary?.Length == 0
+                    || !part.IsInstantiable
+                    || part.TypeRef.IsGenericTypeDefinition
+                    || part.OnImportsSatisfiedMethodRefs.Count > 0
+                    || typeof(IDisposable).GetTypeInfo().IsAssignableFrom(part.TypeRef.Resolve().GetTypeInfo())
+                    || !partsBeingBuilt.Add(part.TypeRef))
+                {
+                    return false;
+                }
+
+                try
+                {
+                    if (part.ImportingConstructorOrFactoryMethod is not ConstructorInfo constructor
+                        || constructor.ContainsGenericParameters)
+                    {
+                        return false;
+                    }
+
+                    IReadOnlyList<RuntimeComposition.RuntimeImport> constructorImports = part.ImportingConstructorArguments;
+                    ParameterInfo[] constructorParameters = constructor.GetParameters();
+                    var constructorArguments = new ParameterExpression[constructorImports.Count];
+                    var variables = new List<ParameterExpression>(constructorImports.Count + 1);
+                    var expressions = new List<Expression>(constructorImports.Count + part.ImportingMembers.Count + 2);
+                    for (int i = 0; i < constructorImports.Count; i++)
+                    {
+                        RuntimeComposition.RuntimeImport import = constructorImports[i];
+                        if (!this.TryCreateFusedImportExpression(
+                            import,
+                            exportProviderParameter,
+                            importingPartTrackerParameter,
+                            partsBeingBuilt,
+                            allowLifecycleFallback,
+                            ref operationCount,
+                            maximumOperationCount,
+                            out Expression? importExpression))
+                        {
+                            return false;
+                        }
+
+                        var argumentVariable = Expression.Variable(constructorParameters[i].ParameterType, "argument" + i);
+                        constructorArguments[i] = argumentVariable;
+                        variables.Add(argumentVariable);
+                        expressions.Add(Expression.Assign(
+                            argumentVariable,
+                            ConvertFusedImportValue(importExpression, constructorParameters[i].ParameterType)));
+                    }
+
+                    operationCount++;
+                    if (operationCount > maximumOperationCount)
+                    {
+                        return false;
+                    }
+
+                    Type partType = part.TypeRef.Resolve();
+                    var instanceVariable = Expression.Variable(partType, "part");
+                    variables.Add(instanceVariable);
+                    var activationException = Expression.Parameter(typeof(Exception), "activationException");
+                    expressions.Add(Expression.TryCatch(
+                        Expression.Assign(instanceVariable, Expression.New(constructor, constructorArguments)),
+                        Expression.Catch(
+                            activationException,
+                            Expression.Throw(
+                                Expression.Call(
+                                    CreateFusedPartActivationExceptionMethod,
+                                    Expression.Constant(part),
+                                    activationException),
+                                partType))));
+
+                    if (includeMemberImports)
+                    {
+                        if (!this.TryCreateFusedMemberAssignments(
+                            part,
+                            instanceVariable,
+                            exportProviderParameter,
+                            importingPartTrackerParameter,
+                            partsBeingBuilt,
+                            allowLifecycleFallback,
+                            ref operationCount,
+                            maximumOperationCount,
+                            out IReadOnlyList<Expression>? memberAssignments))
+                        {
+                            return false;
+                        }
+
+                        expressions.AddRange(memberAssignments);
+                    }
+
+                    expressions.Add(instanceVariable);
+                    partExpression = Expression.Block(variables, expressions);
+                    return true;
+                }
+                finally
+                {
+                    partsBeingBuilt.Remove(part.TypeRef);
+                }
+            }
+
+            private bool TryCreateFusedMemberAssignments(
+                RuntimeComposition.RuntimePart part,
+                Expression instanceExpression,
+                ParameterExpression exportProviderParameter,
+                ParameterExpression importingPartTrackerParameter,
+                HashSet<TypeRef> partsBeingBuilt,
+                bool allowLifecycleFallback,
+                ref int operationCount,
+                int maximumOperationCount,
+                [NotNullWhen(true)] out IReadOnlyList<Expression>? memberAssignments)
+            {
+                IReadOnlyList<RuntimeComposition.RuntimeImport> memberImports = part.ImportingMembers;
+                var assignments = new Expression[memberImports.Count];
+                for (int i = 0; i < memberImports.Count; i++)
+                {
+                    RuntimeComposition.RuntimeImport import = memberImports[i];
+                    if (import.Cardinality != ImportCardinality.ExactlyOne
+                        || (!allowLifecycleFallback && (import.IsLazy || import.IsExportFactory || import.IsNonSharedInstanceRequired))
+                        || import.SatisfyingExports.Count != 1
+                        || !this.TryCreateFusedImportExpression(
+                            import,
+                            exportProviderParameter,
+                            importingPartTrackerParameter,
+                            partsBeingBuilt,
+                            allowLifecycleFallback,
+                            ref operationCount,
+                            maximumOperationCount,
+                            out Expression? importedValueExpression))
+                    {
+                        memberAssignments = null;
+                        return false;
+                    }
+
+                    MemberInfo importingMember = import.ImportingMember!;
+                    Type importingMemberType = importingMember switch
+                    {
+                        PropertyInfo property => property.PropertyType,
+                        FieldInfo field => field.FieldType,
+                        _ => throw new NotSupportedException(),
+                    };
+                    Expression importingMemberExpression = importingMember switch
+                    {
+                        PropertyInfo property => Expression.Property(instanceExpression, property),
+                        FieldInfo field => Expression.Field(instanceExpression, field),
+                        _ => throw new NotSupportedException(),
+                    };
+                    var importedValueVariable = Expression.Variable(importingMemberType, "importedValue" + i);
+                    var importException = Expression.Parameter(typeof(CompositionFailedException), "importException");
+                    var assignmentException = Expression.Parameter(typeof(Exception), "assignmentException");
+                    assignments[i] = Expression.Block(
+                        new[] { importedValueVariable },
+                        Expression.TryCatch(
+                            Expression.Assign(
+                                importedValueVariable,
+                                ConvertFusedImportValue(importedValueExpression, importingMemberType)),
+                            Expression.Catch(
+                                importException,
+                                Expression.Throw(
+                                    Expression.Call(
+                                        CreateFusedImportAssignmentExceptionMethod,
+                                        Expression.Constant(import),
+                                        importException),
+                                    importingMemberType))),
+                        Expression.TryCatch(
+                            Expression.Assign(importingMemberExpression, importedValueVariable),
+                            Expression.Catch(
+                                assignmentException,
+                                Expression.Throw(
+                                    Expression.Call(
+                                        CreateFusedPartActivationExceptionMethod,
+                                        Expression.Constant(part),
+                                        assignmentException),
+                                    importingMemberType))));
+
+                    operationCount++;
+                    if (operationCount > maximumOperationCount)
+                    {
+                        memberAssignments = null;
+                        return false;
+                    }
+                }
+
+                memberAssignments = assignments;
+                return true;
+            }
+
+            private bool TryCreateFusedImportExpression(
+                RuntimeComposition.RuntimeImport import,
+                ParameterExpression exportProviderParameter,
+                ParameterExpression importingPartTrackerParameter,
+                HashSet<TypeRef> partsBeingBuilt,
+                bool allowLifecycleFallback,
+                ref int operationCount,
+                int maximumOperationCount,
+                [NotNullWhen(true)] out Expression? importExpression)
+            {
+                importExpression = null;
+                if (import.IsLazy || import.IsExportFactory || import.IsNonSharedInstanceRequired)
+                {
+                    if (!allowLifecycleFallback)
+                    {
+                        return false;
+                    }
+
+                    importExpression = Expression.Property(
+                        Expression.Call(
+                            exportProviderParameter,
+                            GetValueForImportSiteMethod,
+                            importingPartTrackerParameter,
+                            Expression.Constant(import)),
+                        nameof(ValueForImportSite.Value));
+                    return true;
+                }
+
+                if (import.Cardinality == ImportCardinality.ZeroOrMore)
+                {
+                    Type importingSiteType = import.ImportingSiteType;
+                    if (!importingSiteType.IsArray
+                        && (!importingSiteType.GetTypeInfo().IsGenericType
+                            || !importingSiteType.GetGenericTypeDefinition().IsEquivalentTo(typeof(IEnumerable<>))))
+                    {
+                        return false;
+                    }
+
+                    Type elementType = import.ImportingSiteTypeWithoutCollection;
+                    var elementExpressions = new Expression[import.SatisfyingExports.Count];
+                    int elementIndex = 0;
+                    foreach (RuntimeComposition.RuntimeExport importedExport in import.SatisfyingExports)
+                    {
+                        if (!this.TryCreateFusedImportElementExpression(
+                            import,
+                            importedExport,
+                            exportProviderParameter,
+                            importingPartTrackerParameter,
+                            partsBeingBuilt,
+                            ref operationCount,
+                            maximumOperationCount,
+                            out Expression? elementExpression))
+                        {
+                            return false;
+                        }
+
+                        elementExpressions[elementIndex++] = ConvertFusedImportValue(elementExpression, elementType);
+                    }
+
+                    importExpression = Expression.NewArrayInit(elementType, elementExpressions);
+                    return true;
+                }
+
+                return import.SatisfyingExports.Count == 1
+                    && this.TryCreateFusedImportElementExpression(
+                        import,
+                        import.SatisfyingExports.First(),
+                        exportProviderParameter,
+                        importingPartTrackerParameter,
+                        partsBeingBuilt,
+                        ref operationCount,
+                        maximumOperationCount,
+                        out importExpression);
+            }
+
+            private bool TryCreateFusedImportElementExpression(
+                RuntimeComposition.RuntimeImport import,
+                RuntimeComposition.RuntimeExport importedExport,
+                ParameterExpression exportProviderParameter,
+                ParameterExpression importingPartTrackerParameter,
+                HashSet<TypeRef> partsBeingBuilt,
+                ref int operationCount,
+                int maximumOperationCount,
+                [NotNullWhen(true)] out Expression? importExpression)
+            {
+                importExpression = null;
+                if (importedExport.MemberRef is object)
+                {
+                    return false;
+                }
+
+                RuntimeComposition.RuntimePart importedPart = this.composition.GetPart(importedExport);
+                if (importedPart.TypeRef.IsGenericTypeDefinition)
+                {
+                    return false;
+                }
+
+                if (importedPart.IsShared)
+                {
+                    var providerLookup = new ProviderScopedRuntimeExportLookup(import, importedPart, importedExport);
+                    MethodInfo getValueMethod = typeof(ProviderScopedRuntimeExportLookup).GetMethod(
+                        nameof(ProviderScopedRuntimeExportLookup.GetValue),
+                        BindingFlags.Instance | BindingFlags.NonPublic)!;
+                    importExpression = Expression.Call(
+                        Expression.Constant(providerLookup),
+                        getValueMethod,
+                        exportProviderParameter,
+                        importingPartTrackerParameter);
+                    return true;
+                }
+
+                return this.TryCreateFusedPartExpression(
+                    importedPart,
+                    exportProviderParameter,
+                    importingPartTrackerParameter,
+                    includeMemberImports: true,
+                    allowLifecycleFallback: false,
+                    partsBeingBuilt,
+                    ref operationCount,
+                    maximumOperationCount,
+                    out importExpression);
+            }
+
+            private static Expression ConvertFusedImportValue(Expression valueExpression, Type destinationType)
+            {
+                return destinationType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(destinationType) is null
+                    ? Expression.Condition(
+                        Expression.ReferenceEqual(Expression.Convert(valueExpression, typeof(object)), Expression.Constant(null)),
+                        Expression.Default(destinationType),
+                        Expression.Convert(valueExpression, destinationType))
+                    : Expression.Convert(valueExpression, destinationType);
+            }
+
             private bool TryCreateDirectImportFactory(
                 RuntimeComposition.RuntimeImport import,
                 RuntimeComposition.RuntimeExport importedExport,
@@ -352,23 +764,8 @@ namespace Microsoft.VisualStudio.Composition
 
                 if (importedPart.IsShared)
                 {
-                    var providerLookups = new ProviderScopedRuntimeExportLookup(importedPart, importedExport);
-                    valueFactory = (exportProvider, importingPartTracker) =>
-                    {
-                        RuntimeExportLookup lookup = providerLookups.GetLookup(exportProvider);
-                        if (lookup.TryGetSharedValue(out object? sharedValue))
-                        {
-                            return sharedValue;
-                        }
-
-                        sharedValue = exportProvider.GetExportedValue(import, importedExport, importingPartTracker, out PartLifecycleTracker? partLifecycle);
-                        if (partLifecycle?.State == PartLifecycleState.Final)
-                        {
-                            lookup.SetSharedValue(sharedValue);
-                        }
-
-                        return sharedValue;
-                    };
+                    var providerLookups = new ProviderScopedRuntimeExportLookup(import, importedPart, importedExport);
+                    valueFactory = providerLookups.GetValue;
                     return true;
                 }
 
@@ -564,8 +961,10 @@ namespace Microsoft.VisualStudio.Composition
                 Type importingSiteElementType = import.ImportingSiteElementType;
                 ImmutableHashSet<string> sharingBoundaries = import.ExportFactorySharingBoundaries.ToImmutableHashSet();
                 bool newSharingScope = sharingBoundaries.Count > 0;
+                RuntimeComposition.RuntimePart exportedPart = this.composition.GetPart(export);
                 Func<KeyValuePair<object?, IDisposable?>> valueFactory = () =>
                 {
+                    this.activationPlanRegistry.RecordExportFactoryActivation(exportedPart);
                     RuntimeExportProvider scope = newSharingScope
                         ? new RuntimeExportProvider(this.composition, this.activationPlanRegistry, this, sharingBoundaries)
                         : this;
@@ -717,6 +1116,27 @@ namespace Microsoft.VisualStudio.Composition
                 return part.TypeRef;
             }
 
+            private static Exception CreateFusedImportAssignmentException(
+                RuntimeComposition.RuntimeImport import,
+                CompositionFailedException exception)
+            {
+                return new CompositionFailedException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.ErrorWhileSettingImport,
+                        RuntimeComposition.GetDiagnosticLocation(import)),
+                    exception);
+            }
+
+            private static Exception CreateFusedPartActivationException(
+                RuntimeComposition.RuntimePart part,
+                Exception exception)
+            {
+                return new CompositionFailedException(
+                    Strings.FormatExceptionThrownByPartUnderInitialization(part.TypeRef.Resolve().FullName),
+                    exception);
+            }
+
             private static void SetImportingMember(object part, MemberInfo member, object? value)
             {
                 Requires.NotNull(part, nameof(part));
@@ -794,7 +1214,9 @@ namespace Microsoft.VisualStudio.Composition
             internal sealed class DirectActivationPlan
             {
                 private readonly Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>[] argumentFactories;
-                private readonly Lazy<Func<object?[], object?>> instanceFactory;
+                private readonly Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>? fusedCreateValue;
+                private readonly Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>? fusedSatisfyImports;
+                private readonly Lazy<Func<object?[], object?>>? instanceFactory;
                 private readonly DirectMemberImport[] memberAssignments;
                 private readonly RuntimeComposition.RuntimePart part;
 
@@ -812,6 +1234,20 @@ namespace Microsoft.VisualStudio.Composition
                     this.OperationCount = operationCount;
                 }
 
+                internal DirectActivationPlan(
+                    RuntimeComposition.RuntimePart part,
+                    Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object> createValue,
+                    Action<RuntimeExportProvider, RuntimePartLifecycleTracker?, object>? satisfyImports,
+                    int operationCount)
+                {
+                    this.part = part;
+                    this.argumentFactories = Array.Empty<Func<RuntimeExportProvider, RuntimePartLifecycleTracker?, object?>>();
+                    this.memberAssignments = Array.Empty<DirectMemberImport>();
+                    this.fusedCreateValue = createValue;
+                    this.fusedSatisfyImports = satisfyImports;
+                    this.OperationCount = operationCount;
+                }
+
                 internal int OperationCount { get; }
 
                 internal object Activate(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker)
@@ -823,6 +1259,11 @@ namespace Microsoft.VisualStudio.Composition
 
                 internal object CreateValue(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker)
                 {
+                    if (this.fusedCreateValue is object)
+                    {
+                        return this.fusedCreateValue(exportProvider, importingPartTracker);
+                    }
+
                     object?[] arguments = this.argumentFactories.Length == 0 ? EmptyObjectArray : new object?[this.argumentFactories.Length];
                     for (int i = 0; i < this.argumentFactories.Length; i++)
                     {
@@ -831,7 +1272,7 @@ namespace Microsoft.VisualStudio.Composition
 
                     try
                     {
-                        object? instance = this.instanceFactory.Value(arguments);
+                        object? instance = this.instanceFactory!.Value(arguments);
                         Assumes.NotNull(instance);
                         return instance;
                     }
@@ -845,6 +1286,12 @@ namespace Microsoft.VisualStudio.Composition
 
                 internal void SatisfyImports(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker, object instance)
                 {
+                    if (this.fusedCreateValue is object)
+                    {
+                        this.fusedSatisfyImports?.Invoke(exportProvider, importingPartTracker, instance);
+                        return;
+                    }
+
                     for (int i = 0; i < this.memberAssignments.Length; i++)
                     {
                         DirectMemberImport assignment = this.memberAssignments[i];
@@ -900,13 +1347,35 @@ namespace Microsoft.VisualStudio.Composition
             {
                 private readonly ConditionalWeakTable<RuntimeExportProvider, RuntimeExportLookup> providerLookups = new();
                 private readonly RuntimeComposition.RuntimeExport export;
+                private readonly RuntimeComposition.RuntimeImport import;
                 private readonly RuntimeComposition.RuntimePart part;
                 private FirstProviderLookup? firstProviderLookup;
 
-                internal ProviderScopedRuntimeExportLookup(RuntimeComposition.RuntimePart part, RuntimeComposition.RuntimeExport export)
+                internal ProviderScopedRuntimeExportLookup(
+                    RuntimeComposition.RuntimeImport import,
+                    RuntimeComposition.RuntimePart part,
+                    RuntimeComposition.RuntimeExport export)
                 {
+                    this.import = import;
                     this.part = part;
                     this.export = export;
+                }
+
+                internal object? GetValue(RuntimeExportProvider exportProvider, RuntimePartLifecycleTracker? importingPartTracker)
+                {
+                    RuntimeExportLookup lookup = this.GetLookup(exportProvider);
+                    if (lookup.TryGetSharedValue(out object? sharedValue))
+                    {
+                        return sharedValue;
+                    }
+
+                    sharedValue = exportProvider.GetExportedValue(this.import, this.export, importingPartTracker, out PartLifecycleTracker? partLifecycle);
+                    if (partLifecycle?.State == PartLifecycleState.Final)
+                    {
+                        lookup.SetSharedValue(sharedValue);
+                    }
+
+                    return sharedValue;
                 }
 
                 internal RuntimeExportLookup GetLookup(RuntimeExportProvider exportProvider)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -150,7 +150,8 @@ namespace Microsoft.VisualStudio.Composition
 
             private object? GetRuntimeExportedValue(RuntimeExportLookup lookup, Type type, out bool isFullyInitialized)
             {
-                if (!lookup.Part!.IsShared
+                if (this.faultCallback is null
+                    && !lookup.Part!.IsShared
                     && (lookup.TryGetDirectActivationPlan(out DirectActivationPlan? directActivationPlan)
                         || (lookup.Export!.MemberRef is null
                             && this.activationPlanRegistry.IsExpressionCompilationEnabled
@@ -185,7 +186,8 @@ namespace Microsoft.VisualStudio.Composition
             internal override PartLifecycleTracker CreatePartLifecycleTracker(TypeRef partType, IReadOnlyDictionary<string, object?> importMetadata, PartLifecycleTracker? nonSharedPartOwner)
             {
                 RuntimeComposition.RuntimePart part = this.composition.GetPart(partType);
-                if (this.activationPlanRegistry.IsExpressionCompilationEnabled
+                if (this.faultCallback is null
+                    && this.activationPlanRegistry.IsExpressionCompilationEnabled
                     && this.activationPlanRegistry.TryGetDirectActivationPlan(this, part, out DirectActivationPlan? activationPlan))
                 {
                     return nonSharedPartOwner is object
@@ -1632,10 +1634,11 @@ namespace Microsoft.VisualStudio.Composition
 
                     try
                     {
-                        object? part = this.OwningExportProvider.activationPlanRegistry.TryGetInstanceFactory(
-                            this.partDefinition,
-                            importingConstructorOrFactoryMethod,
-                            out Func<object?[], object?>? instanceFactory)
+                        object? part = this.OwningExportProvider.faultCallback is null
+                            && this.OwningExportProvider.activationPlanRegistry.TryGetInstanceFactory(
+                                this.partDefinition,
+                                importingConstructorOrFactoryMethod,
+                                out Func<object?[], object?>? instanceFactory)
                             ? instanceFactory!(ctorArgs)
                             : importingConstructorOrFactoryMethod.Instantiate(ctorArgs);
                         Assumes.NotNull(part);

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -34,30 +34,34 @@ namespace Microsoft.VisualStudio.Composition
                 metadata: ImmutableDictionary<string, object?>.Empty,
                 exportFactorySharingBoundaries: ImmutableHashSet<string>.Empty);
 
+            private readonly ActivationPlanRegistry activationPlanRegistry;
             private readonly RuntimeComposition composition;
             private readonly ReportFaultCallback? faultCallback;
-            private readonly ConcurrentDictionary<MemberInfo, Action<object, object?>> importingMemberSetterCache = new();
-            private readonly ConcurrentDictionary<MethodBase, Func<object?[], object?>> instanceFactoryCache = new();
             private readonly ConcurrentDictionary<(Type Type, string? ContractName), RuntimeExportLookup> runtimeExportLookupCache = new();
 
-            internal RuntimeExportProvider(RuntimeComposition composition, ReportFaultCallback faultCallback)
-                : this(composition)
+            internal RuntimeExportProvider(RuntimeComposition composition, ActivationPlanRegistry activationPlanRegistry, ReportFaultCallback faultCallback)
+                : this(composition, activationPlanRegistry)
             {
                 this.faultCallback = faultCallback;
             }
 
-            internal RuntimeExportProvider(RuntimeComposition composition)
+            internal RuntimeExportProvider(RuntimeComposition composition, ActivationPlanRegistry activationPlanRegistry)
                 : base(Requires.NotNull(composition, nameof(composition)).Resolver)
             {
+                Requires.NotNull(activationPlanRegistry, nameof(activationPlanRegistry));
+
                 this.composition = composition;
+                this.activationPlanRegistry = activationPlanRegistry;
             }
 
-            internal RuntimeExportProvider(RuntimeComposition composition, ExportProvider parent, ImmutableHashSet<string> freshSharingBoundaries)
+            internal RuntimeExportProvider(RuntimeComposition composition, ActivationPlanRegistry activationPlanRegistry, ExportProvider parent, ImmutableHashSet<string> freshSharingBoundaries)
                 : base(parent, freshSharingBoundaries)
             {
                 Requires.NotNull(composition, nameof(composition));
+                Requires.NotNull(activationPlanRegistry, nameof(activationPlanRegistry));
 
                 this.composition = composition;
+                this.activationPlanRegistry = activationPlanRegistry;
             }
 
             private protected override IEnumerable<ExportInfo> GetExportsCore(ImportDefinition importDefinition)
@@ -111,10 +115,18 @@ namespace Microsoft.VisualStudio.Composition
 
             private object? GetRuntimeExportedValue(RuntimeExportLookup lookup, Type type, out bool isFullyInitialized)
             {
-                if (lookup.DirectValueFactory is object)
+                if (lookup.TryGetDirectValueFactory(out Func<object?>? directValueFactory))
                 {
                     isFullyInitialized = true;
-                    return lookup.DirectValueFactory();
+                    return directValueFactory();
+                }
+
+                if (lookup.ShouldAttemptDirectValueFactory(this.activationPlanRegistry.IsExpressionCompilationEnabled)
+                    && this.TryCreateDirectValueFactory(lookup.Part!, lookup.Export!, new HashSet<TypeRef>(), out directValueFactory))
+                {
+                    lookup.SetDirectValueFactory(directValueFactory);
+                    isFullyInitialized = true;
+                    return directValueFactory();
                 }
 
                 isFullyInitialized = false;
@@ -169,7 +181,7 @@ namespace Microsoft.VisualStudio.Composition
                 RuntimeComposition.RuntimePart part = this.composition.GetPart(matchingExport!);
                 return part.TypeRef.IsGenericTypeDefinition
                     ? RuntimeExportLookup.Unsupported
-                    : new RuntimeExportLookup(this, part, matchingExport!);
+                    : new RuntimeExportLookup(part, matchingExport!);
             }
 
             private bool TryCreateDirectValueFactory(
@@ -360,7 +372,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 if (importedPart.IsShared)
                 {
-                    var sharedLookup = new RuntimeExportLookup(this, importedPart, importedExport);
+                    var sharedLookup = new RuntimeExportLookup(importedPart, importedExport);
                     valueFactory = () =>
                     {
                         if (sharedLookup.TryGetSharedValue(out object? sharedValue))
@@ -380,22 +392,12 @@ namespace Microsoft.VisualStudio.Composition
 
             private Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)
             {
-                if (!this.importingMemberSetterCache.TryGetValue(member, out Action<object, object?>? setter))
-                {
-                    setter = this.importingMemberSetterCache.GetOrAdd(member, static member => member.CreateImportingMemberSetter());
-                }
-
-                return setter;
+                return this.activationPlanRegistry.GetOrCreateImportingMemberSetter(member);
             }
 
             private Func<object?[], object?> GetOrCreateInstanceFactory(MethodBase method)
             {
-                if (!this.instanceFactoryCache.TryGetValue(method, out Func<object?[], object?>? factory))
-                {
-                    factory = this.instanceFactoryCache.GetOrAdd(method, static method => method.CreateInstanceFactory());
-                }
-
-                return factory;
+                return this.activationPlanRegistry.GetOrCreateInstanceFactory(method);
             }
 
             internal override IMetadataViewProvider GetMetadataViewProvider(Type metadataView)
@@ -573,7 +575,7 @@ namespace Microsoft.VisualStudio.Composition
                 Func<KeyValuePair<object?, IDisposable?>> valueFactory = () =>
                 {
                     RuntimeExportProvider scope = newSharingScope
-                        ? new RuntimeExportProvider(this.composition, this, sharingBoundaries)
+                        ? new RuntimeExportProvider(this.composition, this.activationPlanRegistry, this, sharingBoundaries)
                         : this;
                     object? constructedValue = scope.GetExportedValue(import, export, importingPartTracker, out PartLifecycleTracker? partLifecycle);
                     partLifecycle!.GetValueReadyToExpose();
@@ -816,6 +818,9 @@ namespace Microsoft.VisualStudio.Composition
             private sealed class RuntimeExportLookup
             {
                 internal static readonly RuntimeExportLookup Unsupported = new RuntimeExportLookup();
+                private int directValueFactoryActivationCount;
+                private int directValueFactoryAttempted;
+                private volatile Func<object?>? directValueFactory;
                 private volatile bool hasSharedValue;
                 private object? sharedValue;
 
@@ -823,12 +828,10 @@ namespace Microsoft.VisualStudio.Composition
                 {
                 }
 
-                internal RuntimeExportLookup(RuntimeExportProvider exportProvider, RuntimeComposition.RuntimePart part, RuntimeComposition.RuntimeExport export)
+                internal RuntimeExportLookup(RuntimeComposition.RuntimePart part, RuntimeComposition.RuntimeExport export)
                 {
                     this.Part = part;
                     this.Export = export;
-                    exportProvider.TryCreateDirectValueFactory(part, export, new HashSet<TypeRef>(), out Func<object?>? directValueFactory);
-                    this.DirectValueFactory = directValueFactory;
                 }
 
                 internal bool CanUseFastPath => this.Part is object;
@@ -836,8 +839,6 @@ namespace Microsoft.VisualStudio.Composition
                 internal RuntimeComposition.RuntimePart? Part { get; }
 
                 internal RuntimeComposition.RuntimeExport? Export { get; }
-
-                internal Func<object?>? DirectValueFactory { get; }
 
                 internal bool TryGetSharedValue(out object? value)
                 {
@@ -858,6 +859,29 @@ namespace Microsoft.VisualStudio.Composition
                         this.sharedValue = value;
                         this.hasSharedValue = true;
                     }
+                }
+
+                internal bool ShouldAttemptDirectValueFactory(bool expressionCompilationEnabled)
+                {
+                    if (!expressionCompilationEnabled || this.Part!.IsShared)
+                    {
+                        return false;
+                    }
+
+                    int activationCount = Interlocked.Increment(ref this.directValueFactoryActivationCount);
+                    return activationCount >= ActivationExpressionCompilationThreshold
+                        && Interlocked.CompareExchange(ref this.directValueFactoryAttempted, 1, 0) == 0;
+                }
+
+                internal void SetDirectValueFactory(Func<object?> valueFactory)
+                {
+                    this.directValueFactory = valueFactory;
+                }
+
+                internal bool TryGetDirectValueFactory([NotNullWhen(true)] out Func<object?>? valueFactory)
+                {
+                    valueFactory = this.directValueFactory;
+                    return valueFactory is object;
                 }
             }
 
@@ -945,8 +969,11 @@ namespace Microsoft.VisualStudio.Composition
 
                     try
                     {
-                        object? part = this.IsNonShared
-                            ? this.OwningExportProvider.GetOrCreateInstanceFactory(importingConstructorOrFactoryMethod)(ctorArgs)
+                        object? part = this.OwningExportProvider.activationPlanRegistry.TryGetInstanceFactory(
+                            this.partDefinition,
+                            importingConstructorOrFactoryMethod,
+                            out Func<object?[], object?>? instanceFactory)
+                            ? instanceFactory!(ctorArgs)
                             : importingConstructorOrFactoryMethod.Instantiate(ctorArgs);
                         return part;
                     }

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
@@ -35,6 +36,8 @@ namespace Microsoft.VisualStudio.Composition
 
             private readonly RuntimeComposition composition;
             private readonly ReportFaultCallback? faultCallback;
+            private readonly ConcurrentDictionary<MemberInfo, Action<object, object?>> importingMemberSetterCache = new();
+            private readonly ConcurrentDictionary<MethodBase, Func<object?[], object?>> instanceFactoryCache = new();
             private readonly ConcurrentDictionary<(Type Type, string? ContractName), RuntimeExportLookup> runtimeExportLookupCache = new();
 
             internal RuntimeExportProvider(RuntimeComposition composition, ReportFaultCallback faultCallback)
@@ -108,6 +111,12 @@ namespace Microsoft.VisualStudio.Composition
 
             private object? GetRuntimeExportedValue(RuntimeExportLookup lookup, Type type, out bool isFullyInitialized)
             {
+                if (lookup.DirectValueFactory is object)
+                {
+                    isFullyInitialized = true;
+                    return lookup.DirectValueFactory();
+                }
+
                 isFullyInitialized = false;
                 MemberInfo? exportingMember = lookup.Export!.Member;
                 if (exportingMember?.IsStatic() == true)
@@ -160,7 +169,233 @@ namespace Microsoft.VisualStudio.Composition
                 RuntimeComposition.RuntimePart part = this.composition.GetPart(matchingExport!);
                 return part.TypeRef.IsGenericTypeDefinition
                     ? RuntimeExportLookup.Unsupported
-                    : new RuntimeExportLookup(part, matchingExport!);
+                    : new RuntimeExportLookup(this, part, matchingExport!);
+            }
+
+            private bool TryCreateDirectValueFactory(
+                RuntimeComposition.RuntimePart part,
+                RuntimeComposition.RuntimeExport export,
+                HashSet<TypeRef> partsBeingBuilt,
+                [NotNullWhen(true)] out Func<object?>? valueFactory)
+            {
+                valueFactory = null;
+                if (part.IsShared
+                    || export.MemberRef is object
+                    || !part.IsInstantiable
+                    || part.TypeRef.IsGenericTypeDefinition
+                    || part.OnImportsSatisfiedMethodRefs.Count > 0
+                    || typeof(IDisposable).GetTypeInfo().IsAssignableFrom(part.TypeRef.Resolve().GetTypeInfo())
+                    || !partsBeingBuilt.Add(part.TypeRef))
+                {
+                    return false;
+                }
+
+                try
+                {
+                    MethodBase importingConstructorOrFactoryMethod = part.ImportingConstructorOrFactoryMethod!;
+                    if (importingConstructorOrFactoryMethod is not ConstructorInfo
+                        || importingConstructorOrFactoryMethod.ContainsGenericParameters)
+                    {
+                        return false;
+                    }
+
+                    IReadOnlyList<RuntimeComposition.RuntimeImport> constructorImports = part.ImportingConstructorArguments;
+                    var argumentFactories = new Func<object?>[constructorImports.Count];
+                    for (int i = 0; i < constructorImports.Count; i++)
+                    {
+                        RuntimeComposition.RuntimeImport import = constructorImports[i];
+                        if (import.IsLazy
+                            || import.IsExportFactory
+                            || import.IsNonSharedInstanceRequired)
+                        {
+                            return false;
+                        }
+
+                        if (import.Cardinality == ImportCardinality.ZeroOrMore)
+                        {
+                            Type importingSiteType = import.ImportingSiteType;
+                            if (!importingSiteType.IsArray
+                                && (!importingSiteType.GetTypeInfo().IsGenericType
+                                    || !importingSiteType.GetGenericTypeDefinition().IsEquivalentTo(typeof(IEnumerable<>))))
+                            {
+                                return false;
+                            }
+
+                            Func<object?>[] elementFactories = new Func<object?>[import.SatisfyingExports.Count];
+                            int elementIndex = 0;
+                            foreach (RuntimeComposition.RuntimeExport importedExport in import.SatisfyingExports)
+                            {
+                                if (!this.TryCreateDirectImportFactory(import, importedExport, partsBeingBuilt, out Func<object?>? elementFactory))
+                                {
+                                    return false;
+                                }
+
+                                elementFactories[elementIndex++] = elementFactory;
+                            }
+
+                            Type elementType = import.ImportingSiteTypeWithoutCollection;
+                            argumentFactories[i] = () =>
+                            {
+                                Array values = Array.CreateInstance(elementType, elementFactories.Length);
+                                for (int j = 0; j < elementFactories.Length; j++)
+                                {
+                                    values.SetValue(elementFactories[j](), j);
+                                }
+
+                                return values;
+                            };
+                        }
+                        else
+                        {
+                            if (import.SatisfyingExports.Count != 1
+                                || !this.TryCreateDirectImportFactory(import, import.SatisfyingExports.First(), partsBeingBuilt, out Func<object?>? argumentFactory))
+                            {
+                                return false;
+                            }
+
+                            argumentFactories[i] = argumentFactory;
+                        }
+                    }
+
+                    IReadOnlyList<RuntimeComposition.RuntimeImport> memberImports = part.ImportingMembers;
+                    var memberAssignments = new DirectMemberImport[memberImports.Count];
+                    for (int i = 0; i < memberImports.Count; i++)
+                    {
+                        RuntimeComposition.RuntimeImport import = memberImports[i];
+                        if (import.Cardinality != ImportCardinality.ExactlyOne
+                            || import.IsLazy
+                            || import.IsExportFactory
+                            || import.IsNonSharedInstanceRequired
+                            || import.SatisfyingExports.Count != 1
+                            || !this.TryCreateDirectImportFactory(import, import.SatisfyingExports.First(), partsBeingBuilt, out Func<object?>? importValueFactory))
+                        {
+                            return false;
+                        }
+
+                        memberAssignments[i] = new DirectMemberImport(
+                            import,
+                            importValueFactory,
+                            this.GetOrCreateImportingMemberSetter(import.ImportingMember!));
+                    }
+
+                    Func<object?[], object?> instanceFactory = this.GetOrCreateInstanceFactory(importingConstructorOrFactoryMethod);
+                    valueFactory = () =>
+                    {
+                        object?[] arguments = argumentFactories.Length == 0 ? EmptyObjectArray : new object?[argumentFactories.Length];
+                        for (int i = 0; i < argumentFactories.Length; i++)
+                        {
+                            arguments[i] = argumentFactories[i]();
+                        }
+
+                        object instance;
+                        try
+                        {
+                            instance = instanceFactory(arguments)!;
+                            Assumes.NotNull(instance);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new CompositionFailedException(
+                                Strings.FormatExceptionThrownByPartUnderInitialization(part.TypeRef.Resolve().FullName),
+                                ex);
+                        }
+
+                        for (int i = 0; i < memberAssignments.Length; i++)
+                        {
+                            DirectMemberImport assignment = memberAssignments[i];
+                            object? importedValue;
+                            try
+                            {
+                                importedValue = assignment.ValueFactory();
+                            }
+                            catch (CompositionFailedException ex)
+                            {
+                                throw new CompositionFailedException(
+                                    string.Format(
+                                        CultureInfo.CurrentCulture,
+                                        Strings.ErrorWhileSettingImport,
+                                        RuntimeComposition.GetDiagnosticLocation(assignment.Import)),
+                                    ex);
+                            }
+
+                            try
+                            {
+                                assignment.Setter(instance, importedValue);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new CompositionFailedException(
+                                    Strings.FormatExceptionThrownByPartUnderInitialization(part.TypeRef.Resolve().FullName),
+                                    ex);
+                            }
+                        }
+
+                        return instance;
+                    };
+                    return true;
+                }
+                finally
+                {
+                    partsBeingBuilt.Remove(part.TypeRef);
+                }
+            }
+
+            private bool TryCreateDirectImportFactory(
+                RuntimeComposition.RuntimeImport import,
+                RuntimeComposition.RuntimeExport importedExport,
+                HashSet<TypeRef> partsBeingBuilt,
+                [NotNullWhen(true)] out Func<object?>? valueFactory)
+            {
+                valueFactory = null;
+                if (importedExport.MemberRef is object)
+                {
+                    return false;
+                }
+
+                RuntimeComposition.RuntimePart importedPart = this.composition.GetPart(importedExport);
+                if (importedPart.TypeRef.IsGenericTypeDefinition)
+                {
+                    return false;
+                }
+
+                if (importedPart.IsShared)
+                {
+                    var sharedLookup = new RuntimeExportLookup(this, importedPart, importedExport);
+                    valueFactory = () =>
+                    {
+                        if (sharedLookup.TryGetSharedValue(out object? sharedValue))
+                        {
+                            return sharedValue;
+                        }
+
+                        sharedValue = this.GetRuntimeExportedValue(sharedLookup, import.ImportingSiteTypeWithoutCollection, out _);
+                        sharedLookup.SetSharedValue(sharedValue);
+                        return sharedValue;
+                    };
+                    return true;
+                }
+
+                return this.TryCreateDirectValueFactory(importedPart, importedExport, partsBeingBuilt, out valueFactory);
+            }
+
+            private Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)
+            {
+                if (!this.importingMemberSetterCache.TryGetValue(member, out Action<object, object?>? setter))
+                {
+                    setter = this.importingMemberSetterCache.GetOrAdd(member, static member => member.CreateImportingMemberSetter());
+                }
+
+                return setter;
+            }
+
+            private Func<object?[], object?> GetOrCreateInstanceFactory(MethodBase method)
+            {
+                if (!this.instanceFactoryCache.TryGetValue(method, out Func<object?[], object?>? factory))
+                {
+                    factory = this.instanceFactoryCache.GetOrAdd(method, static method => method.CreateInstanceFactory());
+                }
+
+                return factory;
             }
 
             internal override IMetadataViewProvider GetMetadataViewProvider(Type metadataView)
@@ -562,6 +797,22 @@ namespace Microsoft.VisualStudio.Composition
                 public object? Value { get; private set; }
             }
 
+            private readonly struct DirectMemberImport
+            {
+                internal DirectMemberImport(RuntimeComposition.RuntimeImport import, Func<object?> valueFactory, Action<object, object?> setter)
+                {
+                    this.Import = import;
+                    this.ValueFactory = valueFactory;
+                    this.Setter = setter;
+                }
+
+                internal RuntimeComposition.RuntimeImport Import { get; }
+
+                internal Action<object, object?> Setter { get; }
+
+                internal Func<object?> ValueFactory { get; }
+            }
+
             private sealed class RuntimeExportLookup
             {
                 internal static readonly RuntimeExportLookup Unsupported = new RuntimeExportLookup();
@@ -572,10 +823,12 @@ namespace Microsoft.VisualStudio.Composition
                 {
                 }
 
-                internal RuntimeExportLookup(RuntimeComposition.RuntimePart part, RuntimeComposition.RuntimeExport export)
+                internal RuntimeExportLookup(RuntimeExportProvider exportProvider, RuntimeComposition.RuntimePart part, RuntimeComposition.RuntimeExport export)
                 {
                     this.Part = part;
                     this.Export = export;
+                    exportProvider.TryCreateDirectValueFactory(part, export, new HashSet<TypeRef>(), out Func<object?>? directValueFactory);
+                    this.DirectValueFactory = directValueFactory;
                 }
 
                 internal bool CanUseFastPath => this.Part is object;
@@ -583,6 +836,8 @@ namespace Microsoft.VisualStudio.Composition
                 internal RuntimeComposition.RuntimePart? Part { get; }
 
                 internal RuntimeComposition.RuntimeExport? Export { get; }
+
+                internal Func<object?>? DirectValueFactory { get; }
 
                 internal bool TryGetSharedValue(out object? value)
                 {
@@ -690,12 +945,14 @@ namespace Microsoft.VisualStudio.Composition
 
                     try
                     {
-                        object? part = importingConstructorOrFactoryMethod.Instantiate(ctorArgs);
+                        object? part = this.IsNonShared
+                            ? this.OwningExportProvider.GetOrCreateInstanceFactory(importingConstructorOrFactoryMethod)(ctorArgs)
+                            : importingConstructorOrFactoryMethod.Instantiate(ctorArgs);
                         return part;
                     }
-                    catch (TargetInvocationException ex)
+                    catch (Exception ex)
                     {
-                        throw this.PrepareExceptionForFaultedPart(ex);
+                        throw this.PrepareExceptionForFaultedPart(ex as TargetInvocationException ?? new TargetInvocationException(ex));
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory+RuntimeExportProvider.cs
@@ -32,6 +32,10 @@ namespace Microsoft.VisualStudio.Composition
                 nameof(CreateFusedImportAssignmentException),
                 BindingFlags.Static | BindingFlags.NonPublic)!;
 
+            private static readonly MethodInfo CreateFusedMemberAssignmentExceptionMethod = typeof(RuntimeExportProvider).GetMethod(
+                nameof(CreateFusedMemberAssignmentException),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
             private static readonly MethodInfo CreateFusedPartActivationExceptionMethod = typeof(RuntimeExportProvider).GetMethod(
                 nameof(CreateFusedPartActivationException),
                 BindingFlags.Static | BindingFlags.NonPublic)!;
@@ -651,8 +655,9 @@ namespace Microsoft.VisualStudio.Composition
                                 assignmentException,
                                 Expression.Throw(
                                     Expression.Call(
-                                        CreateFusedPartActivationExceptionMethod,
+                                        CreateFusedMemberAssignmentExceptionMethod,
                                         Expression.Constant(part),
+                                        Expression.Constant(importingMember),
                                         assignmentException),
                                     importingMemberType))));
 
@@ -1212,6 +1217,16 @@ namespace Microsoft.VisualStudio.Composition
                 return new CompositionFailedException(
                     Strings.FormatExceptionThrownByPartUnderInitialization(part.TypeRef.Resolve().FullName),
                     exception);
+            }
+
+            private static Exception CreateFusedMemberAssignmentException(
+                RuntimeComposition.RuntimePart part,
+                MemberInfo importingMember,
+                Exception exception)
+            {
+                return CreateFusedPartActivationException(
+                    part,
+                    importingMember is PropertyInfo ? new TargetInvocationException(exception) : exception);
             }
 
             private static void SetImportingMember(object part, MemberInfo member, object? value)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -7,6 +7,7 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
     using System.Text;
@@ -17,6 +18,7 @@ namespace Microsoft.VisualStudio.Composition
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
     {
         private const int ActivationExpressionCompilationThreshold = 2;
+        private const int NamedBoundaryDirectActivationPlanMinimumOperationCount = 4;
 
         private readonly ActivationPlanRegistry activationPlanRegistry;
         private readonly RuntimeComposition composition;
@@ -35,6 +37,8 @@ namespace Microsoft.VisualStudio.Composition
 
         internal int ExpressionCompilationCount => this.activationPlanRegistry.ExpressionCompilationCount;
 
+        internal int DirectActivationPlanCount => this.activationPlanRegistry.DirectActivationPlanCount;
+
         public ExportProvider CreateExportProvider()
         {
             return new RuntimeExportProvider(this.composition, this.activationPlanRegistry);
@@ -51,6 +55,9 @@ namespace Microsoft.VisualStudio.Composition
             private readonly ConcurrentDictionary<MethodBase, Lazy<Func<object?[], object?>>> instanceFactories = new();
             private readonly ConcurrentDictionary<MethodBase, int> instanceFactoryActivationCounts = new();
             private readonly ConcurrentDictionary<MemberInfo, Lazy<Action<object, object?>>> importingMemberSetters = new();
+            private readonly ConcurrentDictionary<RuntimeComposition.RuntimePart, Lazy<RuntimeExportProvider.DirectActivationPlan?>> directActivationPlans = new();
+            private readonly ConcurrentDictionary<RuntimeComposition.RuntimePart, int> directActivationPlanCounts = new();
+            private int directActivationPlanCount;
             private int expressionCompilationCount;
 
             internal ActivationPlanRegistry(ExportProviderFactoryOptions options)
@@ -60,9 +67,77 @@ namespace Microsoft.VisualStudio.Composition
 
             internal int ExpressionCompilationCount => Volatile.Read(ref this.expressionCompilationCount);
 
+            internal int DirectActivationPlanCount => Volatile.Read(ref this.directActivationPlanCount);
+
             internal bool IsExpressionCompilationEnabled { get; }
 
+            internal bool TryGetDirectActivationPlan(
+                RuntimeExportProvider exportProvider,
+                RuntimeComposition.RuntimePart part,
+                [NotNullWhen(true)] out RuntimeExportProvider.DirectActivationPlan? activationPlan)
+            {
+                activationPlan = null;
+                if (!this.IsExpressionCompilationEnabled || !IsEligibleForRepeatedActivation(part))
+                {
+                    return false;
+                }
+
+                if (this.TryGetExistingDirectActivationPlan(part, out activationPlan))
+                {
+                    return true;
+                }
+
+                int activationCount = this.directActivationPlanCounts.AddOrUpdate(
+                    part,
+                    1,
+                    static (_, count) => count < ActivationExpressionCompilationThreshold ? count + 1 : count);
+                if (activationCount < ActivationExpressionCompilationThreshold)
+                {
+                    return false;
+                }
+
+                Lazy<RuntimeExportProvider.DirectActivationPlan?> lazyPlan = this.directActivationPlans.GetOrAdd(
+                    part,
+                    part => new Lazy<RuntimeExportProvider.DirectActivationPlan?>(
+                        () =>
+                        {
+                            if (exportProvider.TryCreateDirectActivationPlan(part, new HashSet<TypeRef>(), out RuntimeExportProvider.DirectActivationPlan? plan))
+                            {
+                                if (part.SharingBoundary?.Length > 0
+                                    && plan.OperationCount < NamedBoundaryDirectActivationPlanMinimumOperationCount)
+                                {
+                                    return null;
+                                }
+
+                                Interlocked.Increment(ref this.directActivationPlanCount);
+                                return plan;
+                            }
+
+                            return null;
+                        },
+                        LazyThreadSafetyMode.ExecutionAndPublication));
+                activationPlan = lazyPlan.Value;
+                return activationPlan is object;
+            }
+
+            internal bool TryGetExistingDirectActivationPlan(
+                RuntimeComposition.RuntimePart part,
+                [NotNullWhen(true)] out RuntimeExportProvider.DirectActivationPlan? activationPlan)
+            {
+                if (this.directActivationPlans.TryGetValue(part, out Lazy<RuntimeExportProvider.DirectActivationPlan?>? lazyPlan))
+                {
+                    activationPlan = lazyPlan.Value;
+                    return activationPlan is object;
+                }
+
+                activationPlan = null;
+                return false;
+            }
+
             internal Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)
+                => this.GetOrCreateLazyImportingMemberSetter(member).Value;
+
+            internal Lazy<Action<object, object?>> GetOrCreateLazyImportingMemberSetter(MemberInfo member)
             {
                 return this.importingMemberSetters.GetOrAdd(
                     member,
@@ -72,10 +147,13 @@ namespace Microsoft.VisualStudio.Composition
                             Interlocked.Increment(ref this.expressionCompilationCount);
                             return member.CreateImportingMemberSetter();
                         },
-                        LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+                        LazyThreadSafetyMode.ExecutionAndPublication));
             }
 
             internal Func<object?[], object?> GetOrCreateInstanceFactory(MethodBase method)
+                => this.GetOrCreateLazyInstanceFactory(method).Value;
+
+            internal Lazy<Func<object?[], object?>> GetOrCreateLazyInstanceFactory(MethodBase method)
             {
                 return this.instanceFactories.GetOrAdd(
                     method,
@@ -85,7 +163,7 @@ namespace Microsoft.VisualStudio.Composition
                             Interlocked.Increment(ref this.expressionCompilationCount);
                             return method.CreateInstanceFactory();
                         },
-                        LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+                        LazyThreadSafetyMode.ExecutionAndPublication));
             }
 
             internal bool TryGetInstanceFactory(RuntimeComposition.RuntimePart part, MethodBase method, out Func<object?[], object?>? factory)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -199,9 +199,6 @@ namespace Microsoft.VisualStudio.Composition
                 Interlocked.Increment(ref this.fusedExpressionCompilationCount);
             }
 
-            internal Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)
-                => this.GetOrCreateLazyImportingMemberSetter(member).Value;
-
             internal Lazy<Action<object, object?>> GetOrCreateLazyImportingMemberSetter(MemberInfo member)
             {
                 return this.importingMemberSetters.GetOrAdd(
@@ -209,14 +206,24 @@ namespace Microsoft.VisualStudio.Composition
                     member => new Lazy<Action<object, object?>>(
                         () =>
                         {
-                            Interlocked.Increment(ref this.expressionCompilationCount);
-                            return member.CreateImportingMemberSetter();
+                            try
+                            {
+                                Action<object, object?> setter = member.CreateImportingMemberSetter();
+                                Interlocked.Increment(ref this.expressionCompilationCount);
+                                return setter;
+                            }
+                            catch (Exception ex) when (ex.IsExpressionCompilationFailure())
+                            {
+                                return member switch
+                                {
+                                    PropertyInfo property => (instance, value) => property.SetValue(instance, value),
+                                    FieldInfo field => (instance, value) => field.SetValue(instance, value),
+                                    _ => throw new NotSupportedException(),
+                                };
+                            }
                         },
                         LazyThreadSafetyMode.ExecutionAndPublication));
             }
-
-            internal Func<object?[], object?> GetOrCreateInstanceFactory(MethodBase method)
-                => this.GetOrCreateLazyInstanceFactory(method).Value;
 
             internal Lazy<Func<object?[], object?>> GetOrCreateLazyInstanceFactory(MethodBase method)
             {
@@ -225,8 +232,16 @@ namespace Microsoft.VisualStudio.Composition
                     method => new Lazy<Func<object?[], object?>>(
                         () =>
                         {
-                            Interlocked.Increment(ref this.expressionCompilationCount);
-                            return method.CreateInstanceFactory();
+                            try
+                            {
+                                Func<object?[], object?> factory = method.CreateInstanceFactory();
+                                Interlocked.Increment(ref this.expressionCompilationCount);
+                                return factory;
+                            }
+                            catch (Exception ex) when (ex.IsExpressionCompilationFailure())
+                            {
+                                return arguments => method.Instantiate(arguments);
+                            }
                         },
                         LazyThreadSafetyMode.ExecutionAndPublication));
             }
@@ -254,7 +269,7 @@ namespace Microsoft.VisualStudio.Composition
                     return false;
                 }
 
-                factory = this.GetOrCreateInstanceFactory(method);
+                factory = this.GetOrCreateLazyInstanceFactory(method).Value;
                 return true;
             }
 

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.Composition
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -15,23 +16,109 @@ namespace Microsoft.VisualStudio.Composition
 
     internal partial class RuntimeExportProviderFactory : IFaultReportingExportProviderFactory
     {
+        private const int ActivationExpressionCompilationThreshold = 2;
+
+        private readonly ActivationPlanRegistry activationPlanRegistry;
         private readonly RuntimeComposition composition;
 
         internal RuntimeExportProviderFactory(RuntimeComposition composition)
+            : this(composition, ExportProviderFactoryOptions.None)
+        {
+        }
+
+        internal RuntimeExportProviderFactory(RuntimeComposition composition, ExportProviderFactoryOptions options)
         {
             Requires.NotNull(composition, nameof(composition));
             this.composition = composition;
+            this.activationPlanRegistry = new ActivationPlanRegistry(options);
         }
+
+        internal int ExpressionCompilationCount => this.activationPlanRegistry.ExpressionCompilationCount;
 
         public ExportProvider CreateExportProvider()
         {
-            return new RuntimeExportProvider(this.composition);
+            return new RuntimeExportProvider(this.composition, this.activationPlanRegistry);
         }
 
         public ExportProvider CreateExportProvider(ReportFaultCallback faultCallback)
         {
             Requires.NotNull(faultCallback, nameof(faultCallback));
-            return new RuntimeExportProvider(this.composition, faultCallback);
+            return new RuntimeExportProvider(this.composition, this.activationPlanRegistry, faultCallback);
+        }
+
+        private sealed class ActivationPlanRegistry
+        {
+            private readonly ConcurrentDictionary<MethodBase, Lazy<Func<object?[], object?>>> instanceFactories = new();
+            private readonly ConcurrentDictionary<MethodBase, int> instanceFactoryActivationCounts = new();
+            private readonly ConcurrentDictionary<MemberInfo, Lazy<Action<object, object?>>> importingMemberSetters = new();
+            private int expressionCompilationCount;
+
+            internal ActivationPlanRegistry(ExportProviderFactoryOptions options)
+            {
+                this.IsExpressionCompilationEnabled = (options & ExportProviderFactoryOptions.EnableActivationExpressionCompilation) != 0;
+            }
+
+            internal int ExpressionCompilationCount => Volatile.Read(ref this.expressionCompilationCount);
+
+            internal bool IsExpressionCompilationEnabled { get; }
+
+            internal Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)
+            {
+                return this.importingMemberSetters.GetOrAdd(
+                    member,
+                    member => new Lazy<Action<object, object?>>(
+                        () =>
+                        {
+                            Interlocked.Increment(ref this.expressionCompilationCount);
+                            return member.CreateImportingMemberSetter();
+                        },
+                        LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+            }
+
+            internal Func<object?[], object?> GetOrCreateInstanceFactory(MethodBase method)
+            {
+                return this.instanceFactories.GetOrAdd(
+                    method,
+                    method => new Lazy<Func<object?[], object?>>(
+                        () =>
+                        {
+                            Interlocked.Increment(ref this.expressionCompilationCount);
+                            return method.CreateInstanceFactory();
+                        },
+                        LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+            }
+
+            internal bool TryGetInstanceFactory(RuntimeComposition.RuntimePart part, MethodBase method, out Func<object?[], object?>? factory)
+            {
+                factory = null;
+                if (!this.IsExpressionCompilationEnabled || !IsEligibleForRepeatedActivation(part))
+                {
+                    return false;
+                }
+
+                if (this.instanceFactories.TryGetValue(method, out Lazy<Func<object?[], object?>>? existingFactory))
+                {
+                    factory = existingFactory.Value;
+                    return true;
+                }
+
+                int activationCount = this.instanceFactoryActivationCounts.AddOrUpdate(
+                    method,
+                    1,
+                    static (_, count) => count < ActivationExpressionCompilationThreshold ? count + 1 : count);
+                if (activationCount < ActivationExpressionCompilationThreshold)
+                {
+                    return false;
+                }
+
+                factory = this.GetOrCreateInstanceFactory(method);
+                return true;
+            }
+
+            private static bool IsEligibleForRepeatedActivation(RuntimeComposition.RuntimePart part)
+            {
+                return part.SharingBoundary is null || part.SharingBoundary.Length > 0;
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -26,10 +26,12 @@ namespace Microsoft.VisualStudio.Composition
         private readonly RuntimeComposition composition;
         private readonly JoinableTaskFactory? joinableTaskFactory;
 
+#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
         internal RuntimeExportProviderFactory(RuntimeComposition composition)
             : this(composition, ExportProviderFactoryOptions.None)
         {
         }
+#pragma warning restore VSTHRD012
 
         internal RuntimeExportProviderFactory(RuntimeComposition composition, ExportProviderFactoryOptions options)
             : this(composition, options, joinableTaskFactory: null)
@@ -142,24 +144,7 @@ namespace Microsoft.VisualStudio.Composition
 
                 Lazy<RuntimeExportProvider.DirectActivationPlan?> lazyPlan = this.directActivationPlans.GetOrAdd(
                     part,
-                    part => new Lazy<RuntimeExportProvider.DirectActivationPlan?>(
-                        () =>
-                        {
-                            if (exportProvider.TryCreateDirectActivationPlan(part, new HashSet<TypeRef>(), out RuntimeExportProvider.DirectActivationPlan? plan))
-                            {
-                                if (part.SharingBoundary?.Length > 0
-                                    && plan.OperationCount < NamedBoundaryDirectActivationPlanMinimumOperationCount)
-                                {
-                                    return null;
-                                }
-
-                                Interlocked.Increment(ref this.directActivationPlanCount);
-                                return plan;
-                            }
-
-                            return null;
-                        },
-                        LazyThreadSafetyMode.ExecutionAndPublication));
+                    part => this.CreateDirectActivationPlanLazy(exportProvider, part));
                 activationPlan = lazyPlan.Value;
                 return activationPlan is object;
             }
@@ -185,25 +170,60 @@ namespace Microsoft.VisualStudio.Composition
             {
                 Lazy<RuntimeExportProvider.DirectActivationPlan?> lazyPlan = this.fusedActivationPlans.GetOrAdd(
                     part,
-                    part => new Lazy<RuntimeExportProvider.DirectActivationPlan?>(
-                        () =>
+                    part => this.CreateFusedActivationPlanLazy(exportProvider, part));
+                activationPlan = lazyPlan.Value;
+                return activationPlan is object;
+            }
+
+            private Lazy<RuntimeExportProvider.DirectActivationPlan?> CreateDirectActivationPlanLazy(
+                RuntimeExportProvider exportProvider,
+                RuntimeComposition.RuntimePart part)
+            {
+                var weakExportProvider = new WeakReference<RuntimeExportProvider>(exportProvider);
+                return new Lazy<RuntimeExportProvider.DirectActivationPlan?>(
+                    () =>
+                    {
+                        if (weakExportProvider.TryGetTarget(out RuntimeExportProvider? currentExportProvider)
+                            && currentExportProvider.TryCreateDirectActivationPlan(part, new HashSet<TypeRef>(), out RuntimeExportProvider.DirectActivationPlan? plan))
                         {
-                            if (exportProvider.TryCreateFusedActivationPlan(
+                            if (part.SharingBoundary?.Length > 0
+                                && plan.OperationCount < NamedBoundaryDirectActivationPlanMinimumOperationCount)
+                            {
+                                return null;
+                            }
+
+                            Interlocked.Increment(ref this.directActivationPlanCount);
+                            return plan;
+                        }
+
+                        return null;
+                    },
+                    LazyThreadSafetyMode.ExecutionAndPublication);
+            }
+
+            private Lazy<RuntimeExportProvider.DirectActivationPlan?> CreateFusedActivationPlanLazy(
+                RuntimeExportProvider exportProvider,
+                RuntimeComposition.RuntimePart part)
+            {
+                var weakExportProvider = new WeakReference<RuntimeExportProvider>(exportProvider);
+                return new Lazy<RuntimeExportProvider.DirectActivationPlan?>(
+                    () =>
+                    {
+                        if (weakExportProvider.TryGetTarget(out RuntimeExportProvider? currentExportProvider)
+                            && currentExportProvider.TryCreateFusedActivationPlan(
                                 part,
                                 NamedBoundaryDirectActivationPlanMinimumOperationCount,
                                 FusedActivationPlanMaximumOperationCount,
                                 out RuntimeExportProvider.DirectActivationPlan? plan))
-                            {
-                                Interlocked.Increment(ref this.directActivationPlanCount);
-                                Interlocked.Increment(ref this.fusedActivationPlanCount);
-                                return plan;
-                            }
+                        {
+                            Interlocked.Increment(ref this.directActivationPlanCount);
+                            Interlocked.Increment(ref this.fusedActivationPlanCount);
+                            return plan;
+                        }
 
-                            return null;
-                        },
-                        LazyThreadSafetyMode.ExecutionAndPublication));
-                activationPlan = lazyPlan.Value;
-                return activationPlan is object;
+                        return null;
+                    },
+                    LazyThreadSafetyMode.ExecutionAndPublication);
             }
 
             internal void RecordFusedExpressionCompilation()

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.Composition
     {
         private const int ActivationExpressionCompilationThreshold = 2;
         private const int NamedBoundaryDirectActivationPlanMinimumOperationCount = 4;
+        private const int FusedActivationPlanMaximumOperationCount = 64;
 
         private readonly ActivationPlanRegistry activationPlanRegistry;
         private readonly RuntimeComposition composition;
@@ -39,6 +40,10 @@ namespace Microsoft.VisualStudio.Composition
 
         internal int DirectActivationPlanCount => this.activationPlanRegistry.DirectActivationPlanCount;
 
+        internal int FusedActivationPlanCount => this.activationPlanRegistry.FusedActivationPlanCount;
+
+        internal int FusedExpressionCompilationCount => this.activationPlanRegistry.FusedExpressionCompilationCount;
+
         public ExportProvider CreateExportProvider()
         {
             return new RuntimeExportProvider(this.composition, this.activationPlanRegistry);
@@ -57,8 +62,12 @@ namespace Microsoft.VisualStudio.Composition
             private readonly ConcurrentDictionary<MemberInfo, Lazy<Action<object, object?>>> importingMemberSetters = new();
             private readonly ConcurrentDictionary<RuntimeComposition.RuntimePart, Lazy<RuntimeExportProvider.DirectActivationPlan?>> directActivationPlans = new();
             private readonly ConcurrentDictionary<RuntimeComposition.RuntimePart, int> directActivationPlanCounts = new();
+            private readonly ConcurrentDictionary<RuntimeComposition.RuntimePart, int> exportFactoryActivationCounts = new();
+            private readonly ConcurrentDictionary<RuntimeComposition.RuntimePart, Lazy<RuntimeExportProvider.DirectActivationPlan?>> fusedActivationPlans = new();
             private int directActivationPlanCount;
             private int expressionCompilationCount;
+            private int fusedActivationPlanCount;
+            private int fusedExpressionCompilationCount;
 
             internal ActivationPlanRegistry(ExportProviderFactoryOptions options)
             {
@@ -69,7 +78,22 @@ namespace Microsoft.VisualStudio.Composition
 
             internal int DirectActivationPlanCount => Volatile.Read(ref this.directActivationPlanCount);
 
+            internal int FusedActivationPlanCount => Volatile.Read(ref this.fusedActivationPlanCount);
+
+            internal int FusedExpressionCompilationCount => Volatile.Read(ref this.fusedExpressionCompilationCount);
+
             internal bool IsExpressionCompilationEnabled { get; }
+
+            internal void RecordExportFactoryActivation(RuntimeComposition.RuntimePart part)
+            {
+                if (this.IsExpressionCompilationEnabled && IsEligibleForRepeatedActivation(part))
+                {
+                    this.exportFactoryActivationCounts.AddOrUpdate(
+                        part,
+                        1,
+                        static (_, count) => count < ActivationExpressionCompilationThreshold ? count + 1 : count);
+                }
+            }
 
             internal bool TryGetDirectActivationPlan(
                 RuntimeExportProvider exportProvider,
@@ -80,6 +104,13 @@ namespace Microsoft.VisualStudio.Composition
                 if (!this.IsExpressionCompilationEnabled || !IsEligibleForRepeatedActivation(part))
                 {
                     return false;
+                }
+
+                if (this.exportFactoryActivationCounts.TryGetValue(part, out int factoryActivationCount)
+                    && factoryActivationCount >= ActivationExpressionCompilationThreshold
+                    && this.TryGetFusedActivationPlan(exportProvider, part, out activationPlan))
+                {
+                    return true;
                 }
 
                 if (this.TryGetExistingDirectActivationPlan(part, out activationPlan))
@@ -132,6 +163,40 @@ namespace Microsoft.VisualStudio.Composition
 
                 activationPlan = null;
                 return false;
+            }
+
+            private bool TryGetFusedActivationPlan(
+                RuntimeExportProvider exportProvider,
+                RuntimeComposition.RuntimePart part,
+                [NotNullWhen(true)] out RuntimeExportProvider.DirectActivationPlan? activationPlan)
+            {
+                Lazy<RuntimeExportProvider.DirectActivationPlan?> lazyPlan = this.fusedActivationPlans.GetOrAdd(
+                    part,
+                    part => new Lazy<RuntimeExportProvider.DirectActivationPlan?>(
+                        () =>
+                        {
+                            if (exportProvider.TryCreateFusedActivationPlan(
+                                part,
+                                NamedBoundaryDirectActivationPlanMinimumOperationCount,
+                                FusedActivationPlanMaximumOperationCount,
+                                out RuntimeExportProvider.DirectActivationPlan? plan))
+                            {
+                                Interlocked.Increment(ref this.directActivationPlanCount);
+                                Interlocked.Increment(ref this.fusedActivationPlanCount);
+                                return plan;
+                            }
+
+                            return null;
+                        },
+                        LazyThreadSafetyMode.ExecutionAndPublication));
+                activationPlan = lazyPlan.Value;
+                return activationPlan is object;
+            }
+
+            internal void RecordFusedExpressionCompilation()
+            {
+                Interlocked.Increment(ref this.expressionCompilationCount);
+                Interlocked.Increment(ref this.fusedExpressionCompilationCount);
             }
 
             internal Action<object, object?> GetOrCreateImportingMemberSetter(MemberInfo member)

--- a/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeExportProviderFactory.cs
@@ -273,7 +273,7 @@ namespace Microsoft.VisualStudio.Composition
                             }
                             catch (Exception ex) when (ex.IsExpressionCompilationFailure())
                             {
-                                return arguments => method.Instantiate(arguments);
+                                return arguments => method.InstantiateWithoutTargetInvocationException(arguments);
                             }
                         },
                         LazyThreadSafetyMode.ExecutionAndPublication));

--- a/test/Microsoft.VisualStudio.Composition.Benchmarks/ActivationBenchmarks.cs
+++ b/test/Microsoft.VisualStudio.Composition.Benchmarks/ActivationBenchmarks.cs
@@ -17,6 +17,12 @@ public class ActivationBenchmarks
     private ExportProvider exportProvider = null!;
 
     /// <summary>
+    /// Gets or sets a value indicating whether expression compilation is enabled.
+    /// </summary>
+    [Params(false, true)]
+    public bool EnableExpressionCompilation { get; set; }
+
+    /// <summary>
     /// Creates and warms the export provider used by the activation benchmarks.
     /// </summary>
     [GlobalSetup]
@@ -52,8 +58,11 @@ public class ActivationBenchmarks
             typeof(AdapterE)).GetAwaiter().GetResult();
 
         var catalog = ComposableCatalog.Create(resolver).AddParts(discoveredParts);
+        ExportProviderFactoryOptions options = this.EnableExpressionCompilation
+            ? ExportProviderFactoryOptions.EnableActivationExpressionCompilation
+            : ExportProviderFactoryOptions.None;
         this.exportProvider = CompositionConfiguration.Create(catalog)
-            .CreateExportProviderFactory()
+            .CreateExportProviderFactory(options)
             .CreateExportProvider();
 
         this.Singleton();

--- a/test/Microsoft.VisualStudio.Composition.Benchmarks/ActivationBenchmarks.cs
+++ b/test/Microsoft.VisualStudio.Composition.Benchmarks/ActivationBenchmarks.cs
@@ -14,6 +14,7 @@ using Microsoft.VSDiagnostics;
 [CPUUsageDiagnoser]
 public class ActivationBenchmarks
 {
+    private ExportFactory<BoundaryPart> boundaryFactory = null!;
     private ExportProvider exportProvider = null!;
 
     /// <summary>
@@ -55,7 +56,16 @@ public class ActivationBenchmarks
             typeof(AdapterB),
             typeof(AdapterC),
             typeof(AdapterD),
-            typeof(AdapterE)).GetAwaiter().GetResult();
+            typeof(AdapterE),
+            typeof(BoundaryOwner),
+            typeof(BoundaryPart),
+            typeof(BoundaryLeafA),
+            typeof(BoundaryLeafB),
+            typeof(BoundaryLeafC),
+            typeof(BoundaryLeafD),
+            typeof(BoundaryLeafE),
+            typeof(BoundaryLeafF),
+            typeof(BoundaryDependency)).GetAwaiter().GetResult();
 
         var catalog = ComposableCatalog.Create(resolver).AddParts(discoveredParts);
         ExportProviderFactoryOptions options = this.EnableExpressionCompilation
@@ -64,6 +74,7 @@ public class ActivationBenchmarks
         this.exportProvider = CompositionConfiguration.Create(catalog)
             .CreateExportProviderFactory(options)
             .CreateExportProvider();
+        this.boundaryFactory = this.exportProvider.GetExportedValue<BoundaryOwner>().Factory;
 
         this.Singleton();
         this.Transient();
@@ -71,6 +82,8 @@ public class ActivationBenchmarks
         this.Complex();
         this.Property();
         this.ImportMany();
+        this.Boundary();
+        this.Boundary();
     }
 
     /// <summary>
@@ -149,6 +162,24 @@ public class ActivationBenchmarks
         _ = this.exportProvider.GetExportedValue<ImportManyPart>();
         _ = this.exportProvider.GetExportedValue<ImportManyPart>();
         return this.exportProvider.GetExportedValue<ImportManyPart>();
+    }
+
+    /// <summary>
+    /// Activates and disposes a shared graph in a newly created sharing boundary.
+    /// </summary>
+    /// <returns>The last activated boundary part.</returns>
+    [Benchmark(OperationsPerInvoke = 3)]
+    public object Boundary()
+    {
+        _ = this.CreateBoundaryPart();
+        _ = this.CreateBoundaryPart();
+        return this.CreateBoundaryPart();
+    }
+
+    private object CreateBoundaryPart()
+    {
+        using Export<BoundaryPart> export = this.boundaryFactory.CreateExport();
+        return export.Value;
     }
 
     [Export]
@@ -335,6 +366,90 @@ public class ActivationBenchmarks
 
     [Export(typeof(IAdapter))]
     private sealed class AdapterE : IAdapter
+    {
+    }
+
+    [Export, Shared]
+    private sealed class BoundaryOwner
+    {
+        [Import, SharingBoundary("BenchmarkBoundary")]
+        internal ExportFactory<BoundaryPart> Factory { get; set; } = null!;
+    }
+
+    [Export, Shared("BenchmarkBoundary")]
+    private sealed class BoundaryPart
+    {
+        [ImportingConstructor]
+        internal BoundaryPart(
+            BoundaryLeafA leafA,
+            BoundaryLeafB leafB,
+            BoundaryLeafC leafC,
+            BoundaryLeafD leafD,
+            BoundaryLeafE leafE,
+            BoundaryLeafF leafF)
+        {
+        }
+
+        [Import]
+        internal BoundaryDependency Dependency { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class BoundaryLeafA
+    {
+        [ImportingConstructor]
+        internal BoundaryLeafA(BoundaryDependency dependency)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class BoundaryLeafB
+    {
+        [ImportingConstructor]
+        internal BoundaryLeafB(BoundaryDependency dependency)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class BoundaryLeafC
+    {
+        [ImportingConstructor]
+        internal BoundaryLeafC(BoundaryDependency dependency)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class BoundaryLeafD
+    {
+        [ImportingConstructor]
+        internal BoundaryLeafD(BoundaryDependency dependency)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class BoundaryLeafE
+    {
+        [ImportingConstructor]
+        internal BoundaryLeafE(BoundaryDependency dependency)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class BoundaryLeafF
+    {
+        [ImportingConstructor]
+        internal BoundaryLeafF(BoundaryDependency dependency)
+        {
+        }
+    }
+
+    [Export, Shared("BenchmarkBoundary")]
+    private sealed class BoundaryDependency
     {
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -36,6 +36,47 @@ public class ActivationExpressionCompilationTests
     }
 
     /// <summary>
+    /// Verifies that fault-reporting providers retain callback behavior after repeated activation.
+    /// </summary>
+    [Fact]
+    public void FaultReportingProviderDoesNotUseCompiledActivation()
+    {
+        var factory = (IFaultReportingExportProviderFactory)CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(FaultReportingImporter),
+            typeof(FaultReportingFailingPart));
+        int callbackCount = 0;
+        using ExportProvider provider = factory.CreateExportProvider((exception, import, export) => callbackCount++);
+
+        Assert.Throws<CompositionFailedException>(() => provider.GetExportedValue<FaultReportingImporter>());
+        Assert.Throws<CompositionFailedException>(() => provider.GetExportedValue<FaultReportingImporter>());
+
+        Assert.Equal(2, callbackCount);
+        Assert.Equal(0, GetExpressionCompilationCount(factory));
+    }
+
+    /// <summary>
+    /// Verifies that compiled property setters preserve reflection's exception chain.
+    /// </summary>
+    [Fact]
+    public void CompiledPropertySetterPreservesTargetInvocationException()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(ThrowingPropertySetterPart),
+            typeof(ThrowingPropertySetterDependency));
+        using ExportProvider provider = factory.CreateExportProvider();
+
+        CompositionFailedException first = Assert.Throws<CompositionFailedException>(
+            () => provider.GetExportedValue<ThrowingPropertySetterPart>());
+        CompositionFailedException second = Assert.Throws<CompositionFailedException>(
+            () => provider.GetExportedValue<ThrowingPropertySetterPart>());
+
+        Assert.IsType<TargetInvocationException>(first.InnerException);
+        Assert.IsType<TargetInvocationException>(second.InnerException);
+    }
+
+    /// <summary>
     /// Verifies that expression compilation is disabled by default.
     /// </summary>
     [Fact]
@@ -568,6 +609,39 @@ public class ActivationExpressionCompilationTests
 
     [Export]
     private sealed class NonSharedPart
+    {
+    }
+
+    [Export]
+    private sealed class FaultReportingFailingPart
+    {
+        internal FaultReportingFailingPart()
+        {
+            throw new InvalidOperationException();
+        }
+    }
+
+    [Export]
+    private sealed class FaultReportingImporter
+    {
+        [ImportingConstructor]
+        internal FaultReportingImporter(FaultReportingFailingPart failingPart)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class ThrowingPropertySetterPart
+    {
+        [Import]
+        internal ThrowingPropertySetterDependency Dependency
+        {
+            set => throw new InvalidOperationException();
+        }
+    }
+
+    [Export]
+    private sealed class ThrowingPropertySetterDependency
     {
     }
 

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -36,6 +36,28 @@ public class ActivationExpressionCompilationTests
     }
 
     /// <summary>
+    /// Verifies that fused value-type conversion evaluates export resolution once.
+    /// </summary>
+    [Fact]
+    public void FusedValueTypeImportIsEvaluatedOnce()
+    {
+        Type runtimeExportProviderType = typeof(CompositionConfiguration).Assembly.GetType(
+            "Microsoft.VisualStudio.Composition.RuntimeExportProviderFactory+RuntimeExportProvider")!;
+        MethodInfo convertMethod = runtimeExportProviderType.GetMethod(
+            "ConvertFusedImportValue",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var source = new FusedImportValueSource();
+        Expression sourceExpression = Expression.Call(
+            Expression.Constant(source),
+            typeof(FusedImportValueSource).GetMethod(nameof(FusedImportValueSource.GetValue))!);
+        var convertedExpression = (Expression)convertMethod.Invoke(null, new object[] { sourceExpression, typeof(int) })!;
+        Func<int> getter = Expression.Lambda<Func<int>>(convertedExpression).Compile();
+
+        Assert.Equal(1, getter());
+        Assert.Equal(1, source.EvaluationCount);
+    }
+
+    /// <summary>
     /// Verifies that the reflection fallback matches compiled constructor exception behavior.
     /// </summary>
     [Fact]
@@ -1044,5 +1066,12 @@ public class ActivationExpressionCompilationTests
         public override Type Type => typeof(int);
 
         public override Expression Reduce() => throw new PlatformNotSupportedException();
+    }
+
+    private sealed class FusedImportValueSource
+    {
+        internal int EvaluationCount { get; private set; }
+
+        public object GetValue() => ++this.EvaluationCount;
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -1,756 +1,755 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.VisualStudio.Composition.Tests
+namespace Microsoft.VisualStudio.Composition.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+/// <summary>
+/// Tests tiered expression compilation for repeated activation.
+/// </summary>
+public class ActivationExpressionCompilationTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Composition;
-    using System.IO;
-    using System.Linq;
-    using System.Reflection;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Xunit;
+    /// <summary>
+    /// Verifies that expression compilation is disabled by default.
+    /// </summary>
+    [Fact]
+    public void ExpressionCompilationIsDisabledByDefault()
+    {
+        IExportProviderFactory factory = CreateFactory(ExportProviderFactoryOptions.None, typeof(NonSharedPart));
+        using ExportProvider provider = factory.CreateExportProvider();
+
+        _ = provider.GetExportedValue<NonSharedPart>();
+        _ = provider.GetExportedValue<NonSharedPart>();
+
+        Assert.Equal(0, GetExpressionCompilationCount(factory));
+    }
 
     /// <summary>
-    /// Tests tiered expression compilation for repeated activation.
+    /// Verifies that a non-shared part compiles only after repeated activation.
     /// </summary>
-    public class ActivationExpressionCompilationTests
+    [Fact]
+    public void NonSharedPartCompilesOnSecondActivation()
     {
-        /// <summary>
-        /// Verifies that expression compilation is disabled by default.
-        /// </summary>
-        [Fact]
-        public void ExpressionCompilationIsDisabledByDefault()
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(NonSharedPart));
+        using ExportProvider provider = factory.CreateExportProvider();
+
+        _ = provider.GetExportedValue<NonSharedPart>();
+        Assert.Equal(0, GetExpressionCompilationCount(factory));
+
+        _ = provider.GetExportedValue<NonSharedPart>();
+        Assert.Equal(1, GetExpressionCompilationCount(factory));
+
+        _ = provider.GetExportedValue<NonSharedPart>();
+        Assert.Equal(1, GetExpressionCompilationCount(factory));
+    }
+
+    /// <summary>
+    /// Verifies that application-wide shared parts are never expression compiled.
+    /// </summary>
+    [Fact]
+    public void ApplicationSharedPartDoesNotCompile()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(ApplicationSharedPart));
+        using ExportProvider provider = factory.CreateExportProvider();
+
+        _ = provider.GetExportedValue<ApplicationSharedPart>();
+        _ = provider.GetExportedValue<ApplicationSharedPart>();
+
+        Assert.Equal(0, GetExpressionCompilationCount(factory));
+    }
+
+    /// <summary>
+    /// Verifies that activation counts and compiled delegates are shared across sharing-boundary instances.
+    /// </summary>
+    [Fact]
+    public void SharingBoundaryPartCompilesOnSecondBoundaryInstance()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(SharingBoundaryOwner),
+            typeof(SharingBoundaryPart),
+            typeof(SharingBoundarySimpleDependency));
+        using ExportProvider provider = factory.CreateExportProvider();
+        SharingBoundaryOwner owner = provider.GetExportedValue<SharingBoundaryOwner>();
+
+        using (Export<SharingBoundaryPart> first = owner.Factory.CreateExport())
         {
-            IExportProviderFactory factory = CreateFactory(ExportProviderFactoryOptions.None, typeof(NonSharedPart));
-            using ExportProvider provider = factory.CreateExportProvider();
-
-            _ = provider.GetExportedValue<NonSharedPart>();
-            _ = provider.GetExportedValue<NonSharedPart>();
-
+            _ = first.Value;
             Assert.Equal(0, GetExpressionCompilationCount(factory));
         }
 
-        /// <summary>
-        /// Verifies that a non-shared part compiles only after repeated activation.
-        /// </summary>
-        [Fact]
-        public void NonSharedPartCompilesOnSecondActivation()
+        using (Export<SharingBoundaryPart> second = owner.Factory.CreateExport())
         {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(NonSharedPart));
-            using ExportProvider provider = factory.CreateExportProvider();
-
-            _ = provider.GetExportedValue<NonSharedPart>();
-            Assert.Equal(0, GetExpressionCompilationCount(factory));
-
-            _ = provider.GetExportedValue<NonSharedPart>();
+            Assert.NotNull(second.Value.Dependency);
             Assert.Equal(1, GetExpressionCompilationCount(factory));
-
-            _ = provider.GetExportedValue<NonSharedPart>();
-            Assert.Equal(1, GetExpressionCompilationCount(factory));
-        }
-
-        /// <summary>
-        /// Verifies that application-wide shared parts are never expression compiled.
-        /// </summary>
-        [Fact]
-        public void ApplicationSharedPartDoesNotCompile()
-        {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(ApplicationSharedPart));
-            using ExportProvider provider = factory.CreateExportProvider();
-
-            _ = provider.GetExportedValue<ApplicationSharedPart>();
-            _ = provider.GetExportedValue<ApplicationSharedPart>();
-
-            Assert.Equal(0, GetExpressionCompilationCount(factory));
-        }
-
-        /// <summary>
-        /// Verifies that activation counts and compiled delegates are shared across sharing-boundary instances.
-        /// </summary>
-        [Fact]
-        public void SharingBoundaryPartCompilesOnSecondBoundaryInstance()
-        {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(SharingBoundaryOwner),
-                typeof(SharingBoundaryPart),
-                typeof(SharingBoundarySimpleDependency));
-            using ExportProvider provider = factory.CreateExportProvider();
-            SharingBoundaryOwner owner = provider.GetExportedValue<SharingBoundaryOwner>();
-
-            using (Export<SharingBoundaryPart> first = owner.Factory.CreateExport())
-            {
-                _ = first.Value;
-                Assert.Equal(0, GetExpressionCompilationCount(factory));
-            }
-
-            using (Export<SharingBoundaryPart> second = owner.Factory.CreateExport())
-            {
-                Assert.NotNull(second.Value.Dependency);
-                Assert.Equal(1, GetExpressionCompilationCount(factory));
-                Assert.Equal(0, GetDirectActivationPlanCount(factory));
-            }
-        }
-
-        /// <summary>
-        /// Verifies that a direct activation plan resolves shared dependencies from the current boundary.
-        /// </summary>
-        [Fact]
-        public void DirectActivationPlanPreservesBoundaryAndDisposalOwnership()
-        {
-            IExportProviderFactory factory = CreateBoundaryPlanFactory();
-            ExportProvider provider = factory.CreateExportProvider();
-            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
-
-            BoundaryScopedDependency firstScoped;
-            GlobalSharedDependency global;
-            using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
-            {
-                BoundaryGraphRoot root = first.Value;
-                Assert.Equal(0, GetDirectActivationPlanCount(factory));
-                Assert.Equal(0, GetFusedActivationPlanCount(factory));
-                Assert.Same(root.Scoped, root.Leaf.Scoped);
-                firstScoped = root.Scoped;
-                global = root.Global;
-                Assert.False(firstScoped.IsDisposed);
-                Assert.False(global.IsDisposed);
-            }
-
-            Assert.True(firstScoped.IsDisposed);
-            Assert.False(global.IsDisposed);
-
-            BoundaryScopedDependency secondScoped;
-            using (Export<BoundaryGraphRoot> second = owner.GraphFactory.CreateExport())
-            {
-                BoundaryGraphRoot root = second.Value;
-                Assert.Equal(1, GetDirectActivationPlanCount(factory));
-                Assert.Equal(1, GetFusedActivationPlanCount(factory));
-                Assert.Equal(2, GetFusedExpressionCompilationCount(factory));
-                Assert.Equal(3, GetExpressionCompilationCount(factory));
-                Assert.Same(root.Scoped, root.Leaf.Scoped);
-                Assert.NotSame(firstScoped, root.Scoped);
-                Assert.Same(global, root.Global);
-                secondScoped = root.Scoped;
-                Assert.False(secondScoped.IsDisposed);
-            }
-
-            Assert.True(secondScoped.IsDisposed);
-            Assert.False(global.IsDisposed);
-            provider.Dispose();
-            Assert.True(global.IsDisposed);
-        }
-
-        /// <summary>
-        /// Verifies that incidental activation does not trigger fusion before an export factory is exercised twice.
-        /// </summary>
-        [Fact]
-        public void FusedActivationRequiresRepeatedExportFactoryUse()
-        {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(FactoryOnlyOwner),
-                typeof(FactoryOnlyRoot),
-                typeof(FactoryOnlyDependencyA),
-                typeof(FactoryOnlyDependencyB),
-                typeof(FactoryOnlyDependencyC),
-                typeof(FactoryOnlyDependencyD));
-            using ExportProvider provider = factory.CreateExportProvider();
-
-            _ = provider.GetExportedValue<FactoryOnlyRoot>();
-            _ = provider.GetExportedValue<FactoryOnlyRoot>();
-            Assert.Equal(0, GetFusedActivationPlanCount(factory));
-
-            FactoryOnlyOwner owner = provider.GetExportedValue<FactoryOnlyOwner>();
-            using (Export<FactoryOnlyRoot> first = owner.Factory.CreateExport())
-            {
-                _ = first.Value;
-                Assert.Equal(0, GetFusedActivationPlanCount(factory));
-            }
-
-            using (Export<FactoryOnlyRoot> second = owner.Factory.CreateExport())
-            {
-                _ = second.Value;
-                Assert.Equal(1, GetFusedActivationPlanCount(factory));
-                Assert.Equal(1, GetFusedExpressionCompilationCount(factory));
-            }
-        }
-
-        /// <summary>
-        /// Verifies that fused member imports preserve the lifecycle engine's failure diagnostics.
-        /// </summary>
-        [Fact]
-        public void FusedActivationPreservesImportFailureDiagnostics()
-        {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(FailingFactoryOwner),
-                typeof(FailingFactoryRoot),
-                typeof(ThrowingDependency),
-                typeof(FactoryOnlyDependencyA),
-                typeof(FactoryOnlyDependencyB));
-            using ExportProvider provider = factory.CreateExportProvider();
-            FailingFactoryOwner owner = provider.GetExportedValue<FailingFactoryOwner>();
-
-            CompositionFailedException firstException = Assert.Throws<CompositionFailedException>(
-                () =>
-                {
-                    using Export<FailingFactoryRoot> first = owner.Factory.CreateExport();
-                });
-
-            CompositionFailedException secondException = Assert.Throws<CompositionFailedException>(
-                () =>
-                {
-                    using Export<FailingFactoryRoot> second = owner.Factory.CreateExport();
-                });
-
-            Assert.Equal(1, GetFusedActivationPlanCount(factory));
-            Assert.Equal(firstException.Message, secondException.Message);
-            Assert.Equal(firstException.InnerException?.Message, secondException.InnerException?.Message);
-        }
-
-        /// <summary>
-        /// Verifies that a nested export factory remains deferred while the surrounding island is fused.
-        /// </summary>
-        [Fact]
-        public void FusedActivationStopsAtNestedExportFactory()
-        {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(NestedFactoryOwner),
-                typeof(NestedFactoryRoot),
-                typeof(DeferredFactoryPart),
-                typeof(DeferredFactoryControl),
-                typeof(FactoryOnlyDependencyA),
-                typeof(FactoryOnlyDependencyB),
-                typeof(FactoryOnlyDependencyC),
-                typeof(FactoryOnlyDependencyD));
-            using ExportProvider provider = factory.CreateExportProvider();
-            NestedFactoryOwner owner = provider.GetExportedValue<NestedFactoryOwner>();
-            DeferredFactoryControl control = provider.GetExportedValue<DeferredFactoryControl>();
-
-            using (Export<NestedFactoryRoot> first = owner.Factory.CreateExport())
-            {
-                Assert.Equal(0, control.ActivationCount);
-            }
-
-            using (Export<NestedFactoryRoot> second = owner.Factory.CreateExport())
-            {
-                Assert.Equal(1, GetFusedActivationPlanCount(factory));
-                Assert.Equal(0, control.ActivationCount);
-
-                using Export<DeferredFactoryPart> nested = second.Value.NestedFactory.CreateExport();
-                Assert.NotNull(nested.Value);
-                Assert.Equal(1, control.ActivationCount);
-            }
-        }
-
-        /// <summary>
-        /// Verifies that concurrent boundary activations share one plan without sharing scoped instances.
-        /// </summary>
-        [Fact]
-        public async Task DirectActivationPlanIsSafeAcrossConcurrentBoundaries()
-        {
-            IExportProviderFactory factory = CreateBoundaryPlanFactory();
-            using ExportProvider provider = factory.CreateExportProvider();
-            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
-            using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
-            {
-                _ = first.Value;
-            }
-
-            BoundaryScopedDependency[] scopedDependencies = await Task.WhenAll(
-                Enumerable.Range(0, 8).Select(
-                    _ => Task.Run(
-                        () =>
-                        {
-                            using Export<BoundaryGraphRoot> export = owner.GraphFactory.CreateExport();
-                            BoundaryGraphRoot root = export.Value;
-                            Assert.Same(root.Scoped, root.Leaf.Scoped);
-                            return root.Scoped;
-                        })));
-
-            Assert.Equal(scopedDependencies.Length, scopedDependencies.Distinct().Count());
-            Assert.All(scopedDependencies, scoped => Assert.True(scoped.IsDisposed));
-            Assert.Equal(1, GetDirectActivationPlanCount(factory));
-        }
-
-        /// <summary>
-        /// Verifies that a shared plan does not retain values from its first boundary provider.
-        /// </summary>
-        [Fact]
-        [Trait("WeakReference", "true")]
-        [Trait(Traits.SkipOnMono, "WeakReference")]
-        public void DirectActivationPlanDoesNotRetainDisposedBoundary()
-        {
-            IExportProviderFactory factory = CreateBoundaryPlanFactory();
-            using ExportProvider provider = factory.CreateExportProvider();
-            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
-
-            WeakReference scopedDependency = CreateAndDisposeCompiledBoundary(owner);
-            Assert.Equal(1, GetDirectActivationPlanCount(factory));
-
-            GC.Collect();
-            Assert.False(scopedDependency.IsAlive);
-        }
-
-        /// <summary>
-        /// Verifies that phased direct plans preserve property-import cycles within each boundary.
-        /// </summary>
-        [Fact]
-        public void DirectActivationPlanPreservesPropertyImportCycles()
-        {
-            IExportProviderFactory factory = CreateBoundaryPlanFactory();
-            using ExportProvider provider = factory.CreateExportProvider();
-            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
-
-            using (Export<BoundaryCycleA> first = owner.CycleFactory.CreateExport())
-            {
-                Assert.Same(first.Value, first.Value.B.A);
-            }
-
-            using (Export<BoundaryCycleA> second = owner.CycleFactory.CreateExport())
-            {
-                Assert.Same(second.Value, second.Value.B.A);
-                Assert.True(GetDirectActivationPlanCount(factory) >= 1);
-            }
-        }
-
-        /// <summary>
-        /// Verifies that disposable boundary roots remain on the lifecycle path.
-        /// </summary>
-        [Fact]
-        public void DisposableBoundaryRootDoesNotUseDirectActivationPlan()
-        {
-            IExportProviderFactory factory = CreateBoundaryPlanFactory();
-            using ExportProvider provider = factory.CreateExportProvider();
-            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
-
-            DisposableBoundaryRoot firstValue;
-            using (Export<DisposableBoundaryRoot> first = owner.DisposableFactory.CreateExport())
-            {
-                firstValue = first.Value;
-                Assert.False(firstValue.IsDisposed);
-            }
-
-            Assert.True(firstValue.IsDisposed);
-
-            DisposableBoundaryRoot secondValue;
-            using (Export<DisposableBoundaryRoot> second = owner.DisposableFactory.CreateExport())
-            {
-                secondValue = second.Value;
-                Assert.False(secondValue.IsDisposed);
-            }
-
-            Assert.True(secondValue.IsDisposed);
             Assert.Equal(0, GetDirectActivationPlanCount(factory));
         }
+    }
 
-        /// <summary>
-        /// Verifies that a compiled direct plan correctly satisfies constructor, property, and many imports.
-        /// </summary>
-        [Fact]
-        public void CompiledDirectPlanSatisfiesImports()
+    /// <summary>
+    /// Verifies that a direct activation plan resolves shared dependencies from the current boundary.
+    /// </summary>
+    [Fact]
+    public void DirectActivationPlanPreservesBoundaryAndDisposalOwnership()
+    {
+        IExportProviderFactory factory = CreateBoundaryPlanFactory();
+        ExportProvider provider = factory.CreateExportProvider();
+        BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+        BoundaryScopedDependency firstScoped;
+        GlobalSharedDependency global;
+        using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
         {
-            IExportProviderFactory factory = CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(ImportedPart),
-                typeof(ImportedProperty),
-                typeof(FirstAdapter),
-                typeof(SecondAdapter));
-            using ExportProvider provider = factory.CreateExportProvider();
-
-            ImportedPart first = provider.GetExportedValue<ImportedPart>();
-            Assert.Equal(0, GetExpressionCompilationCount(factory));
-            Assert.IsType<ImportedProperty>(first.Property);
-            Assert.Contains(first.Adapters, adapter => adapter is FirstAdapter);
-            Assert.Contains(first.Adapters, adapter => adapter is SecondAdapter);
-
-            ImportedPart second = provider.GetExportedValue<ImportedPart>();
-            Assert.NotSame(first, second);
-            Assert.True(GetExpressionCompilationCount(factory) > 0);
-            Assert.IsType<ImportedProperty>(second.Property);
-            Assert.Contains(second.Adapters, adapter => adapter is FirstAdapter);
-            Assert.Contains(second.Adapters, adapter => adapter is SecondAdapter);
+            BoundaryGraphRoot root = first.Value;
+            Assert.Equal(0, GetDirectActivationPlanCount(factory));
+            Assert.Equal(0, GetFusedActivationPlanCount(factory));
+            Assert.Same(root.Scoped, root.Leaf.Scoped);
+            firstScoped = root.Scoped;
+            global = root.Global;
+            Assert.False(firstScoped.IsDisposed);
+            Assert.False(global.IsDisposed);
         }
 
-        /// <summary>
-        /// Verifies that undefined options are rejected.
-        /// </summary>
-        [Fact]
-        public void UndefinedOptionIsRejected()
-        {
-            var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
-            RuntimeComposition composition = RuntimeComposition.CreateRuntimeComposition(configuration);
+        Assert.True(firstScoped.IsDisposed);
+        Assert.False(global.IsDisposed);
 
-            Assert.Throws<ArgumentException>(() => composition.CreateExportProviderFactory((ExportProviderFactoryOptions)0x2));
+        BoundaryScopedDependency secondScoped;
+        using (Export<BoundaryGraphRoot> second = owner.GraphFactory.CreateExport())
+        {
+            BoundaryGraphRoot root = second.Value;
+            Assert.Equal(1, GetDirectActivationPlanCount(factory));
+            Assert.Equal(1, GetFusedActivationPlanCount(factory));
+            Assert.Equal(2, GetFusedExpressionCompilationCount(factory));
+            Assert.Equal(3, GetExpressionCompilationCount(factory));
+            Assert.Same(root.Scoped, root.Leaf.Scoped);
+            Assert.NotSame(firstScoped, root.Scoped);
+            Assert.Same(global, root.Global);
+            secondScoped = root.Scoped;
+            Assert.False(secondScoped.IsDisposed);
         }
 
-        /// <summary>
-        /// Verifies that cached-composition loading propagates expression compilation options.
-        /// </summary>
-        [Fact]
-        public async Task CachedCompositionPropagatesOptions()
+        Assert.True(secondScoped.IsDisposed);
+        Assert.False(global.IsDisposed);
+        provider.Dispose();
+        Assert.True(global.IsDisposed);
+    }
+
+    /// <summary>
+    /// Verifies that incidental activation does not trigger fusion before an export factory is exercised twice.
+    /// </summary>
+    [Fact]
+    public void FusedActivationRequiresRepeatedExportFactoryUse()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(FactoryOnlyOwner),
+            typeof(FactoryOnlyRoot),
+            typeof(FactoryOnlyDependencyA),
+            typeof(FactoryOnlyDependencyB),
+            typeof(FactoryOnlyDependencyC),
+            typeof(FactoryOnlyDependencyD));
+        using ExportProvider provider = factory.CreateExportProvider();
+
+        _ = provider.GetExportedValue<FactoryOnlyRoot>();
+        _ = provider.GetExportedValue<FactoryOnlyRoot>();
+        Assert.Equal(0, GetFusedActivationPlanCount(factory));
+
+        FactoryOnlyOwner owner = provider.GetExportedValue<FactoryOnlyOwner>();
+        using (Export<FactoryOnlyRoot> first = owner.Factory.CreateExport())
         {
-            CompositionConfiguration configuration = CreateConfiguration(typeof(NonSharedPart));
-            var cache = new CachedComposition();
-            using var stream = new MemoryStream();
-            await cache.SaveAsync(configuration, stream);
-            stream.Position = 0;
-
-            IExportProviderFactory factory = await cache.LoadExportProviderFactoryAsync(
-                stream,
-                Resolver.DefaultInstance,
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                cancellationToken: default);
-            using ExportProvider provider = factory.CreateExportProvider();
-            _ = provider.GetExportedValue<NonSharedPart>();
-            _ = provider.GetExportedValue<NonSharedPart>();
-
-            Assert.Equal(1, GetExpressionCompilationCount(factory));
+            _ = first.Value;
+            Assert.Equal(0, GetFusedActivationPlanCount(factory));
         }
 
-        private static IExportProviderFactory CreateFactory(ExportProviderFactoryOptions options, params Type[] partTypes)
+        using (Export<FactoryOnlyRoot> second = owner.Factory.CreateExport())
         {
-            RuntimeComposition composition = RuntimeComposition.CreateRuntimeComposition(CreateConfiguration(partTypes));
-            return composition.CreateExportProviderFactory(options);
+            _ = second.Value;
+            Assert.Equal(1, GetFusedActivationPlanCount(factory));
+            Assert.Equal(1, GetFusedExpressionCompilationCount(factory));
         }
+    }
 
-        private static IExportProviderFactory CreateBoundaryPlanFactory()
-        {
-            return CreateFactory(
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
-                typeof(BoundaryPlanOwner),
-                typeof(BoundaryGraphRoot),
-                typeof(BoundaryGraphLeaf),
-                typeof(BoundaryScopedDependency),
-                typeof(GlobalSharedDependency),
-                typeof(BoundaryCycleA),
-                typeof(BoundaryCycleB),
-                typeof(BoundaryCycleHelperA),
-                typeof(BoundaryCycleHelperB),
-                typeof(DisposableBoundaryRoot));
-        }
+    /// <summary>
+    /// Verifies that fused member imports preserve the lifecycle engine's failure diagnostics.
+    /// </summary>
+    [Fact]
+    public void FusedActivationPreservesImportFailureDiagnostics()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(FailingFactoryOwner),
+            typeof(FailingFactoryRoot),
+            typeof(ThrowingDependency),
+            typeof(FactoryOnlyDependencyA),
+            typeof(FactoryOnlyDependencyB));
+        using ExportProvider provider = factory.CreateExportProvider();
+        FailingFactoryOwner owner = provider.GetExportedValue<FailingFactoryOwner>();
 
-        private static CompositionConfiguration CreateConfiguration(params Type[] partTypes)
-        {
-            var resolver = Resolver.DefaultInstance;
-            var discovery = new AttributedPartDiscovery(resolver, isNonPublicSupported: true);
-            DiscoveredParts discoveredParts = discovery.CreatePartsAsync(partTypes).GetAwaiter().GetResult();
-            ComposableCatalog catalog = ComposableCatalog.Create(resolver).AddParts(discoveredParts);
-            return CompositionConfiguration.Create(catalog);
-        }
-
-        private static int GetExpressionCompilationCount(IExportProviderFactory factory)
-        {
-            PropertyInfo property = factory.GetType().GetProperty("ExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            return (int)property.GetValue(factory)!;
-        }
-
-        private static int GetDirectActivationPlanCount(IExportProviderFactory factory)
-        {
-            PropertyInfo property = factory.GetType().GetProperty("DirectActivationPlanCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            return (int)property.GetValue(factory)!;
-        }
-
-        private static int GetFusedActivationPlanCount(IExportProviderFactory factory)
-        {
-            PropertyInfo property = factory.GetType().GetProperty("FusedActivationPlanCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            return (int)property.GetValue(factory)!;
-        }
-
-        private static int GetFusedExpressionCompilationCount(IExportProviderFactory factory)
-        {
-            PropertyInfo property = factory.GetType().GetProperty("FusedExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            return (int)property.GetValue(factory)!;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static WeakReference CreateAndDisposeCompiledBoundary(BoundaryPlanOwner owner)
-        {
-            using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
+        CompositionFailedException firstException = Assert.Throws<CompositionFailedException>(
+            () =>
             {
-                _ = first.Value;
-            }
+                using Export<FailingFactoryRoot> first = owner.Factory.CreateExport();
+            });
 
-            using (Export<BoundaryGraphRoot> second = owner.GraphFactory.CreateExport())
+        CompositionFailedException secondException = Assert.Throws<CompositionFailedException>(
+            () =>
             {
-                return new WeakReference(second.Value.Scoped);
-            }
+                using Export<FailingFactoryRoot> second = owner.Factory.CreateExport();
+            });
+
+        Assert.Equal(1, GetFusedActivationPlanCount(factory));
+        Assert.Equal(firstException.Message, secondException.Message);
+        Assert.Equal(firstException.InnerException?.Message, secondException.InnerException?.Message);
+    }
+
+    /// <summary>
+    /// Verifies that a nested export factory remains deferred while the surrounding island is fused.
+    /// </summary>
+    [Fact]
+    public void FusedActivationStopsAtNestedExportFactory()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(NestedFactoryOwner),
+            typeof(NestedFactoryRoot),
+            typeof(DeferredFactoryPart),
+            typeof(DeferredFactoryControl),
+            typeof(FactoryOnlyDependencyA),
+            typeof(FactoryOnlyDependencyB),
+            typeof(FactoryOnlyDependencyC),
+            typeof(FactoryOnlyDependencyD));
+        using ExportProvider provider = factory.CreateExportProvider();
+        NestedFactoryOwner owner = provider.GetExportedValue<NestedFactoryOwner>();
+        DeferredFactoryControl control = provider.GetExportedValue<DeferredFactoryControl>();
+
+        using (Export<NestedFactoryRoot> first = owner.Factory.CreateExport())
+        {
+            Assert.Equal(0, control.ActivationCount);
         }
 
-        [Export]
-        private sealed class NonSharedPart
+        using (Export<NestedFactoryRoot> second = owner.Factory.CreateExport())
+        {
+            Assert.Equal(1, GetFusedActivationPlanCount(factory));
+            Assert.Equal(0, control.ActivationCount);
+
+            using Export<DeferredFactoryPart> nested = second.Value.NestedFactory.CreateExport();
+            Assert.NotNull(nested.Value);
+            Assert.Equal(1, control.ActivationCount);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that concurrent boundary activations share one plan without sharing scoped instances.
+    /// </summary>
+    [Fact]
+    public async Task DirectActivationPlanIsSafeAcrossConcurrentBoundaries()
+    {
+        IExportProviderFactory factory = CreateBoundaryPlanFactory();
+        using ExportProvider provider = factory.CreateExportProvider();
+        BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+        using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
+        {
+            _ = first.Value;
+        }
+
+        BoundaryScopedDependency[] scopedDependencies = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(
+                _ => Task.Run(
+                    () =>
+                    {
+                        using Export<BoundaryGraphRoot> export = owner.GraphFactory.CreateExport();
+                        BoundaryGraphRoot root = export.Value;
+                        Assert.Same(root.Scoped, root.Leaf.Scoped);
+                        return root.Scoped;
+                    })));
+
+        Assert.Equal(scopedDependencies.Length, scopedDependencies.Distinct().Count());
+        Assert.All(scopedDependencies, scoped => Assert.True(scoped.IsDisposed));
+        Assert.Equal(1, GetDirectActivationPlanCount(factory));
+    }
+
+    /// <summary>
+    /// Verifies that a shared plan does not retain values from its first boundary provider.
+    /// </summary>
+    [Fact]
+    [Trait("WeakReference", "true")]
+    [Trait(Traits.SkipOnMono, "WeakReference")]
+    public void DirectActivationPlanDoesNotRetainDisposedBoundary()
+    {
+        IExportProviderFactory factory = CreateBoundaryPlanFactory();
+        using ExportProvider provider = factory.CreateExportProvider();
+        BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+        WeakReference scopedDependency = CreateAndDisposeCompiledBoundary(owner);
+        Assert.Equal(1, GetDirectActivationPlanCount(factory));
+
+        GC.Collect();
+        Assert.False(scopedDependency.IsAlive);
+    }
+
+    /// <summary>
+    /// Verifies that phased direct plans preserve property-import cycles within each boundary.
+    /// </summary>
+    [Fact]
+    public void DirectActivationPlanPreservesPropertyImportCycles()
+    {
+        IExportProviderFactory factory = CreateBoundaryPlanFactory();
+        using ExportProvider provider = factory.CreateExportProvider();
+        BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+        using (Export<BoundaryCycleA> first = owner.CycleFactory.CreateExport())
+        {
+            Assert.Same(first.Value, first.Value.B.A);
+        }
+
+        using (Export<BoundaryCycleA> second = owner.CycleFactory.CreateExport())
+        {
+            Assert.Same(second.Value, second.Value.B.A);
+            Assert.True(GetDirectActivationPlanCount(factory) >= 1);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposable boundary roots remain on the lifecycle path.
+    /// </summary>
+    [Fact]
+    public void DisposableBoundaryRootDoesNotUseDirectActivationPlan()
+    {
+        IExportProviderFactory factory = CreateBoundaryPlanFactory();
+        using ExportProvider provider = factory.CreateExportProvider();
+        BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+        DisposableBoundaryRoot firstValue;
+        using (Export<DisposableBoundaryRoot> first = owner.DisposableFactory.CreateExport())
+        {
+            firstValue = first.Value;
+            Assert.False(firstValue.IsDisposed);
+        }
+
+        Assert.True(firstValue.IsDisposed);
+
+        DisposableBoundaryRoot secondValue;
+        using (Export<DisposableBoundaryRoot> second = owner.DisposableFactory.CreateExport())
+        {
+            secondValue = second.Value;
+            Assert.False(secondValue.IsDisposed);
+        }
+
+        Assert.True(secondValue.IsDisposed);
+        Assert.Equal(0, GetDirectActivationPlanCount(factory));
+    }
+
+    /// <summary>
+    /// Verifies that a compiled direct plan correctly satisfies constructor, property, and many imports.
+    /// </summary>
+    [Fact]
+    public void CompiledDirectPlanSatisfiesImports()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(ImportedPart),
+            typeof(ImportedProperty),
+            typeof(FirstAdapter),
+            typeof(SecondAdapter));
+        using ExportProvider provider = factory.CreateExportProvider();
+
+        ImportedPart first = provider.GetExportedValue<ImportedPart>();
+        Assert.Equal(0, GetExpressionCompilationCount(factory));
+        Assert.IsType<ImportedProperty>(first.Property);
+        Assert.Contains(first.Adapters, adapter => adapter is FirstAdapter);
+        Assert.Contains(first.Adapters, adapter => adapter is SecondAdapter);
+
+        ImportedPart second = provider.GetExportedValue<ImportedPart>();
+        Assert.NotSame(first, second);
+        Assert.True(GetExpressionCompilationCount(factory) > 0);
+        Assert.IsType<ImportedProperty>(second.Property);
+        Assert.Contains(second.Adapters, adapter => adapter is FirstAdapter);
+        Assert.Contains(second.Adapters, adapter => adapter is SecondAdapter);
+    }
+
+    /// <summary>
+    /// Verifies that undefined options are rejected.
+    /// </summary>
+    [Fact]
+    public void UndefinedOptionIsRejected()
+    {
+        var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
+        RuntimeComposition composition = RuntimeComposition.CreateRuntimeComposition(configuration);
+
+        Assert.Throws<ArgumentException>(() => composition.CreateExportProviderFactory((ExportProviderFactoryOptions)0x2));
+    }
+
+    /// <summary>
+    /// Verifies that cached-composition loading propagates expression compilation options.
+    /// </summary>
+    [Fact]
+    public async Task CachedCompositionPropagatesOptions()
+    {
+        CompositionConfiguration configuration = CreateConfiguration(typeof(NonSharedPart));
+        var cache = new CachedComposition();
+        using var stream = new MemoryStream();
+        await cache.SaveAsync(configuration, stream);
+        stream.Position = 0;
+
+        IExportProviderFactory factory = await cache.LoadExportProviderFactoryAsync(
+            stream,
+            Resolver.DefaultInstance,
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            cancellationToken: default);
+        using ExportProvider provider = factory.CreateExportProvider();
+        _ = provider.GetExportedValue<NonSharedPart>();
+        _ = provider.GetExportedValue<NonSharedPart>();
+
+        Assert.Equal(1, GetExpressionCompilationCount(factory));
+    }
+
+    private static IExportProviderFactory CreateFactory(ExportProviderFactoryOptions options, params Type[] partTypes)
+    {
+        RuntimeComposition composition = RuntimeComposition.CreateRuntimeComposition(CreateConfiguration(partTypes));
+        return composition.CreateExportProviderFactory(options);
+    }
+
+    private static IExportProviderFactory CreateBoundaryPlanFactory()
+    {
+        return CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(BoundaryPlanOwner),
+            typeof(BoundaryGraphRoot),
+            typeof(BoundaryGraphLeaf),
+            typeof(BoundaryScopedDependency),
+            typeof(GlobalSharedDependency),
+            typeof(BoundaryCycleA),
+            typeof(BoundaryCycleB),
+            typeof(BoundaryCycleHelperA),
+            typeof(BoundaryCycleHelperB),
+            typeof(DisposableBoundaryRoot));
+    }
+
+    private static CompositionConfiguration CreateConfiguration(params Type[] partTypes)
+    {
+        var resolver = Resolver.DefaultInstance;
+        var discovery = new AttributedPartDiscovery(resolver, isNonPublicSupported: true);
+        DiscoveredParts discoveredParts = discovery.CreatePartsAsync(partTypes).GetAwaiter().GetResult();
+        ComposableCatalog catalog = ComposableCatalog.Create(resolver).AddParts(discoveredParts);
+        return CompositionConfiguration.Create(catalog);
+    }
+
+    private static int GetExpressionCompilationCount(IExportProviderFactory factory)
+    {
+        PropertyInfo property = factory.GetType().GetProperty("ExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (int)property.GetValue(factory)!;
+    }
+
+    private static int GetDirectActivationPlanCount(IExportProviderFactory factory)
+    {
+        PropertyInfo property = factory.GetType().GetProperty("DirectActivationPlanCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (int)property.GetValue(factory)!;
+    }
+
+    private static int GetFusedActivationPlanCount(IExportProviderFactory factory)
+    {
+        PropertyInfo property = factory.GetType().GetProperty("FusedActivationPlanCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (int)property.GetValue(factory)!;
+    }
+
+    private static int GetFusedExpressionCompilationCount(IExportProviderFactory factory)
+    {
+        PropertyInfo property = factory.GetType().GetProperty("FusedExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (int)property.GetValue(factory)!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateAndDisposeCompiledBoundary(BoundaryPlanOwner owner)
+    {
+        using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
+        {
+            _ = first.Value;
+        }
+
+        using (Export<BoundaryGraphRoot> second = owner.GraphFactory.CreateExport())
+        {
+            return new WeakReference(second.Value.Scoped);
+        }
+    }
+
+    [Export]
+    private sealed class NonSharedPart
+    {
+    }
+
+    [Export, Shared]
+    private sealed class ApplicationSharedPart
+    {
+    }
+
+    [Export, Shared]
+    private sealed class SharingBoundaryOwner
+    {
+        [Import, SharingBoundary("TestBoundary")]
+        internal ExportFactory<SharingBoundaryPart> Factory { get; set; } = null!;
+    }
+
+    [Export, Shared("TestBoundary")]
+    private sealed class SharingBoundaryPart
+    {
+        [Import]
+        internal SharingBoundarySimpleDependency Dependency { get; set; } = null!;
+    }
+
+    [Export, Shared]
+    private sealed class SharingBoundarySimpleDependency
+    {
+    }
+
+    [Export, Shared]
+    private sealed class BoundaryPlanOwner
+    {
+        [Import, SharingBoundary("SharedPlanBoundary")]
+        internal ExportFactory<BoundaryGraphRoot> GraphFactory { get; set; } = null!;
+
+        [Import, SharingBoundary("SharedPlanBoundary")]
+        internal ExportFactory<BoundaryCycleA> CycleFactory { get; set; } = null!;
+
+        [Import, SharingBoundary("SharedPlanBoundary")]
+        internal ExportFactory<DisposableBoundaryRoot> DisposableFactory { get; set; } = null!;
+    }
+
+    [Export, Shared("SharedPlanBoundary")]
+    private sealed class BoundaryGraphRoot
+    {
+        [ImportingConstructor]
+        internal BoundaryGraphRoot(BoundaryGraphLeaf leaf)
+        {
+            this.Leaf = leaf;
+        }
+
+        internal BoundaryGraphLeaf Leaf { get; }
+
+        [Import]
+        internal BoundaryScopedDependency Scoped { get; set; } = null!;
+
+        [Import]
+        internal GlobalSharedDependency Global { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class BoundaryGraphLeaf
+    {
+        [ImportingConstructor]
+        internal BoundaryGraphLeaf(BoundaryScopedDependency scoped)
+        {
+            this.Scoped = scoped;
+        }
+
+        internal BoundaryScopedDependency Scoped { get; }
+    }
+
+    [Export, Shared("SharedPlanBoundary")]
+    private sealed class BoundaryScopedDependency : IDisposable
+    {
+        internal bool IsDisposed { get; private set; }
+
+        public void Dispose() => this.IsDisposed = true;
+    }
+
+    [Export, Shared]
+    private sealed class GlobalSharedDependency : IDisposable
+    {
+        internal bool IsDisposed { get; private set; }
+
+        public void Dispose() => this.IsDisposed = true;
+    }
+
+    [Export, Shared("SharedPlanBoundary")]
+    private sealed class BoundaryCycleA
+    {
+        [Import]
+        internal BoundaryCycleB B { get; set; } = null!;
+
+        [Import]
+        internal BoundaryCycleHelperA HelperA { get; set; } = null!;
+
+        [Import]
+        internal BoundaryCycleHelperB HelperB { get; set; } = null!;
+    }
+
+    [Export, Shared("SharedPlanBoundary")]
+    private sealed class BoundaryCycleB
+    {
+        [Import]
+        internal BoundaryCycleA A { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class BoundaryCycleHelperA
+    {
+    }
+
+    [Export]
+    private sealed class BoundaryCycleHelperB
+    {
+    }
+
+    [Export, Shared("SharedPlanBoundary")]
+    private sealed class DisposableBoundaryRoot : IDisposable
+    {
+        internal bool IsDisposed { get; private set; }
+
+        public void Dispose() => this.IsDisposed = true;
+    }
+
+    [Export, Shared]
+    private sealed class FactoryOnlyOwner
+    {
+        [Import]
+        internal ExportFactory<FactoryOnlyRoot> Factory { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class FactoryOnlyRoot
+    {
+        [ImportingConstructor]
+        internal FactoryOnlyRoot(
+            FactoryOnlyDependencyA dependencyA,
+            FactoryOnlyDependencyB dependencyB,
+            FactoryOnlyDependencyC dependencyC,
+            FactoryOnlyDependencyD dependencyD)
+        {
+        }
+    }
+
+    [Export]
+    private sealed class FactoryOnlyDependencyA
+    {
+    }
+
+    [Export]
+    private sealed class FactoryOnlyDependencyB
+    {
+    }
+
+    [Export]
+    private sealed class FactoryOnlyDependencyC
+    {
+    }
+
+    [Export]
+    private sealed class FactoryOnlyDependencyD
+    {
+    }
+
+    [Export, Shared]
+    private sealed class FailingFactoryOwner
+    {
+        [Import]
+        internal ExportFactory<FailingFactoryRoot> Factory { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class FailingFactoryRoot
+    {
+        [Import]
+        internal ThrowingDependency FailingImport { get; set; } = null!;
+
+        [Import]
+        internal FactoryOnlyDependencyA DependencyA { get; set; } = null!;
+
+        [Import]
+        internal FactoryOnlyDependencyB DependencyB { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class ThrowingDependency
+    {
+        internal ThrowingDependency()
+        {
+            throw new InvalidOperationException("Expected activation failure.");
+        }
+    }
+
+    [Export, Shared]
+    private sealed class NestedFactoryOwner
+    {
+        [Import]
+        internal ExportFactory<NestedFactoryRoot> Factory { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class NestedFactoryRoot
+    {
+        [ImportingConstructor]
+        internal NestedFactoryRoot(
+            FactoryOnlyDependencyA dependencyA,
+            FactoryOnlyDependencyB dependencyB,
+            FactoryOnlyDependencyC dependencyC,
+            FactoryOnlyDependencyD dependencyD)
         {
         }
 
-        [Export, Shared]
-        private sealed class ApplicationSharedPart
+        [Import]
+        internal ExportFactory<DeferredFactoryPart> NestedFactory { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class DeferredFactoryPart
+    {
+        [ImportingConstructor]
+        internal DeferredFactoryPart(DeferredFactoryControl control)
         {
+            control.ActivationCount++;
+        }
+    }
+
+    [Export, Shared]
+    private sealed class DeferredFactoryControl
+    {
+        internal int ActivationCount { get; set; }
+    }
+
+    [Export]
+    private sealed class ImportedPart
+    {
+        [ImportingConstructor]
+        internal ImportedPart([ImportMany] IEnumerable<IAdapter> adapters)
+        {
+            this.Adapters = adapters;
         }
 
-        [Export, Shared]
-        private sealed class SharingBoundaryOwner
-        {
-            [Import, SharingBoundary("TestBoundary")]
-            internal ExportFactory<SharingBoundaryPart> Factory { get; set; } = null!;
-        }
+        internal IEnumerable<IAdapter> Adapters { get; }
 
-        [Export, Shared("TestBoundary")]
-        private sealed class SharingBoundaryPart
-        {
-            [Import]
-            internal SharingBoundarySimpleDependency Dependency { get; set; } = null!;
-        }
+        [Import]
+        internal ImportedProperty Property { get; set; } = null!;
+    }
 
-        [Export, Shared]
-        private sealed class SharingBoundarySimpleDependency
-        {
-        }
+    [Export]
+    private sealed class ImportedProperty
+    {
+    }
 
-        [Export, Shared]
-        private sealed class BoundaryPlanOwner
-        {
-            [Import, SharingBoundary("SharedPlanBoundary")]
-            internal ExportFactory<BoundaryGraphRoot> GraphFactory { get; set; } = null!;
+    private interface IAdapter
+    {
+    }
 
-            [Import, SharingBoundary("SharedPlanBoundary")]
-            internal ExportFactory<BoundaryCycleA> CycleFactory { get; set; } = null!;
+    [Export(typeof(IAdapter))]
+    private sealed class FirstAdapter : IAdapter
+    {
+    }
 
-            [Import, SharingBoundary("SharedPlanBoundary")]
-            internal ExportFactory<DisposableBoundaryRoot> DisposableFactory { get; set; } = null!;
-        }
-
-        [Export, Shared("SharedPlanBoundary")]
-        private sealed class BoundaryGraphRoot
-        {
-            [ImportingConstructor]
-            internal BoundaryGraphRoot(BoundaryGraphLeaf leaf)
-            {
-                this.Leaf = leaf;
-            }
-
-            internal BoundaryGraphLeaf Leaf { get; }
-
-            [Import]
-            internal BoundaryScopedDependency Scoped { get; set; } = null!;
-
-            [Import]
-            internal GlobalSharedDependency Global { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class BoundaryGraphLeaf
-        {
-            [ImportingConstructor]
-            internal BoundaryGraphLeaf(BoundaryScopedDependency scoped)
-            {
-                this.Scoped = scoped;
-            }
-
-            internal BoundaryScopedDependency Scoped { get; }
-        }
-
-        [Export, Shared("SharedPlanBoundary")]
-        private sealed class BoundaryScopedDependency : IDisposable
-        {
-            internal bool IsDisposed { get; private set; }
-
-            public void Dispose() => this.IsDisposed = true;
-        }
-
-        [Export, Shared]
-        private sealed class GlobalSharedDependency : IDisposable
-        {
-            internal bool IsDisposed { get; private set; }
-
-            public void Dispose() => this.IsDisposed = true;
-        }
-
-        [Export, Shared("SharedPlanBoundary")]
-        private sealed class BoundaryCycleA
-        {
-            [Import]
-            internal BoundaryCycleB B { get; set; } = null!;
-
-            [Import]
-            internal BoundaryCycleHelperA HelperA { get; set; } = null!;
-
-            [Import]
-            internal BoundaryCycleHelperB HelperB { get; set; } = null!;
-        }
-
-        [Export, Shared("SharedPlanBoundary")]
-        private sealed class BoundaryCycleB
-        {
-            [Import]
-            internal BoundaryCycleA A { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class BoundaryCycleHelperA
-        {
-        }
-
-        [Export]
-        private sealed class BoundaryCycleHelperB
-        {
-        }
-
-        [Export, Shared("SharedPlanBoundary")]
-        private sealed class DisposableBoundaryRoot : IDisposable
-        {
-            internal bool IsDisposed { get; private set; }
-
-            public void Dispose() => this.IsDisposed = true;
-        }
-
-        [Export, Shared]
-        private sealed class FactoryOnlyOwner
-        {
-            [Import]
-            internal ExportFactory<FactoryOnlyRoot> Factory { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class FactoryOnlyRoot
-        {
-            [ImportingConstructor]
-            internal FactoryOnlyRoot(
-                FactoryOnlyDependencyA dependencyA,
-                FactoryOnlyDependencyB dependencyB,
-                FactoryOnlyDependencyC dependencyC,
-                FactoryOnlyDependencyD dependencyD)
-            {
-            }
-        }
-
-        [Export]
-        private sealed class FactoryOnlyDependencyA
-        {
-        }
-
-        [Export]
-        private sealed class FactoryOnlyDependencyB
-        {
-        }
-
-        [Export]
-        private sealed class FactoryOnlyDependencyC
-        {
-        }
-
-        [Export]
-        private sealed class FactoryOnlyDependencyD
-        {
-        }
-
-        [Export, Shared]
-        private sealed class FailingFactoryOwner
-        {
-            [Import]
-            internal ExportFactory<FailingFactoryRoot> Factory { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class FailingFactoryRoot
-        {
-            [Import]
-            internal ThrowingDependency FailingImport { get; set; } = null!;
-
-            [Import]
-            internal FactoryOnlyDependencyA DependencyA { get; set; } = null!;
-
-            [Import]
-            internal FactoryOnlyDependencyB DependencyB { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class ThrowingDependency
-        {
-            internal ThrowingDependency()
-            {
-                throw new InvalidOperationException("Expected activation failure.");
-            }
-        }
-
-        [Export, Shared]
-        private sealed class NestedFactoryOwner
-        {
-            [Import]
-            internal ExportFactory<NestedFactoryRoot> Factory { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class NestedFactoryRoot
-        {
-            [ImportingConstructor]
-            internal NestedFactoryRoot(
-                FactoryOnlyDependencyA dependencyA,
-                FactoryOnlyDependencyB dependencyB,
-                FactoryOnlyDependencyC dependencyC,
-                FactoryOnlyDependencyD dependencyD)
-            {
-            }
-
-            [Import]
-            internal ExportFactory<DeferredFactoryPart> NestedFactory { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class DeferredFactoryPart
-        {
-            [ImportingConstructor]
-            internal DeferredFactoryPart(DeferredFactoryControl control)
-            {
-                control.ActivationCount++;
-            }
-        }
-
-        [Export, Shared]
-        private sealed class DeferredFactoryControl
-        {
-            internal int ActivationCount { get; set; }
-        }
-
-        [Export]
-        private sealed class ImportedPart
-        {
-            [ImportingConstructor]
-            internal ImportedPart([ImportMany] IEnumerable<IAdapter> adapters)
-            {
-                this.Adapters = adapters;
-            }
-
-            internal IEnumerable<IAdapter> Adapters { get; }
-
-            [Import]
-            internal ImportedProperty Property { get; set; } = null!;
-        }
-
-        [Export]
-        private sealed class ImportedProperty
-        {
-        }
-
-        private interface IAdapter
-        {
-        }
-
-        [Export(typeof(IAdapter))]
-        private sealed class FirstAdapter : IAdapter
-        {
-        }
-
-        [Export(typeof(IAdapter))]
-        private sealed class SecondAdapter : IAdapter
-        {
-        }
+    [Export(typeof(IAdapter))]
+    private sealed class SecondAdapter : IAdapter
+    {
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -115,6 +115,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 BoundaryGraphRoot root = first.Value;
                 Assert.Equal(0, GetDirectActivationPlanCount(factory));
+                Assert.Equal(0, GetFusedActivationPlanCount(factory));
                 Assert.Same(root.Scoped, root.Leaf.Scoped);
                 firstScoped = root.Scoped;
                 global = root.Global;
@@ -130,6 +131,9 @@ namespace Microsoft.VisualStudio.Composition.Tests
             {
                 BoundaryGraphRoot root = second.Value;
                 Assert.Equal(1, GetDirectActivationPlanCount(factory));
+                Assert.Equal(1, GetFusedActivationPlanCount(factory));
+                Assert.Equal(2, GetFusedExpressionCompilationCount(factory));
+                Assert.Equal(3, GetExpressionCompilationCount(factory));
                 Assert.Same(root.Scoped, root.Leaf.Scoped);
                 Assert.NotSame(firstScoped, root.Scoped);
                 Assert.Same(global, root.Global);
@@ -141,6 +145,110 @@ namespace Microsoft.VisualStudio.Composition.Tests
             Assert.False(global.IsDisposed);
             provider.Dispose();
             Assert.True(global.IsDisposed);
+        }
+
+        /// <summary>
+        /// Verifies that incidental activation does not trigger fusion before an export factory is exercised twice.
+        /// </summary>
+        [Fact]
+        public void FusedActivationRequiresRepeatedExportFactoryUse()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(FactoryOnlyOwner),
+                typeof(FactoryOnlyRoot),
+                typeof(FactoryOnlyDependencyA),
+                typeof(FactoryOnlyDependencyB),
+                typeof(FactoryOnlyDependencyC),
+                typeof(FactoryOnlyDependencyD));
+            using ExportProvider provider = factory.CreateExportProvider();
+
+            _ = provider.GetExportedValue<FactoryOnlyRoot>();
+            _ = provider.GetExportedValue<FactoryOnlyRoot>();
+            Assert.Equal(0, GetFusedActivationPlanCount(factory));
+
+            FactoryOnlyOwner owner = provider.GetExportedValue<FactoryOnlyOwner>();
+            using (Export<FactoryOnlyRoot> first = owner.Factory.CreateExport())
+            {
+                _ = first.Value;
+                Assert.Equal(0, GetFusedActivationPlanCount(factory));
+            }
+
+            using (Export<FactoryOnlyRoot> second = owner.Factory.CreateExport())
+            {
+                _ = second.Value;
+                Assert.Equal(1, GetFusedActivationPlanCount(factory));
+                Assert.Equal(1, GetFusedExpressionCompilationCount(factory));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that fused member imports preserve the lifecycle engine's failure diagnostics.
+        /// </summary>
+        [Fact]
+        public void FusedActivationPreservesImportFailureDiagnostics()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(FailingFactoryOwner),
+                typeof(FailingFactoryRoot),
+                typeof(ThrowingDependency),
+                typeof(FactoryOnlyDependencyA),
+                typeof(FactoryOnlyDependencyB));
+            using ExportProvider provider = factory.CreateExportProvider();
+            FailingFactoryOwner owner = provider.GetExportedValue<FailingFactoryOwner>();
+
+            CompositionFailedException firstException = Assert.Throws<CompositionFailedException>(
+                () =>
+                {
+                    using Export<FailingFactoryRoot> first = owner.Factory.CreateExport();
+                });
+
+            CompositionFailedException secondException = Assert.Throws<CompositionFailedException>(
+                () =>
+                {
+                    using Export<FailingFactoryRoot> second = owner.Factory.CreateExport();
+                });
+
+            Assert.Equal(1, GetFusedActivationPlanCount(factory));
+            Assert.Equal(firstException.Message, secondException.Message);
+            Assert.Equal(firstException.InnerException?.Message, secondException.InnerException?.Message);
+        }
+
+        /// <summary>
+        /// Verifies that a nested export factory remains deferred while the surrounding island is fused.
+        /// </summary>
+        [Fact]
+        public void FusedActivationStopsAtNestedExportFactory()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(NestedFactoryOwner),
+                typeof(NestedFactoryRoot),
+                typeof(DeferredFactoryPart),
+                typeof(DeferredFactoryControl),
+                typeof(FactoryOnlyDependencyA),
+                typeof(FactoryOnlyDependencyB),
+                typeof(FactoryOnlyDependencyC),
+                typeof(FactoryOnlyDependencyD));
+            using ExportProvider provider = factory.CreateExportProvider();
+            NestedFactoryOwner owner = provider.GetExportedValue<NestedFactoryOwner>();
+            DeferredFactoryControl control = provider.GetExportedValue<DeferredFactoryControl>();
+
+            using (Export<NestedFactoryRoot> first = owner.Factory.CreateExport())
+            {
+                Assert.Equal(0, control.ActivationCount);
+            }
+
+            using (Export<NestedFactoryRoot> second = owner.Factory.CreateExport())
+            {
+                Assert.Equal(1, GetFusedActivationPlanCount(factory));
+                Assert.Equal(0, control.ActivationCount);
+
+                using Export<DeferredFactoryPart> nested = second.Value.NestedFactory.CreateExport();
+                Assert.NotNull(nested.Value);
+                Assert.Equal(1, control.ActivationCount);
+            }
         }
 
         /// <summary>
@@ -350,6 +458,18 @@ namespace Microsoft.VisualStudio.Composition.Tests
             return (int)property.GetValue(factory)!;
         }
 
+        private static int GetFusedActivationPlanCount(IExportProviderFactory factory)
+        {
+            PropertyInfo property = factory.GetType().GetProperty("FusedActivationPlanCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (int)property.GetValue(factory)!;
+        }
+
+        private static int GetFusedExpressionCompilationCount(IExportProviderFactory factory)
+        {
+            PropertyInfo property = factory.GetType().GetProperty("FusedExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (int)property.GetValue(factory)!;
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static WeakReference CreateAndDisposeCompiledBoundary(BoundaryPlanOwner owner)
         {
@@ -488,6 +608,114 @@ namespace Microsoft.VisualStudio.Composition.Tests
             internal bool IsDisposed { get; private set; }
 
             public void Dispose() => this.IsDisposed = true;
+        }
+
+        [Export, Shared]
+        private sealed class FactoryOnlyOwner
+        {
+            [Import]
+            internal ExportFactory<FactoryOnlyRoot> Factory { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class FactoryOnlyRoot
+        {
+            [ImportingConstructor]
+            internal FactoryOnlyRoot(
+                FactoryOnlyDependencyA dependencyA,
+                FactoryOnlyDependencyB dependencyB,
+                FactoryOnlyDependencyC dependencyC,
+                FactoryOnlyDependencyD dependencyD)
+            {
+            }
+        }
+
+        [Export]
+        private sealed class FactoryOnlyDependencyA
+        {
+        }
+
+        [Export]
+        private sealed class FactoryOnlyDependencyB
+        {
+        }
+
+        [Export]
+        private sealed class FactoryOnlyDependencyC
+        {
+        }
+
+        [Export]
+        private sealed class FactoryOnlyDependencyD
+        {
+        }
+
+        [Export, Shared]
+        private sealed class FailingFactoryOwner
+        {
+            [Import]
+            internal ExportFactory<FailingFactoryRoot> Factory { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class FailingFactoryRoot
+        {
+            [Import]
+            internal ThrowingDependency FailingImport { get; set; } = null!;
+
+            [Import]
+            internal FactoryOnlyDependencyA DependencyA { get; set; } = null!;
+
+            [Import]
+            internal FactoryOnlyDependencyB DependencyB { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class ThrowingDependency
+        {
+            internal ThrowingDependency()
+            {
+                throw new InvalidOperationException("Expected activation failure.");
+            }
+        }
+
+        [Export, Shared]
+        private sealed class NestedFactoryOwner
+        {
+            [Import]
+            internal ExportFactory<NestedFactoryRoot> Factory { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class NestedFactoryRoot
+        {
+            [ImportingConstructor]
+            internal NestedFactoryRoot(
+                FactoryOnlyDependencyA dependencyA,
+                FactoryOnlyDependencyB dependencyB,
+                FactoryOnlyDependencyC dependencyC,
+                FactoryOnlyDependencyD dependencyD)
+            {
+            }
+
+            [Import]
+            internal ExportFactory<DeferredFactoryPart> NestedFactory { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class DeferredFactoryPart
+        {
+            [ImportingConstructor]
+            internal DeferredFactoryPart(DeferredFactoryControl control)
+            {
+                control.ActivationCount++;
+            }
+        }
+
+        [Export, Shared]
+        private sealed class DeferredFactoryControl
+        {
+            internal int ActivationCount { get; set; }
         }
 
         [Export]

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -36,6 +36,28 @@ public class ActivationExpressionCompilationTests
     }
 
     /// <summary>
+    /// Verifies that the reflection fallback matches compiled constructor exception behavior.
+    /// </summary>
+    [Fact]
+    public void ReflectionInstanceFactoryFallbackUnwrapsTargetInvocationException()
+    {
+        ConstructorInfo constructor = typeof(ThrowingDependency).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            Type.EmptyTypes,
+            modifiers: null)!;
+
+        MethodInfo fallbackMethod = typeof(ReflectionHelpers).GetMethod(
+            "InstantiateWithoutTargetInvocationException",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        TargetInvocationException invocationException = Assert.Throws<TargetInvocationException>(
+            () => fallbackMethod.Invoke(null, new object?[] { constructor, Array.Empty<object?>() }));
+        InvalidOperationException exception = Assert.IsType<InvalidOperationException>(invocationException.InnerException);
+
+        Assert.Equal("Expected activation failure.", exception.Message);
+    }
+
+    /// <summary>
     /// Verifies that fault-reporting providers retain callback behavior after repeated activation.
     /// </summary>
     [Fact]

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -18,6 +19,22 @@ using Xunit;
 /// </summary>
 public class ActivationExpressionCompilationTests
 {
+    /// <summary>
+    /// Verifies that unsupported expression compilation is reported as unavailable instead of throwing.
+    /// </summary>
+    [Fact]
+    public void ExpressionCompilationFailureReturnsFalse()
+    {
+        Expression<Func<int>> expression = Expression.Lambda<Func<int>>(new UnsupportedCompilationExpression());
+        MethodInfo tryCompileMethod = typeof(ReflectionHelpers)
+            .GetMethod("TryCompile", BindingFlags.Static | BindingFlags.NonPublic)!
+            .MakeGenericMethod(typeof(Func<int>));
+        object?[] arguments = new object?[] { expression, null };
+
+        Assert.False((bool)tryCompileMethod.Invoke(null, arguments)!);
+        Assert.Null(arguments[1]);
+    }
+
     /// <summary>
     /// Verifies that expression compilation is disabled by default.
     /// </summary>
@@ -751,5 +768,16 @@ public class ActivationExpressionCompilationTests
     [Export(typeof(IAdapter))]
     private sealed class SecondAdapter : IAdapter
     {
+    }
+
+    private sealed class UnsupportedCompilationExpression : Expression
+    {
+        public override bool CanReduce => true;
+
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        public override Type Type => typeof(int);
+
+        public override Expression Reduce() => throw new PlatformNotSupportedException();
     }
 }

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Composition.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Composition;
+    using System.IO;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    /// <summary>
+    /// Tests tiered expression compilation for repeated activation.
+    /// </summary>
+    public class ActivationExpressionCompilationTests
+    {
+        /// <summary>
+        /// Verifies that expression compilation is disabled by default.
+        /// </summary>
+        [Fact]
+        public void ExpressionCompilationIsDisabledByDefault()
+        {
+            IExportProviderFactory factory = CreateFactory(ExportProviderFactoryOptions.None, typeof(NonSharedPart));
+            using ExportProvider provider = factory.CreateExportProvider();
+
+            _ = provider.GetExportedValue<NonSharedPart>();
+            _ = provider.GetExportedValue<NonSharedPart>();
+
+            Assert.Equal(0, GetExpressionCompilationCount(factory));
+        }
+
+        /// <summary>
+        /// Verifies that a non-shared part compiles only after repeated activation.
+        /// </summary>
+        [Fact]
+        public void NonSharedPartCompilesOnSecondActivation()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(NonSharedPart));
+            using ExportProvider provider = factory.CreateExportProvider();
+
+            _ = provider.GetExportedValue<NonSharedPart>();
+            Assert.Equal(0, GetExpressionCompilationCount(factory));
+
+            _ = provider.GetExportedValue<NonSharedPart>();
+            Assert.Equal(1, GetExpressionCompilationCount(factory));
+
+            _ = provider.GetExportedValue<NonSharedPart>();
+            Assert.Equal(1, GetExpressionCompilationCount(factory));
+        }
+
+        /// <summary>
+        /// Verifies that application-wide shared parts are never expression compiled.
+        /// </summary>
+        [Fact]
+        public void ApplicationSharedPartDoesNotCompile()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(ApplicationSharedPart));
+            using ExportProvider provider = factory.CreateExportProvider();
+
+            _ = provider.GetExportedValue<ApplicationSharedPart>();
+            _ = provider.GetExportedValue<ApplicationSharedPart>();
+
+            Assert.Equal(0, GetExpressionCompilationCount(factory));
+        }
+
+        /// <summary>
+        /// Verifies that activation counts and compiled delegates are shared across sharing-boundary instances.
+        /// </summary>
+        [Fact]
+        public void SharingBoundaryPartCompilesOnSecondBoundaryInstance()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(SharingBoundaryOwner),
+                typeof(SharingBoundaryPart));
+            using ExportProvider provider = factory.CreateExportProvider();
+            SharingBoundaryOwner owner = provider.GetExportedValue<SharingBoundaryOwner>();
+
+            using (Export<SharingBoundaryPart> first = owner.Factory.CreateExport())
+            {
+                _ = first.Value;
+                Assert.Equal(0, GetExpressionCompilationCount(factory));
+            }
+
+            using (Export<SharingBoundaryPart> second = owner.Factory.CreateExport())
+            {
+                _ = second.Value;
+                Assert.Equal(1, GetExpressionCompilationCount(factory));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a compiled direct plan correctly satisfies constructor, property, and many imports.
+        /// </summary>
+        [Fact]
+        public void CompiledDirectPlanSatisfiesImports()
+        {
+            IExportProviderFactory factory = CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(ImportedPart),
+                typeof(ImportedProperty),
+                typeof(FirstAdapter),
+                typeof(SecondAdapter));
+            using ExportProvider provider = factory.CreateExportProvider();
+
+            ImportedPart first = provider.GetExportedValue<ImportedPart>();
+            Assert.Equal(0, GetExpressionCompilationCount(factory));
+            Assert.IsType<ImportedProperty>(first.Property);
+            Assert.Contains(first.Adapters, adapter => adapter is FirstAdapter);
+            Assert.Contains(first.Adapters, adapter => adapter is SecondAdapter);
+
+            ImportedPart second = provider.GetExportedValue<ImportedPart>();
+            Assert.NotSame(first, second);
+            Assert.True(GetExpressionCompilationCount(factory) > 0);
+            Assert.IsType<ImportedProperty>(second.Property);
+            Assert.Contains(second.Adapters, adapter => adapter is FirstAdapter);
+            Assert.Contains(second.Adapters, adapter => adapter is SecondAdapter);
+        }
+
+        /// <summary>
+        /// Verifies that undefined options are rejected.
+        /// </summary>
+        [Fact]
+        public void UndefinedOptionIsRejected()
+        {
+            var configuration = CompositionConfiguration.Create(TestUtilities.EmptyCatalog);
+            RuntimeComposition composition = RuntimeComposition.CreateRuntimeComposition(configuration);
+
+            Assert.Throws<ArgumentException>(() => composition.CreateExportProviderFactory((ExportProviderFactoryOptions)0x2));
+        }
+
+        /// <summary>
+        /// Verifies that cached-composition loading propagates expression compilation options.
+        /// </summary>
+        [Fact]
+        public async Task CachedCompositionPropagatesOptions()
+        {
+            CompositionConfiguration configuration = CreateConfiguration(typeof(NonSharedPart));
+            var cache = new CachedComposition();
+            using var stream = new MemoryStream();
+            await cache.SaveAsync(configuration, stream);
+            stream.Position = 0;
+
+            IExportProviderFactory factory = await cache.LoadExportProviderFactoryAsync(
+                stream,
+                Resolver.DefaultInstance,
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation);
+            using ExportProvider provider = factory.CreateExportProvider();
+            _ = provider.GetExportedValue<NonSharedPart>();
+            _ = provider.GetExportedValue<NonSharedPart>();
+
+            Assert.Equal(1, GetExpressionCompilationCount(factory));
+        }
+
+        private static IExportProviderFactory CreateFactory(ExportProviderFactoryOptions options, params Type[] partTypes)
+        {
+            RuntimeComposition composition = RuntimeComposition.CreateRuntimeComposition(CreateConfiguration(partTypes));
+            return composition.CreateExportProviderFactory(options);
+        }
+
+        private static CompositionConfiguration CreateConfiguration(params Type[] partTypes)
+        {
+            var resolver = Resolver.DefaultInstance;
+            var discovery = new AttributedPartDiscovery(resolver, isNonPublicSupported: true);
+            DiscoveredParts discoveredParts = discovery.CreatePartsAsync(partTypes).GetAwaiter().GetResult();
+            ComposableCatalog catalog = ComposableCatalog.Create(resolver).AddParts(discoveredParts);
+            return CompositionConfiguration.Create(catalog);
+        }
+
+        private static int GetExpressionCompilationCount(IExportProviderFactory factory)
+        {
+            PropertyInfo property = factory.GetType().GetProperty("ExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (int)property.GetValue(factory)!;
+        }
+
+        [Export]
+        private sealed class NonSharedPart
+        {
+        }
+
+        [Export, Shared]
+        private sealed class ApplicationSharedPart
+        {
+        }
+
+        [Export, Shared]
+        private sealed class SharingBoundaryOwner
+        {
+            [Import, SharingBoundary("TestBoundary")]
+            internal ExportFactory<SharingBoundaryPart> Factory { get; set; } = null!;
+        }
+
+        [Export, Shared("TestBoundary")]
+        private sealed class SharingBoundaryPart
+        {
+        }
+
+        [Export]
+        private sealed class ImportedPart
+        {
+            [ImportingConstructor]
+            internal ImportedPart([ImportMany] IEnumerable<IAdapter> adapters)
+            {
+                this.Adapters = adapters;
+            }
+
+            internal IEnumerable<IAdapter> Adapters { get; }
+
+            [Import]
+            internal ImportedProperty Property { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class ImportedProperty
+        {
+        }
+
+        private interface IAdapter
+        {
+        }
+
+        [Export(typeof(IAdapter))]
+        private sealed class FirstAdapter : IAdapter
+        {
+        }
+
+        [Export(typeof(IAdapter))]
+        private sealed class SecondAdapter : IAdapter
+        {
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -370,6 +370,69 @@ public class ActivationExpressionCompilationTests
     }
 
     /// <summary>
+    /// Verifies that asynchronous disposal keeps boundary roots on the lifecycle path.
+    /// </summary>
+    [Fact]
+    public void AsyncDisposableBoundaryRootDoesNotUseDirectActivationPlan()
+    {
+        IExportProviderFactory factory = CreateBoundaryPlanFactory();
+        using ExportProvider provider = factory.CreateExportProvider();
+        BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+        AsyncDisposableBoundaryRoot firstValue;
+        using (Export<AsyncDisposableBoundaryRoot> first = owner.AsyncDisposableFactory.CreateExport())
+        {
+            firstValue = first.Value;
+            Assert.False(firstValue.IsDisposed);
+        }
+
+        Assert.True(firstValue.IsDisposed);
+
+        AsyncDisposableBoundaryRoot secondValue;
+        using (Export<AsyncDisposableBoundaryRoot> second = owner.AsyncDisposableFactory.CreateExport())
+        {
+            secondValue = second.Value;
+            Assert.False(secondValue.IsDisposed);
+        }
+
+        Assert.True(secondValue.IsDisposed);
+        Assert.Equal(0, GetDirectActivationPlanCount(factory));
+    }
+
+    /// <summary>
+    /// Verifies that an asynchronous disposable dependency prevents factory-island fusion.
+    /// </summary>
+    [Fact]
+    public void AsyncDisposableDependencyDoesNotUseFusedActivationPlan()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(AsyncDisposableIslandOwner),
+            typeof(AsyncDisposableIslandRoot),
+            typeof(AsyncDisposableIslandDependency),
+            typeof(FactoryOnlyDependencyA),
+            typeof(FactoryOnlyDependencyB),
+            typeof(FactoryOnlyDependencyC));
+        using ExportProvider provider = factory.CreateExportProvider();
+        AsyncDisposableIslandOwner owner = provider.GetExportedValue<AsyncDisposableIslandOwner>();
+
+        using (Export<AsyncDisposableIslandRoot> first = owner.Factory.CreateExport())
+        {
+            _ = first.Value;
+        }
+
+        AsyncDisposableIslandDependency secondDependency;
+        using (Export<AsyncDisposableIslandRoot> second = owner.Factory.CreateExport())
+        {
+            secondDependency = second.Value.AsyncDisposableDependency;
+            Assert.False(secondDependency.IsDisposed);
+        }
+
+        Assert.True(secondDependency.IsDisposed);
+        Assert.Equal(0, GetFusedActivationPlanCount(factory));
+    }
+
+    /// <summary>
     /// Verifies that a compiled direct plan correctly satisfies constructor, property, and many imports.
     /// </summary>
     [Fact]
@@ -452,7 +515,8 @@ public class ActivationExpressionCompilationTests
             typeof(BoundaryCycleB),
             typeof(BoundaryCycleHelperA),
             typeof(BoundaryCycleHelperB),
-            typeof(DisposableBoundaryRoot));
+            typeof(DisposableBoundaryRoot),
+            typeof(AsyncDisposableBoundaryRoot));
     }
 
     private static CompositionConfiguration CreateConfiguration(params Type[] partTypes)
@@ -542,6 +606,9 @@ public class ActivationExpressionCompilationTests
 
         [Import, SharingBoundary("SharedPlanBoundary")]
         internal ExportFactory<DisposableBoundaryRoot> DisposableFactory { get; set; } = null!;
+
+        [Import, SharingBoundary("SharedPlanBoundary")]
+        internal ExportFactory<AsyncDisposableBoundaryRoot> AsyncDisposableFactory { get; set; } = null!;
     }
 
     [Export, Shared("SharedPlanBoundary")]
@@ -626,6 +693,53 @@ public class ActivationExpressionCompilationTests
         internal bool IsDisposed { get; private set; }
 
         public void Dispose() => this.IsDisposed = true;
+    }
+
+    [Export, Shared("SharedPlanBoundary")]
+    private sealed class AsyncDisposableBoundaryRoot : IAsyncDisposable
+    {
+        internal bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            this.IsDisposed = true;
+            return default;
+        }
+    }
+
+    [Export, Shared]
+    private sealed class AsyncDisposableIslandOwner
+    {
+        [Import]
+        internal ExportFactory<AsyncDisposableIslandRoot> Factory { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class AsyncDisposableIslandRoot
+    {
+        [ImportingConstructor]
+        internal AsyncDisposableIslandRoot(
+            AsyncDisposableIslandDependency asyncDisposableDependency,
+            FactoryOnlyDependencyA dependencyA,
+            FactoryOnlyDependencyB dependencyB,
+            FactoryOnlyDependencyC dependencyC)
+        {
+            this.AsyncDisposableDependency = asyncDisposableDependency;
+        }
+
+        internal AsyncDisposableIslandDependency AsyncDisposableDependency { get; }
+    }
+
+    [Export]
+    private sealed class AsyncDisposableIslandDependency : IAsyncDisposable
+    {
+        internal bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            this.IsDisposed = true;
+            return default;
+        }
     }
 
     [Export, Shared]

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -296,6 +296,38 @@ public class ActivationExpressionCompilationTests
     }
 
     /// <summary>
+    /// Verifies that fused property setters preserve reflection's exception chain.
+    /// </summary>
+    [Fact]
+    public void FusedPropertySetterPreservesTargetInvocationException()
+    {
+        IExportProviderFactory factory = CreateFactory(
+            ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+            typeof(ThrowingPropertySetterFactoryOwner),
+            typeof(ThrowingPropertySetterFactoryRoot),
+            typeof(ThrowingPropertySetterDependency),
+            typeof(FactoryOnlyDependencyA),
+            typeof(FactoryOnlyDependencyB));
+        using ExportProvider provider = factory.CreateExportProvider();
+        ThrowingPropertySetterFactoryOwner owner = provider.GetExportedValue<ThrowingPropertySetterFactoryOwner>();
+
+        CompositionFailedException firstException = Assert.Throws<CompositionFailedException>(
+            () =>
+            {
+                using Export<ThrowingPropertySetterFactoryRoot> first = owner.Factory.CreateExport();
+            });
+        CompositionFailedException secondException = Assert.Throws<CompositionFailedException>(
+            () =>
+            {
+                using Export<ThrowingPropertySetterFactoryRoot> second = owner.Factory.CreateExport();
+            });
+
+        Assert.Equal(1, GetFusedActivationPlanCount(factory));
+        Assert.IsType<TargetInvocationException>(firstException.InnerException);
+        Assert.IsType<TargetInvocationException>(secondException.InnerException);
+    }
+
+    /// <summary>
     /// Verifies that a nested export factory remains deferred while the surrounding island is fused.
     /// </summary>
     [Fact]
@@ -665,6 +697,29 @@ public class ActivationExpressionCompilationTests
     [Export]
     private sealed class ThrowingPropertySetterDependency
     {
+    }
+
+    [Export, Shared]
+    private sealed class ThrowingPropertySetterFactoryOwner
+    {
+        [Import]
+        internal ExportFactory<ThrowingPropertySetterFactoryRoot> Factory { get; set; } = null!;
+    }
+
+    [Export]
+    private sealed class ThrowingPropertySetterFactoryRoot
+    {
+        [Import]
+        internal ThrowingPropertySetterDependency Dependency
+        {
+            set => throw new InvalidOperationException();
+        }
+
+        [Import]
+        internal FactoryOnlyDependencyA DependencyA { get; set; } = null!;
+
+        [Import]
+        internal FactoryOnlyDependencyB DependencyB { get; set; } = null!;
     }
 
     [Export, Shared]

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -7,7 +7,9 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using System.Collections.Generic;
     using System.Composition;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -78,7 +80,8 @@ namespace Microsoft.VisualStudio.Composition.Tests
             IExportProviderFactory factory = CreateFactory(
                 ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
                 typeof(SharingBoundaryOwner),
-                typeof(SharingBoundaryPart));
+                typeof(SharingBoundaryPart),
+                typeof(SharingBoundarySimpleDependency));
             using ExportProvider provider = factory.CreateExportProvider();
             SharingBoundaryOwner owner = provider.GetExportedValue<SharingBoundaryOwner>();
 
@@ -90,9 +93,155 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             using (Export<SharingBoundaryPart> second = owner.Factory.CreateExport())
             {
-                _ = second.Value;
+                Assert.NotNull(second.Value.Dependency);
                 Assert.Equal(1, GetExpressionCompilationCount(factory));
+                Assert.Equal(0, GetDirectActivationPlanCount(factory));
             }
+        }
+
+        /// <summary>
+        /// Verifies that a direct activation plan resolves shared dependencies from the current boundary.
+        /// </summary>
+        [Fact]
+        public void DirectActivationPlanPreservesBoundaryAndDisposalOwnership()
+        {
+            IExportProviderFactory factory = CreateBoundaryPlanFactory();
+            ExportProvider provider = factory.CreateExportProvider();
+            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+            BoundaryScopedDependency firstScoped;
+            GlobalSharedDependency global;
+            using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
+            {
+                BoundaryGraphRoot root = first.Value;
+                Assert.Equal(0, GetDirectActivationPlanCount(factory));
+                Assert.Same(root.Scoped, root.Leaf.Scoped);
+                firstScoped = root.Scoped;
+                global = root.Global;
+                Assert.False(firstScoped.IsDisposed);
+                Assert.False(global.IsDisposed);
+            }
+
+            Assert.True(firstScoped.IsDisposed);
+            Assert.False(global.IsDisposed);
+
+            BoundaryScopedDependency secondScoped;
+            using (Export<BoundaryGraphRoot> second = owner.GraphFactory.CreateExport())
+            {
+                BoundaryGraphRoot root = second.Value;
+                Assert.Equal(1, GetDirectActivationPlanCount(factory));
+                Assert.Same(root.Scoped, root.Leaf.Scoped);
+                Assert.NotSame(firstScoped, root.Scoped);
+                Assert.Same(global, root.Global);
+                secondScoped = root.Scoped;
+                Assert.False(secondScoped.IsDisposed);
+            }
+
+            Assert.True(secondScoped.IsDisposed);
+            Assert.False(global.IsDisposed);
+            provider.Dispose();
+            Assert.True(global.IsDisposed);
+        }
+
+        /// <summary>
+        /// Verifies that concurrent boundary activations share one plan without sharing scoped instances.
+        /// </summary>
+        [Fact]
+        public async Task DirectActivationPlanIsSafeAcrossConcurrentBoundaries()
+        {
+            IExportProviderFactory factory = CreateBoundaryPlanFactory();
+            using ExportProvider provider = factory.CreateExportProvider();
+            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+            using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
+            {
+                _ = first.Value;
+            }
+
+            BoundaryScopedDependency[] scopedDependencies = await Task.WhenAll(
+                Enumerable.Range(0, 8).Select(
+                    _ => Task.Run(
+                        () =>
+                        {
+                            using Export<BoundaryGraphRoot> export = owner.GraphFactory.CreateExport();
+                            BoundaryGraphRoot root = export.Value;
+                            Assert.Same(root.Scoped, root.Leaf.Scoped);
+                            return root.Scoped;
+                        })));
+
+            Assert.Equal(scopedDependencies.Length, scopedDependencies.Distinct().Count());
+            Assert.All(scopedDependencies, scoped => Assert.True(scoped.IsDisposed));
+            Assert.Equal(1, GetDirectActivationPlanCount(factory));
+        }
+
+        /// <summary>
+        /// Verifies that a shared plan does not retain values from its first boundary provider.
+        /// </summary>
+        [Fact]
+        [Trait("WeakReference", "true")]
+        [Trait(Traits.SkipOnMono, "WeakReference")]
+        public void DirectActivationPlanDoesNotRetainDisposedBoundary()
+        {
+            IExportProviderFactory factory = CreateBoundaryPlanFactory();
+            using ExportProvider provider = factory.CreateExportProvider();
+            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+            WeakReference scopedDependency = CreateAndDisposeCompiledBoundary(owner);
+            Assert.Equal(1, GetDirectActivationPlanCount(factory));
+
+            GC.Collect();
+            Assert.False(scopedDependency.IsAlive);
+        }
+
+        /// <summary>
+        /// Verifies that phased direct plans preserve property-import cycles within each boundary.
+        /// </summary>
+        [Fact]
+        public void DirectActivationPlanPreservesPropertyImportCycles()
+        {
+            IExportProviderFactory factory = CreateBoundaryPlanFactory();
+            using ExportProvider provider = factory.CreateExportProvider();
+            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+            using (Export<BoundaryCycleA> first = owner.CycleFactory.CreateExport())
+            {
+                Assert.Same(first.Value, first.Value.B.A);
+            }
+
+            using (Export<BoundaryCycleA> second = owner.CycleFactory.CreateExport())
+            {
+                Assert.Same(second.Value, second.Value.B.A);
+                Assert.True(GetDirectActivationPlanCount(factory) >= 1);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that disposable boundary roots remain on the lifecycle path.
+        /// </summary>
+        [Fact]
+        public void DisposableBoundaryRootDoesNotUseDirectActivationPlan()
+        {
+            IExportProviderFactory factory = CreateBoundaryPlanFactory();
+            using ExportProvider provider = factory.CreateExportProvider();
+            BoundaryPlanOwner owner = provider.GetExportedValue<BoundaryPlanOwner>();
+
+            DisposableBoundaryRoot firstValue;
+            using (Export<DisposableBoundaryRoot> first = owner.DisposableFactory.CreateExport())
+            {
+                firstValue = first.Value;
+                Assert.False(firstValue.IsDisposed);
+            }
+
+            Assert.True(firstValue.IsDisposed);
+
+            DisposableBoundaryRoot secondValue;
+            using (Export<DisposableBoundaryRoot> second = owner.DisposableFactory.CreateExport())
+            {
+                secondValue = second.Value;
+                Assert.False(secondValue.IsDisposed);
+            }
+
+            Assert.True(secondValue.IsDisposed);
+            Assert.Equal(0, GetDirectActivationPlanCount(factory));
         }
 
         /// <summary>
@@ -164,6 +313,22 @@ namespace Microsoft.VisualStudio.Composition.Tests
             return composition.CreateExportProviderFactory(options);
         }
 
+        private static IExportProviderFactory CreateBoundaryPlanFactory()
+        {
+            return CreateFactory(
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                typeof(BoundaryPlanOwner),
+                typeof(BoundaryGraphRoot),
+                typeof(BoundaryGraphLeaf),
+                typeof(BoundaryScopedDependency),
+                typeof(GlobalSharedDependency),
+                typeof(BoundaryCycleA),
+                typeof(BoundaryCycleB),
+                typeof(BoundaryCycleHelperA),
+                typeof(BoundaryCycleHelperB),
+                typeof(DisposableBoundaryRoot));
+        }
+
         private static CompositionConfiguration CreateConfiguration(params Type[] partTypes)
         {
             var resolver = Resolver.DefaultInstance;
@@ -177,6 +342,26 @@ namespace Microsoft.VisualStudio.Composition.Tests
         {
             PropertyInfo property = factory.GetType().GetProperty("ExpressionCompilationCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
             return (int)property.GetValue(factory)!;
+        }
+
+        private static int GetDirectActivationPlanCount(IExportProviderFactory factory)
+        {
+            PropertyInfo property = factory.GetType().GetProperty("DirectActivationPlanCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (int)property.GetValue(factory)!;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference CreateAndDisposeCompiledBoundary(BoundaryPlanOwner owner)
+        {
+            using (Export<BoundaryGraphRoot> first = owner.GraphFactory.CreateExport())
+            {
+                _ = first.Value;
+            }
+
+            using (Export<BoundaryGraphRoot> second = owner.GraphFactory.CreateExport())
+            {
+                return new WeakReference(second.Value.Scoped);
+            }
         }
 
         [Export]
@@ -199,6 +384,110 @@ namespace Microsoft.VisualStudio.Composition.Tests
         [Export, Shared("TestBoundary")]
         private sealed class SharingBoundaryPart
         {
+            [Import]
+            internal SharingBoundarySimpleDependency Dependency { get; set; } = null!;
+        }
+
+        [Export, Shared]
+        private sealed class SharingBoundarySimpleDependency
+        {
+        }
+
+        [Export, Shared]
+        private sealed class BoundaryPlanOwner
+        {
+            [Import, SharingBoundary("SharedPlanBoundary")]
+            internal ExportFactory<BoundaryGraphRoot> GraphFactory { get; set; } = null!;
+
+            [Import, SharingBoundary("SharedPlanBoundary")]
+            internal ExportFactory<BoundaryCycleA> CycleFactory { get; set; } = null!;
+
+            [Import, SharingBoundary("SharedPlanBoundary")]
+            internal ExportFactory<DisposableBoundaryRoot> DisposableFactory { get; set; } = null!;
+        }
+
+        [Export, Shared("SharedPlanBoundary")]
+        private sealed class BoundaryGraphRoot
+        {
+            [ImportingConstructor]
+            internal BoundaryGraphRoot(BoundaryGraphLeaf leaf)
+            {
+                this.Leaf = leaf;
+            }
+
+            internal BoundaryGraphLeaf Leaf { get; }
+
+            [Import]
+            internal BoundaryScopedDependency Scoped { get; set; } = null!;
+
+            [Import]
+            internal GlobalSharedDependency Global { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class BoundaryGraphLeaf
+        {
+            [ImportingConstructor]
+            internal BoundaryGraphLeaf(BoundaryScopedDependency scoped)
+            {
+                this.Scoped = scoped;
+            }
+
+            internal BoundaryScopedDependency Scoped { get; }
+        }
+
+        [Export, Shared("SharedPlanBoundary")]
+        private sealed class BoundaryScopedDependency : IDisposable
+        {
+            internal bool IsDisposed { get; private set; }
+
+            public void Dispose() => this.IsDisposed = true;
+        }
+
+        [Export, Shared]
+        private sealed class GlobalSharedDependency : IDisposable
+        {
+            internal bool IsDisposed { get; private set; }
+
+            public void Dispose() => this.IsDisposed = true;
+        }
+
+        [Export, Shared("SharedPlanBoundary")]
+        private sealed class BoundaryCycleA
+        {
+            [Import]
+            internal BoundaryCycleB B { get; set; } = null!;
+
+            [Import]
+            internal BoundaryCycleHelperA HelperA { get; set; } = null!;
+
+            [Import]
+            internal BoundaryCycleHelperB HelperB { get; set; } = null!;
+        }
+
+        [Export, Shared("SharedPlanBoundary")]
+        private sealed class BoundaryCycleB
+        {
+            [Import]
+            internal BoundaryCycleA A { get; set; } = null!;
+        }
+
+        [Export]
+        private sealed class BoundaryCycleHelperA
+        {
+        }
+
+        [Export]
+        private sealed class BoundaryCycleHelperB
+        {
+        }
+
+        [Export, Shared("SharedPlanBoundary")]
+        private sealed class DisposableBoundaryRoot : IDisposable
+        {
+            internal bool IsDisposed { get; private set; }
+
+            public void Dispose() => this.IsDisposed = true;
         }
 
         [Export]

--- a/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/ActivationExpressionCompilationTests.cs
@@ -407,7 +407,8 @@ namespace Microsoft.VisualStudio.Composition.Tests
             IExportProviderFactory factory = await cache.LoadExportProviderFactoryAsync(
                 stream,
                 Resolver.DefaultInstance,
-                ExportProviderFactoryOptions.EnableActivationExpressionCompilation);
+                ExportProviderFactoryOptions.EnableActivationExpressionCompilation,
+                cancellationToken: default);
             using ExportProvider provider = factory.CreateExportProvider();
             _ = provider.GetExportedValue<NonSharedPart>();
             _ = provider.GetExportedValue<NonSharedPart>();


### PR DESCRIPTION
## Summary

- Add opt-in activation expression compilation, disabled by default.
- Tier compilation after repeated activation and restrict it to non-shared parts and named sharing boundaries where the setup cost can be amortized.
- Share provider-independent activation plans across boundary instances while preserving scope isolation, cycles, synchronous and asynchronous disposal ownership, and diagnostics.
- Fuse bounded eager activation islands used repeatedly through `ExportFactory<T>` or `ExportFactory<T, TMetadata>`, stopping at shared, deferred, disposable, or unsupported edges.
- Fall back to reflection or the normal lifecycle path when expression generation or compilation is unsupported.
- Avoid retaining disposed boundary providers from factory-scoped plan caches.
- Add activation benchmarks, comprehensive regression tests, and design/performance notes.

## Performance

Indicative BenchmarkDotNet results:

| Scenario | Compilation disabled | Compilation enabled |
| --- | ---: | ---: |
| Simple non-shared | 472.66 ns, 160 B | 36.32 ns, 24 B |
| Constructor imports | 1,772.14 ns, 712 B | 69.65 ns, 88 B |
| Complex constructor graph | 8,022.69 ns, 3,176 B | 258.23 ns, 408 B |
| Property imports | 5,846.28 ns, 2,440 B | 596.97 ns, 136 B |
| `ImportMany` | 4,271.04 ns, 1,440 B | 231.00 ns, 240 B |
| Repeated complex sharing boundary | 12.39 us, 8,992 B | 10.75 us, 6,406 B |

For the representative repeated factory island, fusion preserved throughput within measurement noise versus separate delegates (10.68 us versus 10.75 us), reduced allocations from 6.63 KB to 6.26 KB, and reduced island-specific generated methods from eight to two.

## Validation

- Release build: 0 warnings, 0 errors
- net8.0: 2,168 tests passed
- net472: 2,212 tests passed
- GitHub and Azure Pipelines checks passed
