### PR TITLE
Permit null `JoinableTaskFactory` arguments

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
+++ b/src/Microsoft.VisualStudio.Composition/CompositionConfiguration.cs
@@ -8,7 +8,6 @@ namespace Microsoft.VisualStudio.Composition
     using System.Collections.Immutable;
     using System.Diagnostics;
     using System.Globalization;
-    using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Xml.Linq;
@@ -244,22 +243,17 @@ namespace Microsoft.VisualStudio.Composition
             return metadataViewsAndProviders.ToImmutable();
         }
 
+        /// <inheritdoc cref="CreateExportProviderFactory(JoinableTaskFactory?)"/>
         public IExportProviderFactory CreateExportProviderFactory()
-        {
-            var composition = RuntimeComposition.CreateRuntimeComposition(this);
-#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
-            return composition.CreateExportProviderFactory();
-#pragma warning restore VSTHRD012
-        }
+            => this.CreateExportProviderFactory(joinableTaskFactory: null);
 
         /// <summary>
-        /// Creates a factory that synchronously disposes asynchronous parts using the specified joinable task factory.
+        /// Creates an <see cref="IExportProviderFactory"/> for this composition configuration.
         /// </summary>
-        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>. May be <see langword="null"/>.</param>
         /// <returns>A factory that creates export providers for this composition.</returns>
-        public IExportProviderFactory CreateExportProviderFactory(JoinableTaskFactory joinableTaskFactory)
+        public IExportProviderFactory CreateExportProviderFactory(JoinableTaskFactory? joinableTaskFactory)
         {
-            Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
             var composition = RuntimeComposition.CreateRuntimeComposition(this);
             return composition.CreateExportProviderFactory(joinableTaskFactory);
         }

--- a/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/Configuration/CachedComposition.cs
@@ -6,12 +6,7 @@ namespace Microsoft.VisualStudio.Composition
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Diagnostics;
-    using System.Globalization;
     using System.IO;
-    using System.Linq;
-    using System.Reflection;
-    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -71,26 +66,21 @@ namespace Microsoft.VisualStudio.Composition
             });
         }
 
-        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
-#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
-            return runtimeComposition.CreateExportProviderFactory();
-#pragma warning restore VSTHRD012
-        }
+        /// <inheritdoc cref="LoadExportProviderFactoryAsync(Stream, Resolver, JoinableTaskFactory?, CancellationToken)"/>
+        public Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, CancellationToken cancellationToken = default)
+            => this.LoadExportProviderFactoryAsync(cacheStream, resolver, joinableTaskFactory: null, cancellationToken);
 
         /// <summary>
-        /// Loads an export provider factory that synchronously disposes asynchronous parts using the specified joinable task factory.
+        /// Creates an <see cref="IExportProviderFactory"/> for this cached composition.
         /// </summary>
         /// <param name="cacheStream">The stream to read the cached composition from.</param>
         /// <param name="resolver">The resolver to use when loading the composition.</param>
-        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>. May be <see langword="null"/>.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A task whose result is the loaded export provider factory.</returns>
-        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, JoinableTaskFactory joinableTaskFactory, CancellationToken cancellationToken)
+        public async Task<IExportProviderFactory> LoadExportProviderFactoryAsync(Stream cacheStream, Resolver resolver, JoinableTaskFactory? joinableTaskFactory, CancellationToken cancellationToken)
         {
-            Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
-            var runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
+            RuntimeComposition runtimeComposition = await this.LoadRuntimeCompositionAsync(cacheStream, resolver, cancellationToken).ConfigureAwait(false);
             return runtimeComposition.CreateExportProviderFactory(joinableTaskFactory);
         }
 

--- a/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
+++ b/src/Microsoft.VisualStudio.Composition/RuntimeComposition.cs
@@ -6,13 +6,10 @@ namespace Microsoft.VisualStudio.Composition
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Collections.ObjectModel;
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Composition.Reflection;
     using Microsoft.VisualStudio.Threading;
     using IAsyncDisposable = System.IAsyncDisposable;
@@ -115,23 +112,17 @@ namespace Microsoft.VisualStudio.Composition
             return new RuntimeComposition(parts, metadataViewsAndProviders, resolver);
         }
 
+        /// <inheritdoc cref="CreateExportProviderFactory(JoinableTaskFactory?)"/>
         public IExportProviderFactory CreateExportProviderFactory()
-        {
-#pragma warning disable VSTHRD012 // Without a JTF, synchronous disposal blocks directly on async-only parts.
-            return new RuntimeExportProviderFactory(this);
-#pragma warning restore VSTHRD012
-        }
+            => this.CreateExportProviderFactory(joinableTaskFactory: null);
 
         /// <summary>
-        /// Creates a factory that synchronously disposes asynchronous parts using the specified joinable task factory.
+        /// Creates an <see cref="IExportProviderFactory"/> for this runtime composition.
         /// </summary>
-        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>.</param>
+        /// <param name="joinableTaskFactory">The joinable task factory to use when synchronously disposing parts that implement <see cref="IAsyncDisposable"/>. May be <see langword="null"/>.</param>
         /// <returns>A factory that creates export providers for this runtime composition.</returns>
-        public IExportProviderFactory CreateExportProviderFactory(JoinableTaskFactory joinableTaskFactory)
-        {
-            Requires.NotNull(joinableTaskFactory, nameof(joinableTaskFactory));
-            return new RuntimeExportProviderFactory(this, joinableTaskFactory);
-        }
+        public IExportProviderFactory CreateExportProviderFactory(JoinableTaskFactory? joinableTaskFactory)
+            => new RuntimeExportProviderFactory(this, joinableTaskFactory);
 
         public IReadOnlyCollection<RuntimeExport> GetExports(string contractName)
         {


### PR DESCRIPTION
These objects could already be omitted by calling another overload, but that's a pain and leads to vs-threading analyzer warnings about not passing in JTF, which can be suppressed by just passing `null` in as the argument, if the library only allowed it.