### PR TITLE
Fix VS-MEF disposal

### DIFF
--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -22,6 +22,13 @@ namespace Microsoft.VisualStudio.Composition
 
     public abstract partial class ExportProvider : IDisposableObservable, IAsyncDisposable
     {
+        private enum DisposalMode
+        {
+            NotStarted,
+            Synchronous,
+            Asynchronous,
+        }
+
         internal static readonly ExportDefinition ExportProviderExportDefinition = new ExportDefinition(
             ContractNameServices.GetTypeIdentity(typeof(ExportProvider)),
             PartCreationPolicyConstraint.GetExportMetadata(CreationPolicy.Shared).AddRange(ExportTypeIdentityConstraint.GetExportMetadata(typeof(ExportProvider))));
@@ -107,14 +114,12 @@ namespace Microsoft.VisualStudio.Composition
         /// </remarks>
         private Dictionary<Type, IMetadataViewProvider> typeAndSelectedMetadataViewProviderCache = new Dictionary<Type, IMetadataViewProvider>();
 
-        private Task? disposalTask;
+        /// <summary>
+        /// A thread-safe, async or sync way to track disposal.
+        /// </summary>
+        private AsyncLazy<int> disposal;
 
-        // Co-published with disposalTask when a JTF is available so synchronous callers can join the shared operation.
-        private JoinableTask? disposalJoinableTask;
-
-        private bool disposalStartedSynchronously;
-
-        private bool isDisposed;
+        private int disposalMode;
 
         private ExportProvider(
             Resolver resolver,
@@ -154,6 +159,8 @@ namespace Microsoft.VisualStudio.Composition
             this.metadataViewProviders = inheritedMetadataViewProviders
                 ?? new Lazy<ImmutableArray<Lazy<IMetadataViewProvider, IReadOnlyDictionary<string, object?>>>>(
                     this.GetMetadataViewProviderExtensions);
+
+            this.disposal = new AsyncLazy<int>(this.CompleteDisposalAsync, joinableTaskFactory);
         }
 
         private protected ExportProvider(Resolver resolver)
@@ -246,10 +253,7 @@ namespace Microsoft.VisualStudio.Composition
         {
         }
 
-        bool IDisposableObservable.IsDisposed
-        {
-            get { return this.isDisposed; }
-        }
+        bool IDisposableObservable.IsDisposed => this.HasDisposalStarted;
 
         /// <summary>
         /// Gets a lazy that creates an instance of DelegatingExportProvider.
@@ -259,6 +263,10 @@ namespace Microsoft.VisualStudio.Composition
         protected ImmutableList<Export> NonDisposableWrapperExportAsListOfOne { get; private set; }
 
         protected internal Resolver Resolver { get; }
+
+        private bool HasDisposalStarted => (DisposalMode)Volatile.Read(ref this.disposalMode) != DisposalMode.NotStarted;
+
+        private bool ShouldDisposeSynchronously => this.joinableTaskFactory is null && (DisposalMode)Volatile.Read(ref this.disposalMode) == DisposalMode.Synchronous;
 
         /// <summary>
         /// Gets the assembly that declares a given export.
@@ -498,7 +506,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public void Dispose()
         {
-            this.WaitForDisposal(disposeSynchronously: true);
+            this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 
@@ -506,9 +514,10 @@ namespace Microsoft.VisualStudio.Composition
         /// Asynchronously disposes composed parts owned by this export provider.
         /// </summary>
         /// <returns>A task that completes when all disposable parts have been disposed.</returns>
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
-            await this.GetOrStartDisposalTaskAsync(disposeSynchronously: false, out _).ConfigureAwait(false);
+            this.RecordDisposalMode(disposeSynchronously: false);
+            await this.disposal.GetValueAsync().ConfigureAwait(this.joinableTaskFactory is object);
             GC.SuppressFinalize(this);
         }
 
@@ -516,7 +525,8 @@ namespace Microsoft.VisualStudio.Composition
         {
             if (disposing && !this.invokingDisposeCallback.Value)
             {
-                this.WaitForDisposal(disposeSynchronously: true);
+                this.RecordDisposalMode(disposeSynchronously: true);
+                this.disposal.GetValue();
             }
         }
 
@@ -529,12 +539,29 @@ namespace Microsoft.VisualStudio.Composition
             List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
 
             // When a JTF is available, the shared JoinableTask preserves its context across each part's disposal.
-            bool disposeSynchronously = this.disposalStartedSynchronously && this.joinableTaskFactory is null;
             bool continueOnCapturedContext = this.joinableTaskFactory is object;
-            await DisposeSnapshotAsync(disposableSnapshot, disposeSynchronously, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+            await DisposeSnapshotAsync(disposableSnapshot, this.ShouldDisposeSynchronously, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
 
-        private async Task CompleteDisposalAsync(TaskCompletionSource<object?> completionSource)
+        private void RecordDisposalMode(bool disposeSynchronously)
+        {
+            lock (this.disposalSyncObject)
+            {
+                if ((DisposalMode)this.disposalMode == DisposalMode.NotStarted)
+                {
+                    Volatile.Write(
+                        ref this.disposalMode,
+                        (int)(disposeSynchronously ? DisposalMode.Synchronous : DisposalMode.Asynchronous));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Performs the meat of the disposal logic. This is only invoked via an AsyncLazy to ensure it is invoked only once,
+        /// and that later calls can block on it.
+        /// </summary>
+        /// <returns>A task that returns a meaningless integer.</returns>
+        private async Task<int> CompleteDisposalAsync()
         {
             Exception? disposeException = null;
             try
@@ -564,25 +591,20 @@ namespace Microsoft.VisualStudio.Composition
                 asyncDisposeException = ex;
             }
 
-            if (disposeException is null && asyncDisposeException is null)
-            {
-                completionSource.SetResult(null);
-            }
-            else if (disposeException is null)
-            {
-                completionSource.SetException(asyncDisposeException!);
-            }
-            else if (asyncDisposeException is null)
-            {
-                completionSource.SetException(disposeException);
-            }
-            else
+            if (disposeException is not null && asyncDisposeException is not null)
             {
                 var exceptions = new List<Exception>();
                 AddFlattenedException(exceptions, disposeException);
                 AddFlattenedException(exceptions, asyncDisposeException);
-                completionSource.SetException(new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions));
+                throw new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions);
             }
+
+            if ((asyncDisposeException ?? disposeException) is Exception thrownException)
+            {
+                ExceptionDispatchInfo.Capture(thrownException).Throw();
+            }
+
+            return 0;
         }
 
         private static void AddFlattenedException(List<Exception> exceptions, Exception exception)
@@ -594,75 +616,6 @@ namespace Microsoft.VisualStudio.Composition
             else
             {
                 exceptions.Add(exception);
-            }
-        }
-
-        private Task GetOrStartDisposalTaskAsync(bool disposeSynchronously, out JoinableTask? joinableTask)
-        {
-            TaskCompletionSource<object?>? completionSource = null;
-            TaskCompletionSource<object?>? startDisposalSource = null;
-            Task result;
-            lock (this.disposalSyncObject)
-            {
-                if (this.disposalTask is null)
-                {
-                    completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    this.disposalTask = completionSource.Task;
-                    this.disposalStartedSynchronously = disposeSynchronously;
-                    this.isDisposed = true;
-
-                    if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
-                    {
-                        startDisposalSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-                        Task startDisposalTask = startDisposalSource.Task;
-                        TaskCompletionSource<object?> disposalCompletionSource = completionSource;
-                        this.disposalJoinableTask = joinableTaskFactory.RunAsync(async () =>
-                        {
-#pragma warning disable VSTHRD003 // This publication gate is completed synchronously after the JoinableTask is stored.
-                            await startDisposalTask;
-#pragma warning restore VSTHRD003
-                            await this.CompleteDisposalAsync(disposalCompletionSource);
-                        });
-                    }
-                }
-
-                result = this.disposalTask;
-                joinableTask = this.disposalJoinableTask;
-            }
-
-            if (completionSource is object)
-            {
-                if (startDisposalSource is object)
-                {
-                    startDisposalSource.SetResult(null);
-                }
-                else
-                {
-                    this.CompleteDisposalAsync(completionSource).Forget();
-                }
-            }
-
-            return result;
-        }
-
-        private void WaitForDisposal(bool disposeSynchronously)
-        {
-            if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
-            {
-                joinableTaskFactory.Run(async () =>
-                {
-                    Task disposalTask = this.GetOrStartDisposalTaskAsync(disposeSynchronously, out JoinableTask? disposalJoinableTask);
-                    Assumes.NotNull(disposalJoinableTask);
-                    await disposalJoinableTask;
-                    await disposalTask;
-                });
-            }
-            else
-            {
-                Task disposalTask = this.GetOrStartDisposalTaskAsync(disposeSynchronously, out _);
-#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async parts are disposed.
-                disposalTask.GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
             }
         }
 
@@ -698,12 +651,11 @@ namespace Microsoft.VisualStudio.Composition
                 }
                 catch (Exception ex)
                 {
-                    exceptions ??= new List<Exception>();
-                    exceptions.Add(ex);
+                    (exceptions ??= []).Add(ex);
                 }
             }
 
-            if (exceptions != null)
+            if (exceptions is not null)
             {
                 throw new AggregateException(Strings.ContainerDisposalEncounteredExceptions, exceptions);
             }
@@ -711,8 +663,6 @@ namespace Microsoft.VisualStudio.Composition
 
         private List<IDisposable> TakeDisposableSnapshot()
         {
-            this.isDisposed = true;
-
             // Snapshot the contents of the collection within the lock,
             // then dispose of the values outside the lock to avoid
             // executing arbitrary 3rd-party code within our lock.
@@ -1044,7 +994,7 @@ namespace Microsoft.VisualStudio.Composition
             bool disposeImmediately;
             lock (this.disposalSyncObject)
             {
-                disposeImmediately = this.isDisposed;
+                disposeImmediately = this.HasDisposalStarted;
                 if (!disposeImmediately)
                 {
                     if (sharingBoundary is null)
@@ -1073,8 +1023,7 @@ namespace Microsoft.VisualStudio.Composition
 
         private void DisposeLateTrackedValue(IDisposable disposable)
         {
-            bool disposeSynchronously = this.disposalStartedSynchronously && this.joinableTaskFactory is null;
-            if (!disposeSynchronously && disposable is IAsyncDisposable asyncDisposable)
+            if (!this.ShouldDisposeSynchronously && disposable is IAsyncDisposable asyncDisposable)
             {
                 // Disposal must finish before the concurrent activation can expose the part.
                 this.WaitForDisposal(asyncDisposable);

--- a/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
+++ b/src/Microsoft.VisualStudio.Composition/ExportProvider.cs
@@ -109,6 +109,9 @@ namespace Microsoft.VisualStudio.Composition
 
         private Task? disposalTask;
 
+        // Co-published with disposalTask when a JTF is available so synchronous callers can join the shared operation.
+        private JoinableTask? disposalJoinableTask;
+
         private bool disposalStartedSynchronously;
 
         private bool isDisposed;
@@ -495,7 +498,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public void Dispose()
         {
-            this.WaitForDisposal(this.GetOrStartDisposalTaskAsync(disposeSynchronously: true));
+            this.WaitForDisposal(disposeSynchronously: true);
             GC.SuppressFinalize(this);
         }
 
@@ -505,7 +508,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>A task that completes when all disposable parts have been disposed.</returns>
         public async ValueTask DisposeAsync()
         {
-            await this.GetOrStartDisposalTaskAsync(disposeSynchronously: false).ConfigureAwait(false);
+            await this.GetOrStartDisposalTaskAsync(disposeSynchronously: false, out _).ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }
 
@@ -513,7 +516,7 @@ namespace Microsoft.VisualStudio.Composition
         {
             if (disposing && !this.invokingDisposeCallback.Value)
             {
-                this.WaitForDisposal(this.GetOrStartDisposalTaskAsync(disposeSynchronously: true));
+                this.WaitForDisposal(disposeSynchronously: true);
             }
         }
 
@@ -525,9 +528,10 @@ namespace Microsoft.VisualStudio.Composition
         {
             List<IDisposable> disposableSnapshot = this.TakeDisposableSnapshot();
 
-            // When a JTF is available, WaitForDisposal joins this whole asynchronous operation once.
+            // When a JTF is available, the shared JoinableTask preserves its context across each part's disposal.
             bool disposeSynchronously = this.disposalStartedSynchronously && this.joinableTaskFactory is null;
-            await DisposeSnapshotAsync(disposableSnapshot, disposeSynchronously).ConfigureAwait(false);
+            bool continueOnCapturedContext = this.joinableTaskFactory is object;
+            await DisposeSnapshotAsync(disposableSnapshot, disposeSynchronously, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
 
         private async Task CompleteDisposalAsync(TaskCompletionSource<object?> completionSource)
@@ -553,7 +557,7 @@ namespace Microsoft.VisualStudio.Composition
             Exception? asyncDisposeException = null;
             try
             {
-                await this.DisposeAsyncCore().ConfigureAwait(false);
+                await this.DisposeAsyncCore().ConfigureAwait(this.joinableTaskFactory is object);
             }
             catch (Exception ex)
             {
@@ -593,9 +597,10 @@ namespace Microsoft.VisualStudio.Composition
             }
         }
 
-        private Task GetOrStartDisposalTaskAsync(bool disposeSynchronously)
+        private Task GetOrStartDisposalTaskAsync(bool disposeSynchronously, out JoinableTask? joinableTask)
         {
             TaskCompletionSource<object?>? completionSource = null;
+            TaskCompletionSource<object?>? startDisposalSource = null;
             Task result;
             lock (this.disposalSyncObject)
             {
@@ -605,36 +610,77 @@ namespace Microsoft.VisualStudio.Composition
                     this.disposalTask = completionSource.Task;
                     this.disposalStartedSynchronously = disposeSynchronously;
                     this.isDisposed = true;
+
+                    if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
+                    {
+                        startDisposalSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        Task startDisposalTask = startDisposalSource.Task;
+                        TaskCompletionSource<object?> disposalCompletionSource = completionSource;
+                        this.disposalJoinableTask = joinableTaskFactory.RunAsync(async () =>
+                        {
+#pragma warning disable VSTHRD003 // This publication gate is completed synchronously after the JoinableTask is stored.
+                            await startDisposalTask;
+#pragma warning restore VSTHRD003
+                            await this.CompleteDisposalAsync(disposalCompletionSource);
+                        });
+                    }
                 }
 
                 result = this.disposalTask;
+                joinableTask = this.disposalJoinableTask;
             }
 
             if (completionSource is object)
             {
-                this.CompleteDisposalAsync(completionSource).Forget();
+                if (startDisposalSource is object)
+                {
+                    startDisposalSource.SetResult(null);
+                }
+                else
+                {
+                    this.CompleteDisposalAsync(completionSource).Forget();
+                }
             }
 
             return result;
         }
 
-        private void WaitForDisposal(Task disposalTask)
+        private void WaitForDisposal(bool disposeSynchronously)
         {
             if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
             {
-#pragma warning disable VSTHRD003 // The JTF is intentionally joining the shared disposal operation initiated by any caller.
-                joinableTaskFactory.Run(async () => await disposalTask.ConfigureAwait(false));
-#pragma warning restore VSTHRD003
+                joinableTaskFactory.Run(async () =>
+                {
+                    Task disposalTask = this.GetOrStartDisposalTaskAsync(disposeSynchronously, out JoinableTask? disposalJoinableTask);
+                    Assumes.NotNull(disposalJoinableTask);
+                    await disposalJoinableTask;
+                    await disposalTask;
+                });
             }
             else
             {
+                Task disposalTask = this.GetOrStartDisposalTaskAsync(disposeSynchronously, out _);
 #pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async parts are disposed.
                 disposalTask.GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
             }
         }
 
-        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot, bool disposeSynchronously)
+        private void WaitForDisposal(IAsyncDisposable asyncDisposable)
+        {
+            if (this.joinableTaskFactory is JoinableTaskFactory joinableTaskFactory)
+            {
+                joinableTaskFactory.Run(async () => await asyncDisposable.DisposeAsync());
+            }
+            else
+            {
+#pragma warning disable VSTHRD002 // Without a JTF, synchronous disposal must still block until async parts are disposed.
+                asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+            }
+        }
+
+        private static async ValueTask DisposeSnapshotAsync(List<IDisposable> disposableSnapshot, bool disposeSynchronously, bool continueOnCapturedContext)
         {
             List<Exception>? exceptions = null;
             foreach (IDisposable item in disposableSnapshot)
@@ -643,7 +689,7 @@ namespace Microsoft.VisualStudio.Composition
                 {
                     if (!disposeSynchronously && item is IAsyncDisposable asyncDisposable)
                     {
-                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(continueOnCapturedContext);
                     }
                     else
                     {
@@ -1031,7 +1077,7 @@ namespace Microsoft.VisualStudio.Composition
             if (!disposeSynchronously && disposable is IAsyncDisposable asyncDisposable)
             {
                 // Disposal must finish before the concurrent activation can expose the part.
-                this.WaitForDisposal(asyncDisposable.DisposeAsync().AsTask());
+                this.WaitForDisposal(asyncDisposable);
             }
             else
             {
@@ -1595,12 +1641,13 @@ namespace Microsoft.VisualStudio.Composition
             public async ValueTask DisposeAsync()
             {
                 (object? value, HashSet<PartLifecycleTracker>? nonSharedChildParts) = this.TakeDisposableValues();
+                bool continueOnCapturedContext = this.OwningExportProvider.joinableTaskFactory is object;
                 List<Exception>? exceptions = null;
                 try
                 {
                     if (value is IAsyncDisposable asyncDisposable)
                     {
-                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(continueOnCapturedContext);
                     }
                     else
                     {
@@ -1618,7 +1665,7 @@ namespace Microsoft.VisualStudio.Composition
                     {
                         try
                         {
-                            await descendant.DisposeAsync().ConfigureAwait(false);
+                            await descendant.DisposeAsync().ConfigureAwait(continueOnCapturedContext);
                         }
                         catch (Exception ex)
                         {

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -93,9 +93,10 @@ namespace Microsoft.VisualStudio.Composition.Tests
             ExportProvider exportProvider = configuration.CreateExportProviderFactory(joinableTaskContext.Factory).CreateExportProvider();
             JoinableAsyncDisposablePart part = exportProvider.GetExportedValue<JoinableAsyncDisposablePart>();
             part.Initialize(joinableTaskContext);
+            using ManualResetEventSlim disposalStarted = part.DisposalStarted;
 
             Task asynchronousDisposal = Task.Run(async () => await exportProvider.DisposeAsync());
-            Assert.True(part.DisposalStarted.Wait(TestUtilities.UnexpectedTimeout));
+            Assert.True(disposalStarted.Wait(TestUtilities.UnexpectedTimeout));
             exportProvider.Dispose();
 
             Assert.True(part.DisposeCompleted);
@@ -116,6 +117,38 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             Assert.True(SpinWait.SpinUntil(() => asynchronousDisposal.IsCompleted, TestUtilities.UnexpectedTimeout));
             await asynchronousDisposal;
+        }
+
+        [Fact]
+        public async Task AsyncDisposalWithoutJoinableTaskFactoryDoesNotRequireCallerContext()
+        {
+            ExportProvider exportProvider = await CreateExportProviderAsync(joinableTaskFactory: null, typeof(AsyncDisposalGatePart));
+            AsyncDisposalGatePart part = exportProvider.GetExportedValue<AsyncDisposalGatePart>();
+            Exception? disposalException = null;
+            using var disposalCompleted = new ManualResetEventSlim();
+            var disposalThread = new Thread(() =>
+            {
+                SynchronizationContext.SetSynchronizationContext(new NonPumpingSynchronizationContext());
+                try
+                {
+                    exportProvider.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    disposalException = ex;
+                }
+                finally
+                {
+                    disposalCompleted.Set();
+                }
+            });
+            disposalThread.IsBackground = true;
+            disposalThread.Start();
+
+            Assert.True(SpinWait.SpinUntil(() => part.DisposalStarted.Task.IsCompleted, TestUtilities.UnexpectedTimeout));
+            part.AllowDisposalToComplete.SetResult(null);
+            Assert.True(disposalCompleted.Wait(TestUtilities.UnexpectedTimeout));
+            Assert.Null(disposalException);
         }
 
         [Fact]
@@ -188,6 +221,46 @@ namespace Microsoft.VisualStudio.Composition.Tests
             await Assert.ThrowsAsync<InvalidOperationException>(() => exportProvider.DisposeAsync().AsTask());
 
             Assert.True(exportProvider.DisposeAsyncCoreCalled);
+        }
+
+        [Fact]
+        public async Task DisposalStartIsSynchronizedWithPartTracking()
+        {
+            ExportProvider innerExportProvider = await CreateExportProviderAsync(joinableTaskFactory: null);
+            var exportProvider = new PartOwningDelegatingExportProvider(innerExportProvider, new DualDisposablePart());
+            var latePart = new DualDisposablePart();
+            object disposalSyncObject = typeof(ExportProvider)
+                .GetField("disposalSyncObject", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(exportProvider)!;
+            using var disposalThreadStarted = new ManualResetEventSlim();
+            Exception? disposalException = null;
+            var disposalThread = new Thread(() =>
+            {
+                disposalThreadStarted.Set();
+                try
+                {
+                    exportProvider.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    disposalException = ex;
+                }
+            });
+            disposalThread.IsBackground = true;
+
+            lock (disposalSyncObject)
+            {
+                disposalThread.Start();
+                Assert.True(disposalThreadStarted.Wait(TestUtilities.UnexpectedTimeout));
+                Assert.True(SpinWait.SpinUntil(
+                    () => (disposalThread.ThreadState & ThreadState.WaitSleepJoin) != 0,
+                    TestUtilities.UnexpectedTimeout));
+                exportProvider.TrackPart(latePart);
+            }
+
+            Assert.True(disposalThread.Join(TestUtilities.UnexpectedTimeout));
+            Assert.Null(disposalException);
+            Assert.True(latePart.DisposeCalled);
         }
 
         [Fact]
@@ -387,13 +460,11 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             internal int DisposalCount { get; private set; }
 
-            public async ValueTask DisposeAsync()
+            public ValueTask DisposeAsync()
             {
                 this.DisposalCount++;
                 this.DisposalStarted.SetResult(null);
-#pragma warning disable VSTHRD003 // This test part intentionally awaits a signal controlled by the test.
-                await this.AllowDisposalToComplete.Task;
-#pragma warning restore VSTHRD003
+                return new ValueTask(this.AllowDisposalToComplete.Task);
             }
         }
 
@@ -417,7 +488,15 @@ namespace Microsoft.VisualStudio.Composition.Tests
                 this.timeoutTimer = new Timer(
                     _ =>
                     {
-                        this.timeoutSource.Cancel();
+                        try
+                        {
+                            this.timeoutSource.Cancel();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Disposal won the race with the queued timeout callback.
+                        }
+
                         this.mainThreadWorkCompleted.TrySetException(new TimeoutException("The main-thread work was not joined."));
                     },
                     null,

--- a/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
+++ b/test/Microsoft.VisualStudio.Composition.Tests/DisposablePartsTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.Composition.Tests
     using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Threading;
     using Xunit;
@@ -66,6 +67,55 @@ namespace Microsoft.VisualStudio.Composition.Tests
 
             Assert.False(part.DisposeCalled);
             Assert.True(part.DisposeAsyncCalled);
+        }
+
+        [Fact]
+        public async Task SynchronousDisposalJoinsAsyncPartMainThreadWork()
+        {
+            var catalog = TestUtilities.EmptyCatalog.AddParts(await TestUtilities.V2Discovery.CreatePartsAsync(typeof(JoinableAsyncDisposablePart)));
+            CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+            using var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, new NonPumpingSynchronizationContext());
+            ExportProvider exportProvider = configuration.CreateExportProviderFactory(joinableTaskContext.Factory).CreateExportProvider();
+            JoinableAsyncDisposablePart part = exportProvider.GetExportedValue<JoinableAsyncDisposablePart>();
+            part.Initialize(joinableTaskContext);
+
+            exportProvider.Dispose();
+
+            Assert.True(part.DisposeCompleted);
+        }
+
+        [Fact]
+        public async Task SynchronousDisposalJoinsAsyncDisposalStartedByAnotherCaller()
+        {
+            var catalog = TestUtilities.EmptyCatalog.AddParts(await TestUtilities.V2Discovery.CreatePartsAsync(typeof(JoinableAsyncDisposablePart)));
+            CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+            using var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, new NonPumpingSynchronizationContext());
+            ExportProvider exportProvider = configuration.CreateExportProviderFactory(joinableTaskContext.Factory).CreateExportProvider();
+            JoinableAsyncDisposablePart part = exportProvider.GetExportedValue<JoinableAsyncDisposablePart>();
+            part.Initialize(joinableTaskContext);
+
+            Task asynchronousDisposal = Task.Run(async () => await exportProvider.DisposeAsync());
+            Assert.True(part.DisposalStarted.Wait(TestUtilities.UnexpectedTimeout));
+            exportProvider.Dispose();
+
+            Assert.True(part.DisposeCompleted);
+            Assert.True(SpinWait.SpinUntil(() => asynchronousDisposal.IsCompleted, TestUtilities.UnexpectedTimeout));
+            await asynchronousDisposal;
+        }
+
+        [Fact]
+        public async Task AsyncDisposalWithJoinableTaskFactoryDoesNotRequireMainThreadPump()
+        {
+            var catalog = TestUtilities.EmptyCatalog.AddParts(await TestUtilities.V2Discovery.CreatePartsAsync(typeof(AsyncDisposablePart)));
+            CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+            using var joinableTaskContext = new JoinableTaskContext(Thread.CurrentThread, new NonPumpingSynchronizationContext());
+            ExportProvider exportProvider = configuration.CreateExportProviderFactory(joinableTaskContext.Factory).CreateExportProvider();
+            exportProvider.GetExportedValue<AsyncDisposablePart>();
+
+            Task asynchronousDisposal = Task.Run(async () => await exportProvider.DisposeAsync());
+
+            Assert.True(SpinWait.SpinUntil(() => asynchronousDisposal.IsCompleted, TestUtilities.UnexpectedTimeout));
+            await asynchronousDisposal;
         }
 
         [Fact]
@@ -344,6 +394,80 @@ namespace Microsoft.VisualStudio.Composition.Tests
 #pragma warning disable VSTHRD003 // This test part intentionally awaits a signal controlled by the test.
                 await this.AllowDisposalToComplete.Task;
 #pragma warning restore VSTHRD003
+            }
+        }
+
+        [Export]
+        public class JoinableAsyncDisposablePart : IAsyncDisposable
+        {
+            private readonly TaskCompletionSource<object?> disposalStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<object?> mainThreadWorkCompleted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly CancellationTokenSource timeoutSource = new CancellationTokenSource();
+            private JoinableTaskCollection? joinableTaskCollection;
+            private Timer? timeoutTimer;
+
+            internal ManualResetEventSlim DisposalStarted { get; } = new ManualResetEventSlim();
+
+            internal bool DisposeCompleted { get; private set; }
+
+            internal void Initialize(JoinableTaskContext joinableTaskContext)
+            {
+                this.joinableTaskCollection = joinableTaskContext.CreateCollection();
+                JoinableTaskFactory joinableTaskFactory = joinableTaskContext.CreateFactory(this.joinableTaskCollection);
+                this.timeoutTimer = new Timer(
+                    _ =>
+                    {
+                        this.timeoutSource.Cancel();
+                        this.mainThreadWorkCompleted.TrySetException(new TimeoutException("The main-thread work was not joined."));
+                    },
+                    null,
+                    TestUtilities.UnexpectedTimeout,
+                    Timeout.InfiniteTimeSpan);
+
+                joinableTaskFactory.RunAsync(async () =>
+                {
+                    try
+                    {
+#pragma warning disable VSTHRD003 // This test part models work signaled by its disposal operation.
+                        await this.disposalStarted.Task;
+#pragma warning restore VSTHRD003
+                        await joinableTaskFactory.SwitchToMainThreadAsync(this.timeoutSource.Token);
+                        this.mainThreadWorkCompleted.TrySetResult(null);
+                    }
+                    catch (Exception ex)
+                    {
+                        this.mainThreadWorkCompleted.TrySetException(ex);
+                    }
+                }).Task.Forget();
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                Assumes.NotNull(this.joinableTaskCollection);
+                using (this.joinableTaskCollection.Join())
+                {
+                    this.DisposalStarted.Set();
+                    this.disposalStarted.SetResult(null);
+                    try
+                    {
+#pragma warning disable VSTHRD003 // The joined collection contains the work that completes this signal.
+                        await this.mainThreadWorkCompleted.Task;
+#pragma warning restore VSTHRD003
+                        this.DisposeCompleted = true;
+                    }
+                    finally
+                    {
+                        this.timeoutTimer?.Dispose();
+                        this.timeoutSource.Dispose();
+                    }
+                }
+            }
+        }
+
+        private class NonPumpingSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object? state)
+            {
             }
         }
 


### PR DESCRIPTION
`ExportProvider.Dispose` wasn't following the 3rd threading rule properly. It would start an async disposal and then block on it later without having joined the work.

This change reuses `AsyncLazy<T>` to represent the disposal operation and its sync/async invocability.